### PR TITLE
Fix extra-long words in card title overflowing.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -355,8 +355,8 @@ button:hover {
 	font-size: 10pt;
 	padding: 0;
 	margin: 5px;
-	display: inline-block;
-	float: left;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .card.has-labels h3 {


### PR DESCRIPTION
Just a small fix in case there are really long words in card titles.

Signed-off-by: Marin Treselj <marin@pixelipo.com>