### PR TITLE
Add notifications for overdue cards and board sharing

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -23,3 +23,4 @@
 
 $app = new \OCA\Deck\AppInfo\Application();
 $app->registerNavigationEntry();
+$app->registerNotifications();

--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -162,6 +162,11 @@
                 <type>timestamp</type>
                 <default>0</default>
             </field>
+            <field>
+                <name>notified</name>
+                <type>boolean</type>
+                <default>false</default>
+            </field>
             <index>
                 <name>deck_cards_stack_id_index</name>
                 <field>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -31,6 +31,7 @@
     </dependencies>
     <background-jobs>
         <job>OCA\Deck\Cron\DeleteCron</job>
+        <job>OCA\Deck\Cron\ScheduledNotifications</job>
     </background-jobs>
     <repair-steps>
         <post-migration>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -25,6 +25,7 @@ namespace OCA\Deck\AppInfo;
 
 use OCA\Deck\Db\Acl;
 use OCA\Deck\Db\AclMapper;
+use OCA\Deck\Notification\Notifier;
 use OCP\AppFramework\App;
 use OCA\Deck\Middleware\SharingMiddleware;
 use OCP\IGroup;
@@ -92,5 +93,16 @@ class Application extends App {
 				'name' => 'Deck',
 			];
 		});
+	}
+
+	public function registerNotifications() {
+		$notificationManager = \OC::$server->getNotificationManager();
+		$self = &$this;
+		$notificationManager->registerNotifier(function() use (&$self) {
+			return $self->getContainer()->query(Notifier::class);
+		}, function () {
+			return ['id' => 'deck', 'name' => 'Deck'];
+		});
+
 	}
 }

--- a/lib/Cron/ScheduledNotifications.php
+++ b/lib/Cron/ScheduledNotifications.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Created by PhpStorm.
+ * User: jus
+ * Date: 16.05.17
+ * Time: 12:34
+ */
+
+namespace OCA\Deck\Cron;
+
+use DateTime;
+use OC\BackgroundJob\Job;
+use OCA\Deck\Db\Acl;
+use OCA\Deck\Db\BoardMapper;
+use OCA\Deck\Db\Card;
+use OCA\Deck\Db\CardMapper;
+use OCP\IUser;
+use OCP\Notification\IManager;
+
+class ScheduledNotifications extends Job {
+
+	/** @var CardMapper */
+	protected $cardMapper;
+	/** @var BoardMapper */
+	protected $boardMapper;
+	/** @var IManager */
+	protected $notificationManager;
+	/** @var array */
+	private $users = [];
+	/** @var array */
+	private $boards = [];
+
+	public function __construct(
+		CardMapper $cardMapper,
+		BoardMapper $boardMapper,
+		IManager $notificationManager
+	) {
+		$this->cardMapper = $cardMapper;
+		$this->boardMapper = $boardMapper;
+		$this->notificationManager = $notificationManager;
+	}
+
+	public function run($argument) {
+		// Notify board owner and card creator about overdue cards
+		// TODO: Once assigning users is possible, those should be notified instead of all users of the board
+		$cards = $this->cardMapper->findOverdue();
+		/** @var Card $card */
+		foreach ($cards as $card) {
+			// check if notification has already been sent
+			// ideally notifications should not be deleted once seen by the user so we can
+			// also deliver due date notifications for users who have been added later to a board
+			// this should maybe be addressed in nextcloud/server
+			if ($card->getNotified()) {
+				continue;
+			}
+			$boardId = $this->cardMapper->findBoardId($card->getId());
+			/** @var IUser $user */
+			foreach ($this->getUsers($boardId) as $user) {
+				$this->sendNotification($user, $card, $boardId);
+			}
+			$this->cardMapper->markNotified($card);
+		}
+	}
+
+	private function getUsers($boardId) {
+		// cache users of a board so we don't query them for every cards
+		if (array_key_exists((string)$boardId, $this->users)) {
+			return $this->users[(string)$boardId];
+		}
+		$this->boards[(string)$boardId] = $this->boardMapper->find($boardId, false, true);
+		$users = [$this->boards[(string)$boardId]->getOwner()];
+		/** @var Acl $acl */
+		foreach ($this->boards[(string)$boardId]->getAcl() as $acl) {
+			if ($acl->getType() === Acl::PERMISSION_TYPE_USER) {
+				$users[] = $acl->getParticipant();
+			}
+			if ($acl->getType() === Acl::PERMISSION_TYPE_GROUP) {
+				$group = \OC::$server->getGroupManager()->get($acl->getParticipant());
+				/** @var IUser $user */
+				foreach ($group->getUsers() as $user) {
+					$users[] = $user->getUID();
+				}
+			}
+		}
+		$this->users[(string)$boardId] = array_unique($users);
+		return $this->users[(string)$boardId];
+	}
+
+	private function sendNotification($user, $card, $boardId) {
+		$notification = $this->notificationManager->createNotification();
+		$notification
+			->setApp('deck')
+			->setUser($user)
+			->setObject('card', $card->getId())
+			->setSubject('card-overdue', [$card->getTitle(), $this->boards[(string)$boardId]->getTitle()]);
+		// this is only needed, if a notification exists for a user and the notified attribute is not set on the card
+		// if ($this->notificationManager->getCount($notification) > 0)
+		//	return;
+		$notification
+			->setDateTime(new DateTime($card->getDuedate()));
+		$this->notificationManager->notify($notification);
+	}
+
+}

