### PR TITLE
Fix #308 - Document title doesn't update when renaming active board

### DIFF
--- a/js/controller/BoardController.js
+++ b/js/controller/BoardController.js
@@ -46,6 +46,13 @@ app.controller('BoardController', function ($rootScope, $scope, $stateParams, St
 
 	$scope.board = BoardService.getCurrent();
 	StackService.clear(); //FIXME: Is this still needed?
+
+	$scope.$watch(function () {
+   		return BoardService.getCurrent().title;
+	}, function() {
+   		$scope.setPageTitle();
+	});
+
 	$scope.setPageTitle = function () {
 		if (BoardService.getCurrent()) {
 			document.title = BoardService.getCurrent().title + " | Deck - " + oc_defaults.name;


### PR DESCRIPTION
Fix #308 

Signed-off-by: Riccardo Padovani riccardo@rpadovani.com