### PR TITLE
Fix #167 - hide opened menus

### DIFF
--- a/js/directive/appPopoverMenuUtils.js
+++ b/js/directive/appPopoverMenuUtils.js
@@ -28,6 +28,7 @@ app.directive('appPopoverMenuUtils', function () {
             var menu = elm.find('.popovermenu');
             var button = elm.find('button');
             button.click(function (e) {
+                $('.popovermenu').addClass('hidden');
                 menu.toggleClass('hidden');
                 if(!menu.hasClass('hidden')) {
                     button.css('display','block');


### PR DESCRIPTION
This will assure that all the context menus are hidden before toggling selected one.

Signed-off-by: Marin Treselj <marin@pixelipo.com>