--- a/lib/Db/Card.php
+++ b/lib/Db/Card.php
@@ -41,6 +41,7 @@ class Card extends RelationalEntity implements JsonSerializable {
 	protected $order;
 	protected $archived = false;
 	protected $duedate = null;
+	protected $notified = false;
 
 	const DUEDATE_FUTURE = 0;
 	const DUEDATE_NEXT = 1;
@@ -54,6 +55,7 @@ class Card extends RelationalEntity implements JsonSerializable {
 		$this->addType('lastModified', 'integer');
 		$this->addType('createdAt', 'integer');
 		$this->addType('archived', 'boolean');
+		$this->addType('notified', 'boolean');
 		$this->addRelation('labels');
 		$this->addResolvable('owner');
 	}
@@ -92,6 +94,7 @@ class Card extends RelationalEntity implements JsonSerializable {
 			}
 		}
 		$json['duedate'] = $this->getDuedate();
+		unset($json['notified']);
 		return $json;
 	}
 

--- a/lib/Notification/NotificationHelper.php
+++ b/lib/Notification/NotificationHelper.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Deck\Notification;
+
+use DateTime;
+use OCA\Deck\Db\Acl;
+use OCA\Deck\Db\BoardMapper;
+use OCA\Deck\Db\CardMapper;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\Notification\IManager;
+
+class NotificationHelper {
+
+	/** @var CardMapper */
+	protected $cardMapper;
+	/** @var BoardMapper */
+	protected $boardMapper;
+	/** @var IManager */
+	protected $notificationManager;
+	/** @var IGroupManager */
+	protected $groupManager;
+	/** @var string */
+	protected $currentUser;
+	/** @var array */
+	private $users = [];
+	/** @var array */
+	private $boards = [];
+
+	public function __construct(
+		CardMapper $cardMapper,
+		BoardMapper $boardMapper,
+		IManager $notificationManager,
+		$userId
+	) {
+		$this->cardMapper = $cardMapper;
+		$this->boardMapper = $boardMapper;
+		$this->notificationManager = $notificationManager;
+		$this->currentUser = $userId;
+	}
+
+	public function sendCardDuedate($card) {
+		// check if notification has already been sent
+		// ideally notifications should not be deleted once seen by the user so we can
+		// also deliver due date notifications for users who have been added later to a board
+		// this should maybe be addressed in nextcloud/server
+		if ($card->getNotified()) {
+			return;
+		}
+
+		// TODO: Once assigning users is possible, those should be notified instead of all users of the board
+		$boardId = $this->cardMapper->findBoardId($card->getId());
+		/** @var IUser $user */
+		foreach ($this->getUsers($boardId) as $user) {
+			$notification = $this->notificationManager->createNotification();
+			$notification
+				->setApp('deck')
+				->setUser($user)
+				->setObject('card', $card->getId())
+				->setSubject('card-overdue', [
+					$card->getTitle(), $this->boards[(string)$boardId]->getTitle()
+				])
+				->setDateTime(new DateTime($card->getDuedate()));
+			$this->notificationManager->notify($notification);
+		}
+		$this->cardMapper->markNotified($card);
+	}
+
+	/**
+	 * Send notifications that a board was shared with a user/group
+	 *
+	 * @param $boardId
+	 * @param $acl
+	 */
+	public function sendBoardShared($boardId, $acl) {
+		$board = $this->boardMapper->find($boardId);
+		if ($acl->getType() === Acl::PERMISSION_TYPE_USER) {
+			$notification = $this->generateBoardShared($board, $acl->getParticipant());
+			$this->notificationManager->notify($notification);
+		}
+		if ($acl->getType() === Acl::PERMISSION_TYPE_GROUP) {
+			$this->groupManager = \OC::$server->getGroupManager();
+			$group = $this->groupManager->get($acl->getParticipant());
+			foreach ($group->getUsers() as $user) {
+				$notification = $this->generateBoardShared($board, $user->getUID());
+				$this->notificationManager->notify($notification);
+			}
+		}
+	}
+
+	private function generateBoardShared($board, $userId) {
+		$notification = $this->notificationManager->createNotification();
+		$notification
+			->setApp('deck')
+			->setUser($userId)
+			->setDateTime(new DateTime())
+			->setObject('board', $board->getId())
+			->setSubject('board-shared', [$board->getTitle(), $this->currentUser]);
+		return $notification;
+	}
+
+	/**
+	 * Get users that have access to a board
+	 *
+	 * @param $boardId
+	 * @return mixed
+	 */
+	private function getUsers($boardId) {
+		// cache users of a board so we don't query them for every cards
+		if (array_key_exists((string)$boardId, $this->users)) {
+			return $this->users[(string)$boardId];
+		}
+		$this->boards[(string)$boardId] = $this->boardMapper->find($boardId, false, true);
+		$users = [$this->boards[(string)$boardId]->getOwner()];
+		/** @var Acl $acl */
+		foreach ($this->boards[(string)$boardId]->getAcl() as $acl) {
+			if ($acl->getType() === Acl::PERMISSION_TYPE_USER) {
+				$users[] = $acl->getParticipant();
+			}
+			if ($acl->getType() === Acl::PERMISSION_TYPE_GROUP) {
+				$group = \OC::$server->getGroupManager()->get($acl->getParticipant());
+				/** @var IUser $user */
+				foreach ($group->getUsers() as $user) {
+					$users[] = $user->getUID();
+				}
+			}
+		}
+		$this->users[(string)$boardId] = array_unique($users);
+		return $this->users[(string)$boardId];
+	}
+
+}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -85,11 +85,35 @@ class Notifier implements INotifier {
 		}
 		$l = $this->l10nFactory->get('deck', $languageCode);
 		$notification->setIcon($this->url->getAbsoluteURL($this->url->imagePath('deck', 'deck-dark.svg')));
