### PR TITLE
Fix `white-space` styles for `pre code` blocks

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -1053,7 +1053,8 @@ input.input-inline {
 	pre {
 		background-color: $color-lightgrey;
 		padding: 3px;
-		
+		overflow: auto;
+
 		code {
 			white-space: pre;
 		}

--- a/css/style.scss
+++ b/css/style.scss
@@ -1053,6 +1053,10 @@ input.input-inline {
 	pre {
 		background-color: $color-lightgrey;
 		padding: 3px;
+		
+		code {
+			white-space: pre;
+		}
 	}
 }
 


### PR DESCRIPTION
Before:

![4400093f](https://user-images.githubusercontent.com/5972388/29587777-47d2dbb4-878f-11e7-9c2f-35cac4bb9694.png)

After: 

![8bdb5549](https://user-images.githubusercontent.com/5972388/29587786-4e4ebfb2-878f-11e7-88a3-60fa02e91fd2.png)
