### PR TITLE
Do not fail on nonexisting acl users/groups

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@
 💥 This is still alpha software: it may not be stable enough for production!
 
 </description>
-    <version>0.1.3</version>
+    <version>0.1.3.1</version>
     <licence>agpl</licence>
     <author>Julius Härtl</author>
     <namespace>Deck</namespace>
@@ -30,4 +30,9 @@
     <dependencies>
         <nextcloud min-version="11" max-version="12" />
     </dependencies>
+    <repair-steps>
+        <post-migration>
+            <step>OCA\Deck\Migration\UnknownUsers</step>
+        </post-migration>
+    </repair-steps>
 </info>

--- a/lib/Db/AclMapper.php
+++ b/lib/Db/AclMapper.php
@@ -48,4 +48,9 @@ class AclMapper extends DeckMapper implements IPermissionMapper {
 		return $entity->getBoardId();
 	}
 
+	public function findByParticipant($type, $participant) {
+		$sql = 'SELECT * from *PREFIX*deck_board_acl WHERE type = ? AND participant = ?';
+		return $this->findEntities($sql, [$type, $participant]);
+	}
+
 }

--- a/lib/Db/Board.php
+++ b/lib/Db/Board.php
@@ -52,7 +52,6 @@ class Board extends RelationalEntity implements JsonSerializable {
 		if ($this->shared === -1) {
 			unset($json['shared']);
 		}
-		$json['owner'] = $this->resolveOwner();
 		return $json;
 	}
 

--- a/lib/Db/BoardMapper.php
+++ b/lib/Db/BoardMapper.php
@@ -176,7 +176,7 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 					return new User($user);
 				} else {
 					\OC::$server->getLogger()->debug('User ' . $acl->getId() . ' not found when mapping acl ' . $acl->getParticipant());
-					return $participant;
+					return null;
 				}
 			}
 			if($acl->getType() === Acl::PERMISSION_TYPE_GROUP) {
@@ -185,7 +185,7 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 					return new Group($group);
 				} else {
 					\OC::$server->getLogger()->debug('Group ' . $acl->getId() . ' not found when mapping acl ' . $acl->getParticipant());
-					return $participant;
+					return null;
 				}
 			}
 			throw new \Exception('Unknown permission type for mapping Acl');
@@ -198,7 +198,11 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 	public function mapOwner(Board &$board) {
 		$userManager = $this->userManager;
 		$board->resolveRelation('owner', function($owner) use (&$userManager) {
-			return new User($userManager->get($owner));
+			$user = $userManager->get($owner);
+			if($user !== null) {
+				return new User($user);
+			}
+			return null;
 		});
 	}
 

--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -31,6 +31,7 @@ use OCP\IUserManager;
 class CardMapper extends DeckMapper implements IPermissionMapper {
 
 	private $labelMapper;
+	private $userManager;
 
 	public function __construct(IDBConnection $db, LabelMapper $labelMapper, IUserManager $userManager) {
 		parent::__construct($db, 'deck_cards', '\OCA\Deck\Db\Card');
@@ -131,7 +132,11 @@ class CardMapper extends DeckMapper implements IPermissionMapper {
 	public function mapOwner(Card &$card) {
 		$userManager = $this->userManager;
 		$card->resolveRelation('owner', function($owner) use (&$userManager) {
-			return new User($userManager->get($owner));
+			$user = $userManager->get($owner);
+			if($user !== null) {
+				return new User($user);
+			}
+			return null;
 		});
 	}
 

--- a/lib/Db/Group.php
+++ b/lib/Db/Group.php
@@ -35,7 +35,7 @@ class Group extends RelationalObject {
 	public function getObjectSerialization() {
 		return [
 			'uid' => $this->object->getGID(),
-			'displayname' => $this->object->getDisplayName()
+			'displayname' => $this->object->getGID()
 		];
 	}
 }

--- a/lib/Db/RelationalObject.php
+++ b/lib/Db/RelationalObject.php
@@ -25,7 +25,8 @@ namespace OCA\Deck\Db;
 
 class RelationalObject implements \JsonSerializable {
 
-	private $primaryKey;
+	protected $primaryKey;
+	protected $object;
 
 	/**
 	 * RelationalObject constructor.

--- a/lib/Migration/UnknownUsers.php
+++ b/lib/Migration/UnknownUsers.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Deck\Migration;
+
+use OCA\Deck\Db\Acl;
+use OCA\Deck\Db\AclMapper;
+use OCA\Deck\Db\Board;
+use OCA\Deck\Db\BoardMapper;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\Migration\IRepairStep;
+use OCP\Migration\IOutput;
+
+class UnknownUsers implements IRepairStep {
+
+	private $userManager;
+	private $groupManager;
+	private $aclMapper;
+	private $boardMapper;
+
+	public function __construct(IUserManager $userManager, IGroupManager $groupManager, AclMapper $aclMapper, BoardMapper $boardMapper) {
+		$this->userManager = $userManager;
+		$this->groupManager = $groupManager;
+		$this->aclMapper = $aclMapper;
+		$this->boardMapper = $boardMapper;
+	}
+
+	/*
+	 * @inheritdoc
+	 */
+	public function getName() {
+		return 'Delete orphaned ACL rules';
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function run(IOutput $output) {
+		$boards = $this->boardMapper->findAll();
+		/** @var Board $board */
+		foreach ($boards as $board) {
+			$acls = $this->aclMapper->findAll($board->getId());
+			/** @var Acl $acl */
+			foreach ($acls as $acl) {
+				if($acl->getType() === Acl::PERMISSION_TYPE_USER) {
+					$user = $this->userManager->get($acl->getParticipant());
+					if($user === null) {
+						$this->aclMapper->delete($acl);
+					}
+				}
+				if($acl->getType() === Acl::PERMISSION_TYPE_GROUP) {
+					$group = $this->groupManager->get($acl->getParticipant());
+					if($group === null) {
+						$this->aclMapper->delete($acl);
+					}
+				}
+
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fix issues when acl rules cannot be mapped to Nextcloud users/groups. 

Possible fix for #115 / maybe #110

@aproposnix @Aesculapius @dirigit 
Here is a testing build, if you want to help testing: 
~https://bitgrid.net/~jus/deck_0.1.3.1-fix.tar.gz~
~https://bitgrid.net/~jus/deck_0.1.3.1-fix-a6b6842.tar.gz~
https://bitgrid.net/~jus/deck_0.1.3.1-fix-12ebffb.tar.gz


