### PR TITLE
Header redesign - fixes #116

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -126,14 +126,21 @@ button:hover {
 	position: relative;
 	z-index: 120;
 	height: 44px;
-	background-color: #eee;
 }
 
-#board-header h1 {
+#board-header > * {
 	font-size: 14pt;
-	margin: 0;
-	padding: 12px;
+	padding: 7px;
+	margin: 7px;
 	float: left;
+}
+
+#board-header > a {
+	background: url('/core/img/breadcrumb.svg?v=1');
+	background-repeat: no-repeat;
+	background-position: right center;
+	background-size: auto 24px;
+	padding-right: 24px;
 }
 
 #board-actions {
@@ -185,19 +192,13 @@ button:hover {
 	background-color: transparent;
 }
 
-.board-action-button {
-	font-size: 12pt;
-	font-weight: 100;
-	border: none;
-	margin-left: 10px;
+#board-header > .board-action-button {
+	float: right;
 }
 
 #stack-add {
-	float: right;
-	margin: 8px;
-	background-color: #ffffff;
-	border: 1px solid #bbb;
-	border-radius: 4px;
+	background-color: rgba(240,240,240,.9);
+	border-radius: 3px;
 }
 
 #stack-add input {
@@ -207,6 +208,7 @@ button:hover {
 	display: table-cell;
 	vertical-align: middle;
 	min-height: initial;
+	background-color: rgba(240,240,240,.9);
 }
 
 #stack-add input:invalid {
