### PR TITLE
Fix drag-zone when sorting cards

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -310,7 +310,9 @@ input.input-inline {
 	}
 
 	.card-list {
-		min-height: 40px;
+		padding-bottom: 100px;
+		padding-top: 40px;
+		margin-top:-40px;
 	}
 }
 
@@ -406,6 +408,7 @@ input.input-inline {
 		text-align: center;
 		padding: 10px;
 		margin: 10px;
+		margin-top: -90px;
 		border: none;
 		overflow: hidden;
 		-webkit-box-shadow: none;


### PR DESCRIPTION
Follow up of #238 

> I wonder what if we moved the "Add Card" button/form into the list (as always last element)

That did not went well, becasue ng-sortable will then add a placeholder to drag to after the add button.

I did some margin/padding magic to make the drag-target container also include the header/create button. Please review @jancborchardt @pixelipo
