### PR TITLE
Fix icon2

### DIFF
--- a/img/deck-dark.svg
+++ b/img/deck-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" version="1.1">
+<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" version="1.1" viewBox="0 0 16 16">
   <rect ry="1" height="8" width="14" y="7" x="1"/>
   <rect ry=".5" height="1" width="12" y="5" x="2"/>
   <rect ry=".5" height="1" width="10" y="3" x="3"/>

--- a/img/deck.svg
+++ b/img/deck.svg
@@ -1,1 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" id="svg2"><style id="style4">.st0{display:none}.st1{display:inline}.st2{fill:#0071bc}.st3{display:inline}.st3,.st4{fill:#fff}</style><g id="Ebene_3"><path class="st4" d="M432.3 448.1h-348c-13.2 0-24-10.8-24-24V264.6c0-13.2 10.8-24 24-24h348c13.2 0 24 10.8 24 24v159.5c0 13.2-10.8 24-24 24zM380.4 89.8H127.8c-7.7 0-14-6.3-14-14v-6.3c0-7.7 6.3-14 14-14h252.6c7.7 0 14 6.3 14 14v6.3c0 7.7-6.3 14-14 14zm19.4 61.8H110.6c-7.7 0-14-6.3-14-14v-6.3c0-7.7 6.3-14 14-14h289.2c7.7 0 14 6.3 14 14v6.3c0 7.7-6.3 14-14 14zm21.6 61.4H94.6c-7.7 0-14-6.3-14-14v-6.3c0-7.7 6.3-14 14-14h326.8c7.7 0 14 6.3 14 14v6.3c0 7.7-6.3 14-14 14z" id="path12" fill="#fff"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" version="1.1">
+    <g fill="#fff">
+        <rect ry="1" height="8" width="14" y="7" x="1"/>
+        <rect ry=".5" height="1" width="12" y="5" x="2"/>
+        <rect ry=".5" height="1" width="10" y="3" x="3"/>
+        <rect ry=".5" height="1" width="8" y="1" x="4"/>
+    </g>
+</svg>


### PR DESCRIPTION
@juliushaertl I've added viewBox as this was suggested by @jancborchardt as a must-have for app icons.

I've also modified deck.svg to be identical (but white) version of deck-dark.svg

I didn't run scour optimization script - which would basically only remove whitespaces (~40 bytes per file).

Made a PR to your branch so that you can decide if you want these changes or not :wink: 

Signed-off-by: Marin Treselj <marin@pixelipo.com>