@@ -926,6 +928,10 @@ button:hover {
 	position: absolute;
 	top: 0px;
 	right: 0px;
+}
+
+.icon-home {
+	background-image: url('/core/img/places/home.svg');
 }
 
 /**

--- a/css/style.css
+++ b/css/style.css
@@ -199,10 +199,11 @@ button:hover {
 #stack-add {
 	background-color: rgba(240,240,240,.9);
 	border-radius: 3px;
+	padding: 0;
 }
 
 #stack-add input {
-	padding: 4px 5px;
+	padding: 7px;
 	margin: 0px;
 	border: 0px none transparent;
 	display: table-cell;
@@ -928,10 +929,6 @@ button:hover {
 	position: absolute;
 	top: 0px;
 	right: 0px;
-}
-
-.icon-home {
-	background-image: url('/core/img/places/home.svg');
 }
 
 .icon-home {

--- a/templates/part.board.mainView.php
+++ b/templates/part.board.mainView.php
@@ -4,30 +4,40 @@
 		<h2>{{ statusservice.title }}</h2>
 		<p>{{ statusservice.text }}</p></div>
 </div>
-<div id="board-header"
-	 style="background-color: #{{boardservice.getCurrent().color }}; color: {{boardservice.getCurrent().color | textColorFilter }};">
-	<h1>
+<div id="board-header">
+	<a href="#" title="<?php p($l->t('All Boards')); ?>">
+		<i class="icon icon-home"></i>
+	</a>
+	<h1 class="title" style="border-bottom: 2px solid #{{boardservice.getCurrent().color }};">
 		{{ boardservice.getCurrent().title }}
 	</h1>
-  	<div id="board-actions">
-		<div class="board-action-button" ng-if="filter!='archive'"><a ng-click="switchFilter('archive')" style="opacity:0.5;" title="<?php p($l->t('Show archived cards')); ?>"><i class="icon icon-archive{{ boardservice.getCurrent().color | iconWhiteFilter }}"></i></a></div>
-		<div class="board-action-button" ng-if="filter=='archive'"><a ng-click="switchFilter('')" title="<?php p($l->t('Hide archived cards')); ?>"><i class="icon icon-archive{{ boardservice.getCurrent().color | iconWhiteFilter }}"></i></a></div>
-		<div class="board-action-button"><a ui-sref="board.detail({ id: id })" title="<?php p($l->t('Board details')); ?>"><i class="icon icon-details{{ boardservice.getCurrent().color | iconWhiteFilter }}"></i></a>
-    </div>
-</div>
-
-<div id="stack-add" ng-if="boardservice.canEdit() && checkCanEdit()">
-	<form class="ng-pristine ng-valid" ng-submit="createStack()">
-		<input type="text" placeholder="Add a new stack"
+	<div id="stack-add" ng-if="boardservice.canEdit() && checkCanEdit()">
+		<form class="ng-pristine ng-valid" ng-submit="createStack()">
+			<input type="text" placeholder="Add a new stack"
 				ng-focus="status.addStack=true"
 				ng-blur="status.addStack=false"
 				ng-model="newStack.title" required
 				maxlength="100" />
-		<button class="icon icon-add" style="opacity: {{status.addStack ? 1: 0.5}};"
-				type="submit"></button>
-	</form>
+			<button class="icon icon-add" style="opacity: {{status.addStack ? 1: 0.5}};" type="submit"></button>
+		</form>
+	</div>
+	<div class="board-action-button">
+		<a ui-sref="board.detail({ id: id })" title="<?php p($l->t('Board details')); ?>">
+			<i class="icon icon-details"></i>
+		</a>
+	</div>
+	<div class="board-action-button" ng-if="filter!='archive'">
+		<a ng-click="switchFilter('archive')" style="opacity:0.5;" title="<?php p($l->t('Show archived cards')); ?>">
+			<i class="icon icon-archive"></i>
+		</a>
+	</div>
+	<div class="board-action-button" ng-if="filter=='archive'">
+		<a ng-click="switchFilter('')" title="<?php p($l->t('Hide archived cards')); ?>">
+			<i class="icon icon-archive"></i>
+		</a>
 	</div>
 </div>
+
 <div id="board" class="scroll-container" ng-click="sidebar.show=false" ui-sref="board">
 
 	<search on-search="search" class="ng-hide"></search>
@@ -126,7 +136,7 @@
 				</div>
 			</div>
 		</div>
-		
+
 	</div>
 
 </div>

--- a/templates/part.board.mainView.php
+++ b/templates/part.board.mainView.php
@@ -11,16 +11,6 @@
 	<h1 class="title" style="border-bottom: 2px solid #{{boardservice.getCurrent().color }};">
 		{{ boardservice.getCurrent().title }}
 	</h1>
-	<div id="stack-add" ng-if="boardservice.canEdit() && checkCanEdit()">
-		<form class="ng-pristine ng-valid" ng-submit="createStack()">
-			<input type="text" placeholder="Add a new stack"
-				ng-focus="status.addStack=true"
-				ng-blur="status.addStack=false"
-				ng-model="newStack.title" required
-				maxlength="100" />
-			<button class="icon icon-add" style="opacity: {{status.addStack ? 1: 0.5}};" type="submit"></button>
-		</form>
-	</div>
 	<div class="board-action-button">
 		<a ui-sref="board.detail({ id: id })" title="<?php p($l->t('Board details')); ?>">
 			<i class="icon icon-details"></i>
@@ -35,6 +25,16 @@
 		<a ng-click="switchFilter('')" title="<?php p($l->t('Hide archived cards')); ?>">
 			<i class="icon icon-archive"></i>
 		</a>
+	</div>
+	<div id="stack-add" class="board-action-button" ng-if="boardservice.canEdit() && checkCanEdit()">
+		<form class="ng-pristine ng-valid" ng-submit="createStack()">
+			<input type="text" placeholder="Add a new stack"
+				ng-focus="status.addStack=true"
+				ng-blur="status.addStack=false"
+				ng-model="newStack.title" required
+				maxlength="100" />
+			<button class="icon icon-add" style="opacity: {{status.addStack ? 1: 0.5}};" type="submit"></button>
+		</form>
 	</div>
 </div>
 


### PR DESCRIPTION
I tried to take layout ideas from core Nextcloud apps for consistency while keeping all the existing features in the header.

![new_header](https://cloud.githubusercontent.com/assets/4129927/25784406/803f7416-336c-11e7-8918-cfeb33279e9b.png)

I added the "Home" button which could be a first step towards eliminating 

It could use some love regarding responsiveness, but that is out of the scope of this PR. Also out of the scope is the idea that the "Add new stack" should be just a "+" icon-button that would trigger a popup menu which would include "New Stack" and "New Board") - similar to how it is handled in Files app.

Board color is now should in a more minimalistic way, with a line under the title.