### PR TITLE
Include nextcloud variables/functions when building legacy css file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build-js: install-deps
 	cd js && ./node_modules/.bin/grunt build
 
 build-css: install-deps
-	./js/node_modules/node-sass/bin/node-sass --output-style compressed css/style.scss css/style.css
+	./js/node_modules/node-sass/bin/node-sass --output-style compressed css/legacy.scss css/style.css
 
 watch:
 	cd js && ./node_modules/.bin/grunt watch

--- a/css/legacy.scss
+++ b/css/legacy.scss
@@ -1,0 +1,24 @@
+/*
+ * @copyright Copyright (c) 2016 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+@import '../../../core/css/variables.scss';
+@import 'style.scss';


### PR DESCRIPTION
Otherwise nc-darken functions do not work and appear in the final css file.