### PR TITLE
Drop support for NC11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
     matrix:
         - CORE_BRANCH=master DB=mysql
         - CORE_BRANCH=stable12 DB=mysql 
-        - CORE_BRANCH=stable11 DB=mysql 
 
 before_install:
     - wget https://phar.phpunit.de/phpunit-5.7.phar

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -27,7 +27,7 @@
     <screenshot>https://download.bitgrid.net/nextcloud/deck/screenshots/Deck_Board.png</screenshot>
     <screenshot>https://download.bitgrid.net/nextcloud/deck/screenshots/Deck_Details.png</screenshot>
     <dependencies>
-        <nextcloud min-version="11" max-version="13" />
+        <nextcloud min-version="12" max-version="13" />
     </dependencies>
     <background-jobs>
         <job>OCA\Deck\Cron\DeleteCron</job>


### PR DESCRIPTION
Nextcloud 11 will be EOL when NC13 is released, so we don't support it with the upcoming version 0.3.0 of deck.