### PR TITLE
Fix assigning newly created labels

### DIFF
--- a/js/controller/BoardController.js
+++ b/js/controller/BoardController.js
@@ -175,10 +175,12 @@ app.controller('BoardController', function ($rootScope, $scope, $stateParams, St
 	};
 	$scope.labelCreate = function (label) {
 		label.boardId = $scope.id;
-		LabelService.create(label);
-		BoardService.getCurrent().labels.push(label);
-		$scope.status.createLabel = false;
-		$scope.newLabel = {};
+		LabelService.create(label).then(function (data) {
+			$scope.newStack.title = "";
+			BoardService.getCurrent().labels.push(data);
+			$scope.status.createLabel = false;
+			$scope.newLabel = {};
+		});
 	};
 	$scope.labelUpdate = function (label) {
 		label.edit = false;


### PR DESCRIPTION
fixes #252

Steps to reproduce:
- create a new label
- assign it to a card
- reload the page

Signed-off-by: Julius Härtl <jus@bitgrid.net>