### PR TITLE
Fixed SQL statements without prefixes

### DIFF
--- a/lib/Db/BoardMapper.php
+++ b/lib/Db/BoardMapper.php
@@ -75,9 +75,9 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 	 * @return array
 	 */
 	public function findAllByUser($userId, $limit = null, $offset = null) {
-		$sql = 'SELECT id, title, owner, color, archived, 0 as shared FROM oc_deck_boards WHERE owner = ? UNION ' .
-			'SELECT boards.id, title, owner, color, archived, 1 as shared FROM oc_deck_boards as boards ' .
-			'JOIN oc_deck_board_acl as acl ON boards.id=acl.board_id WHERE acl.participant=? AND acl.type=? AND boards.owner != ?';
+		$sql = 'SELECT id, title, owner, color, archived, 0 as shared FROM `*PREFIX*deck_boards` WHERE owner = ? UNION ' .
+			'SELECT boards.id, title, owner, color, archived, 1 as shared FROM `*PREFIX*deck_boards` as boards ' .
+			'JOIN `*PREFIX*deck_board_acl` as acl ON boards.id=acl.board_id WHERE acl.participant=? AND acl.type=? AND boards.owner != ?';
 		$entries = $this->findEntities($sql, [$userId, $userId, Acl::PERMISSION_TYPE_USER, $userId], $limit, $offset);
 		/* @var Board $entry */
 		foreach ($entries as $entry) {
@@ -100,8 +100,8 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 		if (count($groups) <= 0) {
 			return [];
 		}
-		$sql = 'SELECT boards.id, title, owner, color, archived, 2 as shared FROM oc_deck_boards as boards ' .
-			'INNER JOIN oc_deck_board_acl as acl ON boards.id=acl.board_id WHERE owner != ? AND type=? AND (';
+		$sql = 'SELECT boards.id, title, owner, color, archived, 2 as shared FROM `*PREFIX*deck_boards` as boards ' .
+			'INNER JOIN `*PREFIX*deck_board_acl` as acl ON boards.id=acl.board_id WHERE owner != ? AND type=? AND (';
 		for ($i = 0; $i < count($groups); $i++) {
 			$sql .= 'acl.participant = ? ';
 			if (count($groups) > 1 && $i < count($groups) - 1) {

--- a/lib/Db/LabelMapper.php
+++ b/lib/Db/LabelMapper.php
@@ -49,8 +49,8 @@ class LabelMapper extends DeckMapper implements IPermissionMapper {
 		return $this->findEntities($sql, [$cardId], $limit, $offset);
 	}
 	public function findAssignedLabelsForBoard($boardId, $limit = null, $offset = null) {
-		$sql = "SELECT c.id as card_id, l.id as id, l.title as title, l.color as color FROM oc_deck_cards as c " .
-			" INNER JOIN oc_deck_assigned_labels as al ON al.card_id = c.id INNER JOIN oc_deck_labels as l ON  al.label_id = l.id WHERE board_id=? ORDER BY l.id";
+		$sql = "SELECT c.id as card_id, l.id as id, l.title as title, l.color as color FROM `*PREFIX*deck_cards` as c " .
+			" INNER JOIN `*PREFIX*deck_assigned_labels` as al ON al.card_id = c.id INNER JOIN `*PREFIX*deck_labels` as l ON  al.label_id = l.id WHERE board_id=? ORDER BY l.id";
 		$entities = $this->findEntities($sql, [$boardId], $limit, $offset);
 		return $entities;
 	}


### PR DESCRIPTION
Some of the table names started with `oc_` instead of `*PREFIX*`. Now it works on instances with a different DB-prefix.