### PR TITLE
Simplify board view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -127,7 +127,7 @@ button.button-inline:hover {
 	top: 44px;
 }
 
-#board #innerBoard {
+#innerBoard {
 	padding: 10px;
 }
 
@@ -251,9 +251,7 @@ button.button-inline:hover {
 
 .stack {
 	width: 100%;
-	margin-right: 10px;
 	vertical-align: top;
-	background-color: #f8f8f8;
 }
 
 .stack h2 {
@@ -981,10 +979,22 @@ button.button-inline:hover {
 		display: none;
 	}
 
+	#innerBoard {
+		display: flex;
+	}
 	.stack {
 		width: 320px;
+		min-width: 320px;
 		display: inline-block;
+		border-right: 1px solid #eee;
+		margin-right: 10px;
+		padding-right: 10px;
 	}
+
+	.stack:last-child {
+		border-right: 1px solid transparent;
+	}
+
 	.stack h2 button {
 		display: none;
 	}

--- a/templates/part.board.mainView.php
+++ b/templates/part.board.mainView.php
@@ -45,8 +45,7 @@
 						ng-if="!s.status.editStack"
                         ng-click="stackservice.delete(s.id)"></button>
 			</h2>
-			<ul data-as-sortable="sortOptions" is-disabled="!boardservice.canEdit() || filter==='archive'" data-ng-model="s.cards"
-				style="min-height: 40px;">
+			<ul data-as-sortable="sortOptions" is-disabled="!boardservice.canEdit() || filter==='archive'" data-ng-model="s.cards" class="card-list">
 				<li class="card as-sortable-item"
 					ng-repeat="c in s.cards"
 					data-as-sortable-item


### PR DESCRIPTION
- Remove background from stacks
- Make stack height match the largest one #84
- ~Fixed stack headers, so it is clear where you are when scrolling~
- Resize stack width between 320px and 380px if there is enough space #82 

Feedback is very welcome. I'm not sure if the resizing of the stack width is a good way or if we should just go for a fixed width there.

![2017-06-20-213318_1152x862_scrot](https://user-images.githubusercontent.com/3404133/27352208-27166e4c-5600-11e7-9c13-fec341ab93c0.png)

