### PR TITLE
Use ISO8601 date format for duedate

### DIFF
--- a/js/controller/CardController.js
+++ b/js/controller/CardController.js
@@ -94,7 +94,7 @@ app.controller('CardController', function ($scope, $rootScope, $routeParams, $lo
 		newDate.date(duedate.date());
 		newDate.month(duedate.month());
 		newDate.year(duedate.year());
-		element.duedate = newDate.format('YYYY-MM-DD HH:mm:ss');
+		element.duedate = newDate.toISOString();
 		CardService.update(element);
 		StackService.updateCard(element);
 	};
@@ -106,7 +106,7 @@ app.controller('CardController', function ($scope, $rootScope, $routeParams, $lo
 		}
 		newDate.hour(time.hour());
 		newDate.minute(time.minute());
-		element.duedate = newDate.format('YYYY-MM-DD HH:mm:ss');
+		element.duedate = newDate.toISOString();
 		CardService.update(element);
 		StackService.updateCard(element);
 	};

--- a/lib/Db/Card.php
+++ b/lib/Db/Card.php
@@ -58,6 +58,13 @@ class Card extends RelationalEntity implements JsonSerializable {
 		$this->addResolvable('owner');
 	}
 
+	public function getDuedate() {
+		if($this->duedate === null)
+			return null;
+		$dt = new DateTime($this->duedate);
+		return $dt->format('c');
+	}
+
 	public function jsonSerialize() {
 		$json = parent::jsonSerialize();
 		$json['overdue'] = self::DUEDATE_FUTURE;
@@ -84,6 +91,7 @@ class Card extends RelationalEntity implements JsonSerializable {
 				$json['overdue'] = self::DUEDATE_OVERDUE;
 			}
 		}
+		$json['duedate'] = $this->getDuedate();
 		return $json;
 	}
 

--- a/tests/unit/Service/CardServiceTest.php
+++ b/tests/unit/Service/CardServiceTest.php
@@ -104,7 +104,7 @@ class CardServiceTest extends TestCase {
         $this->assertEquals('text', $actual->getType());
         $this->assertEquals(999, $actual->getOrder());
         $this->assertEquals('foo', $actual->getDescription());
-        $this->assertEquals('2017-01-01 00:00:00', $actual->getDuedate());
+        $this->assertEquals('2017-01-01T00:00:00+00:00', $actual->getDuedate());
     }
 
     public function testUpdateArchived() {


### PR DESCRIPTION
Fixes issues with Date.parse on webkit based browsers
closes #240 

Signed-off-by: Julius Härtl <jus@bitgrid.net>