### PR TITLE
Add on label tiles a tooltip with the label name.

### DIFF
--- a/templates/part.board.mainView.php
+++ b/templates/part.board.mainView.php
@@ -52,7 +52,7 @@
 							<h3>{{ c.title }}</h3>
 							<ul class="labels">
 								<li ng-repeat="label in c.labels"
-									style="background-color: #{{ label.color }};">
+									style="background-color: #{{ label.color }};" title="{{ label.title }}">
 									<span>{{ label.title }}</span>
 								</li>
 							</ul>


### PR DESCRIPTION
On each card, there are colored "tiles" who inform which label is associated with this card. It is a good design, but sometimes it's difficult to remember the label color signification, so the user need to open the card to see the label names.

This pull request avoid this by adding on each label tile a tooltip describing the label name, improving the user experience:

![](https://i.imgur.com/zdLs4LW.png)