+		$params = $notification->getSubjectParameters();
 
 		switch($notification->getSubject()) {
+			case 'card-overdue':
+				$cardId = $notification->getObjectId();
+				$boardId = $this->cardMapper->findBoardId($cardId);
+				$notification->setParsedSubject(
+					(string) $l->t('The card "%s" on "%s" has reached its due date.', $notification->getSubjectParameters())
+				);
+				// FIXME: Use type that is provided by NC / if custom type is supported
+				$notification->setRichSubject(
+					(string) $l->t('The card {card} on {board} has reached its due date.'),
+					[
+						'card' => [
+							'id' => null,
+							'type' => 'announcement',
+							'name' => $params[0],
+						],
+						'board' => [
+							'id' => null,
+							'type' => 'announcement',
+							'name' => $params[1],
+						],
+					]
+				);
+				$notification->setLink($this->url->linkToRouteAbsolute('deck.page.index') . '#!/board/'.$boardId.'//card/'.$cardId.'');
+				break;
 			case 'board-shared':
 				$boardId = $notification->getObjectId();
-				$params = $notification->getSubjectParameters();
 				$initiator = \OC::$server->getUserManager()->get($params[1]);
 				if($initiator !== null) {
 					$dn = $initiator->getDisplayName();

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Deck\Notification;
+
+use OCA\Deck\Db\BoardMapper;
+use OCA\Deck\Db\CardMapper;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use OCP\Notification\INotification;
+use OCP\Notification\INotifier;
+use OCP\RichObjectStrings\Definitions;
+
+class Notifier implements INotifier {
+	/** @var IFactory */
+	protected $l10nFactory;
+	/** @var IURLGenerator */
+	protected $url;
+	/** @var IUserManager */
+	protected $userManager;
+	/** @var CardMapper */
+	protected $cardMapper;
+	/** @var BoardMapper */
+	protected $boardMapper;
+
+	public function __construct(
+		IFactory $l10nFactory,
+		IURLGenerator $url,
+		IUserManager $userManager,
+		CardMapper $cardMapper,
+		BoardMapper $boardMapper,
+		Definitions $definitions
+	) {
+		$this->l10nFactory = $l10nFactory;
+		$this->url = $url;
+		$this->userManager = $userManager;
+		$this->cardMapper = $cardMapper;
+		$this->boardMapper = $boardMapper;
+		$definitions->addDefinition('highlight', [
+			'author' => 'Deck',
+			'app' => 'deck',
+			'since' => '12.0.0',
+			'parameters' => [
+				'name' => [
+					'since' => '12.0.0',
+					'required' => true,
+					'description' => 'The text that should be highlighted.',
+					'example' => 'Foobar',
+				]
+			],
+		]);
+	}
+
+	/**
+	 * @param INotification $notification
+	 * @param string $languageCode The code of the language that should be used to prepare the notification
+	 * @return INotification
+	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
+	 * @since 9.0.0
+	 */
+	public function prepare(INotification $notification, $languageCode) {
+		if($notification->getApp() !== 'deck') {
+			throw new \InvalidArgumentException();
+		}
+		$l = $this->l10nFactory->get('deck', $languageCode);
+		$notification->setIcon($this->url->getAbsoluteURL($this->url->imagePath('deck', 'deck-dark.svg')));
+
+		switch($notification->getSubject()) {
+			case 'board-shared':
+				$boardId = $notification->getObjectId();
+				$params = $notification->getSubjectParameters();
+				$initiator = \OC::$server->getUserManager()->get($params[1]);
+				if($initiator !== null) {
+					$dn = $initiator->getDisplayName();
+				} else {
+					$dn = $params[1];
+				}
+				$notification->setParsedSubject(
+					(string) $l->t('The board "%s" has been shared with you by %s.', [$params[0], $dn])
+				)->setRichSubject(
+					(string) $l->t('{user} has shared the board {board} with you.'),
+					[
+						'user' => [
+							'type' => 'user',
+							'id' => $params[1],
+							'name' => $dn,
+						],
+						'board' => [
+							'type' => 'highlight',
+							'name' => $params[0],
+						],
+					]
+				);
+				$notification->setLink($this->url->linkToRouteAbsolute('deck.page.index') . '#!/board/'.$boardId.'/');
+				break;
+		}
+		return $notification;
+	}
+}

--- a/tests/unit/Service/BoardServiceTest.php
+++ b/tests/unit/Service/BoardServiceTest.php
@@ -29,13 +29,11 @@ use OCA\Deck\Db\AclMapper;
 use OCA\Deck\Db\Board;
 use OCA\Deck\Db\BoardMapper;
 use OCA\Deck\Db\LabelMapper;
-use OCA\Deck\Db\User;
-use OCP\IGroupManager;
-use OCP\ILogger;
+use OCA\Deck\Notification\NotificationHelper;
 use OCP\IUser;
-use OCP\IUserManager;
+use \Test\TestCase;
 
-class BoardServiceTest extends \Test\TestCase {
+class BoardServiceTest extends TestCase {
 
 	/** @var BoardService */
 	private $service;
@@ -49,6 +47,8 @@ class BoardServiceTest extends \Test\TestCase {
 	private $boardMapper;
 	/** @var PermissionService */
 	private $permissionService;
+	/** @var NotificationHelper */
+	private $notificationHelper;
 
 	private $userId = 'admin';
 
@@ -59,13 +59,15 @@ class BoardServiceTest extends \Test\TestCase {
 		$this->boardMapper = $this->createMock(BoardMapper::class);
 		$this->labelMapper = $this->createMock(LabelMapper::class);
 		$this->permissionService = $this->createMock(PermissionService::class);
+		$this->notificationHelper = $this->createMock(NotificationHelper::class);
 
 		$this->service = new BoardService(
 			$this->boardMapper,
 			$this->l10n,
 			$this->labelMapper,
 			$this->aclMapper,
-			$this->permissionService
+			$this->permissionService,
+			$this->notificationHelper
 		);
 
 		$user = $this->createMock(IUser::class);
@@ -165,6 +167,8 @@ class BoardServiceTest extends \Test\TestCase {
 		$acl->resolveRelation('participant', function($participant) use (&$user) {
 			return null;
 		});
+		$this->notificationHelper->expects($this->once())
+			->method('sendBoardShared');
 		$this->aclMapper->expects($this->once())
 			->method('insert')
 			->with($acl)


### PR DESCRIPTION
Send users a notification if a board is shared with them and if a card on one of their boards is overdue.