### PR TITLE
Click title to edit

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -250,7 +250,7 @@ button.button-inline:hover {
 
 .stack h2 button {
 	margin-left: auto;
-    display: flex;
+	display: flex;
 	opacity: 0.25;
 }
 
@@ -258,7 +258,7 @@ button.button-inline:hover {
 	white-space: normal;
 	overflow: hidden;
 	text-overflow: ellipsis;
-    cursor: text;
+	cursor: text;
 }
 
 .stack h2:hover .stack-actions {

--- a/css/style.css
+++ b/css/style.css
@@ -261,6 +261,7 @@ button.button-inline:hover {
 	margin-left: auto;
 	display: flex;
 	opacity: 0.25;
+	padding-right: 0;
 }
 
 .stack h2:hover button {
@@ -852,7 +853,7 @@ button.button-inline:hover {
 		width: 320px;
 		display: inline-block;
 	}
-	.stack h2 .stack-actions {
+	.stack h2 button {
 		display: none;
 	}
 }

--- a/css/style.css
+++ b/css/style.css
@@ -58,6 +58,9 @@ button.button-inline:hover {
 	display: flex !important;
 }
 
+.editable-inline {
+	cursor: text;
+}
 /**
  * Navigation sidebar
  */
@@ -248,20 +251,19 @@ button.button-inline:hover {
 	width: 100%;
 }
 
+.stack h2 span {
+	white-space: normal;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
 .stack h2 button {
 	margin-left: auto;
 	display: flex;
 	opacity: 0.25;
 }
 
-.stack h2 span {
-	white-space: normal;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	cursor: text;
-}
-
-.stack h2:hover .stack-actions {
+.stack h2:hover button {
 	display: flex;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -248,27 +248,21 @@ button.button-inline:hover {
 	width: 100%;
 }
 
-.stack h2 button,
-.stack .stack-actions {
-	float: right;
-	margin: 0px 0px 0px 10px;
+.stack h2 button {
+	margin-left: auto;
+    display: flex;
+	opacity: 0.25;
 }
 
 .stack h2 span {
-	width: 100%;
 	white-space: normal;
 	overflow: hidden;
 	text-overflow: ellipsis;
-}
-
-.stack h2 .stack-actions {
-	display: flex;
-	opacity: 0.25;
+    cursor: text;
 }
 
 .stack h2:hover .stack-actions {
 	display: flex;
-	float: right;
 }
 
 .card {

--- a/templates/part.board.mainView.php
+++ b/templates/part.board.mainView.php
@@ -35,7 +35,7 @@
 			 data-columnindex="{{$index}}" id="column{{$index}}"
 			 style="">
 			<h2 data-as-sortable-item-handle>
-                <span ng-show="!s.status.editStack" ng-click="s.status.editStack=true">{{ s.title }}</span>
+				<span ng-show="!s.status.editStack" ng-click="s.status.editStack=true">{{ s.title }}</span>
 				<form ng-if="s.status.editStack" ng-submit="stackservice.update(s)">
 					<input type="text" placeholder="Add a new stack"
 						   ng-blur="stackservice.update(s); s.status.editStack=false" ng-model="s.title"

--- a/templates/part.board.mainView.php
+++ b/templates/part.board.mainView.php
@@ -36,7 +36,7 @@
 			 style="">
 			<h2 data-as-sortable-item-handle>
 				<span class="editable-inline" ng-show="!s.status.editStack" ng-click="s.status.editStack=true">{{ s.title }}</span>
-				<form ng-if="s.status.editStack" ng-submit="stackservice.update(s)">
+				<form ng-if="s.status.editStack" ng-submit="stackservice.update(s); s.status.editStack=false">
 					<input type="text" placeholder="Add a new stack"
 						   ng-blur="stackservice.update(s); s.status.editStack=false" ng-model="s.title"
 						   autofocus-on-insert required maxlength="100" />

--- a/templates/part.board.mainView.php
+++ b/templates/part.board.mainView.php
@@ -34,19 +34,17 @@
 		<div class="stack" ng-repeat="s in stacks" data-as-sortable-item
 			 data-columnindex="{{$index}}" id="column{{$index}}"
 			 style="">
-			<h2 data-as-sortable-item-handle><span ng-show="!s.status.editStack">{{ s.title }}</span>
+			<h2 data-as-sortable-item-handle>
+                <span ng-show="!s.status.editStack" ng-click="s.status.editStack=true">{{ s.title }}</span>
 				<form ng-if="s.status.editStack" ng-submit="stackservice.update(s)">
 					<input type="text" placeholder="Add a new stack"
 						   ng-blur="stackservice.update(s); s.status.editStack=false" ng-model="s.title"
 						   ng-if="s.status.editStack" autofocus-on-insert
 						   required maxlength="100"/>
 				</form>
-				<div ng-if="!s.status.editStack" class="stack-actions">
-					<button class="icon-rename button-inline"
-							ng-click="s.status.editStack=true"></button>
-					<button class="icon-delete button-inline"
-							ng-click="stackservice.delete(s.id)"></button>
-				</div>
+				<button class="icon-delete button-inline stack-actions"
+						ng-if="!s.status.editStack"
+                        ng-click="stackservice.delete(s.id)"></button>
 			</h2>
 			<ul data-as-sortable="sortOptions" is-disabled="!boardservice.canEdit() || filter==='archive'" data-ng-model="s.cards"
 				style="min-height: 40px;">

--- a/templates/part.board.mainView.php
+++ b/templates/part.board.mainView.php
@@ -35,12 +35,11 @@
 			 data-columnindex="{{$index}}" id="column{{$index}}"
 			 style="">
 			<h2 data-as-sortable-item-handle>
-				<span ng-show="!s.status.editStack" ng-click="s.status.editStack=true">{{ s.title }}</span>
+				<span class="editable-inline" ng-show="!s.status.editStack" ng-click="s.status.editStack=true">{{ s.title }}</span>
 				<form ng-if="s.status.editStack" ng-submit="stackservice.update(s)">
 					<input type="text" placeholder="Add a new stack"
 						   ng-blur="stackservice.update(s); s.status.editStack=false" ng-model="s.title"
-						   ng-if="s.status.editStack" autofocus-on-insert
-						   required maxlength="100"/>
+						   autofocus-on-insert required maxlength="100" />
 				</form>
 				<button class="icon-delete button-inline stack-actions"
 						ng-if="!s.status.editStack"


### PR DESCRIPTION
Allows editing stack title by clicking on the title itself. Deprecates edit icon in the stack header.

Signed-off-by: Marin Treselj <marin@pixelipo.com>