### PR TITLE
Add dedicated setting for description change activities

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -136,6 +136,11 @@
                 <notnull>false</notnull>
             </field>
             <field>
+                <name>description_prev</name>
+                <type>clob</type>
+                <notnull>false</notnull>
+            </field>
+            <field>
                 <name>stack_id</name>
                 <type>integer</type>
                 <length>8</length>
@@ -154,6 +159,12 @@
                 <default></default>
                 <notnull>false</notnull>
                 <unsigned>true</unsigned>
+            </field>
+            <field>
+                <name>last_editor</name>
+                <type>text</type>
+                <notnull>false</notnull>
+                <length>64</length>
             </field>
             <field>
                 <name>created_at</name>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@
 - 🚀 Get your project organized
 
 </description>
-    <version>0.5.0</version>
+    <version>0.5.1-dev1</version>
     <licence>agpl</licence>
     <author>Julius Härtl</author>
     <namespace>Deck</namespace>
@@ -53,6 +53,7 @@
     <activity>
         <settings>
             <setting>OCA\Deck\Activity\Setting</setting>
+            <setting>OCA\Deck\Activity\DescriptionSetting</setting>
         </settings>
         <filters>
             <filter>OCA\Deck\Activity\Filter</filter>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@
 - 🚀 Get your project organized
 
 </description>
-    <version>0.5.1-dev1</version>
+    <version>0.5.1-dev2</version>
     <licence>agpl</licence>
     <author>Julius Härtl</author>
     <namespace>Deck</namespace>
@@ -41,6 +41,7 @@
     <background-jobs>
         <job>OCA\Deck\Cron\DeleteCron</job>
         <job>OCA\Deck\Cron\ScheduledNotifications</job>
+        <job>OCA\Deck\Cron\CardDescriptionActivity</job>
     </background-jobs>
     <repair-steps>
         <post-migration>

--- a/lib/Activity/ActivityManager.php
+++ b/lib/Activity/ActivityManager.php
@@ -309,6 +309,7 @@ class ActivityManager {
 		 * Automatically fetch related details for subject parameters
 		 * depending on the subject
 		 */
+		$eventType = 'deck';
 		$subjectParams = [];
 		$message = null;
 		switch ($subject) {
@@ -372,6 +373,7 @@ class ActivityManager {
 
 		if ($subject === self::SUBJECT_CARD_UPDATE_DESCRIPTION){
 			$subjectParams['diff'] = true;
+			$eventType = 'deck_card_description';
 		}
 		if ($subject === self::SUBJECT_CARD_UPDATE_STACKID) {
 			$subjectParams['stackBefore'] = $this->stackMapper->find($additionalParams['before']);
@@ -382,7 +384,7 @@ class ActivityManager {
 
 		$event = $this->manager->generateEvent();
 		$event->setApp('deck')
-			->setType('deck')
+			->setType($eventType)
 			->setAuthor($this->userId)
 			->setObject($objectType, (int)$object->getId(), $object->getTitle())
 			->setSubject($subject, array_merge($subjectParams, $additionalParams))

--- a/lib/Activity/ActivityManager.php
+++ b/lib/Activity/ActivityManager.php
@@ -239,10 +239,12 @@ class ActivityManager {
 		return $subject;
 	}
 
-	public function triggerEvent($objectType, $entity, $subject, $additionalParams = []) {
+	public function triggerEvent($objectType, $entity, $subject, $additionalParams = [], $author = null) {
 		try {
-			$event = $this->createEvent($objectType, $entity, $subject, $additionalParams);
-			$this->sendToUsers($event);
+			$event = $this->createEvent($objectType, $entity, $subject, $additionalParams, $author);
+			if ($event !== null) {
+				$this->sendToUsers($event);
+			}
 		} catch (\Exception $e) {
 			// Ignore exception for undefined activities on update events
 		}
@@ -262,15 +264,17 @@ class ActivityManager {
 		if ($previousEntity !== null) {
 			foreach ($entity->getUpdatedFields() as $field => $value) {
 				$getter = 'get' . ucfirst($field);
-				$subject = $subject . '_' . $field;
+				$subjectComplete = $subject . '_' . $field;
 				$changes = [
 					'before' => $previousEntity->$getter(),
 					'after' => $entity->$getter()
 				];
 				if ($changes['before'] !== $changes['after']) {
 					try {
-						$event = $this->createEvent($objectType, $entity, $subject, $changes);
-						$events[] = $event;
+						$event = $this->createEvent($objectType, $entity, $subjectComplete, $changes);
+						if ($event !== null) {
+							$events[] = $event;
+						}
 					} catch (\Exception $e) {
 						// Ignore exception for undefined activities on update events
 					}
@@ -278,7 +282,7 @@ class ActivityManager {
 			}
 		} else {
 			try {
-				$events = [$this->createEvent($objectType, $entity, $subject)];
+				$events = [$this->createEvent($objectType, $entity, $subject, $author)];
 			} catch (\Exception $e) {
 				// Ignore exception for undefined activities on update events
 			}
@@ -293,10 +297,10 @@ class ActivityManager {
 	 * @param $entity
 	 * @param $subject
 	 * @param array $additionalParams
-	 * @return IEvent
+	 * @return IEvent|null
 	 * @throws \Exception
 	 */
-	private function createEvent($objectType, $entity, $subject, $additionalParams = []) {
+	private function createEvent($objectType, $entity, $subject, $additionalParams = [], $author = null) {
 		try {
 			$object = $this->findObjectForEntity($objectType, $entity);
 		} catch (DoesNotExistException $e) {
@@ -372,6 +376,10 @@ class ActivityManager {
 		}
 
 		if ($subject === self::SUBJECT_CARD_UPDATE_DESCRIPTION){
+			$card = $subjectParams['card'];
+			if ($card->getLastEditor() === $this->userId) {
+				return null;
+			}
 			$subjectParams['diff'] = true;
 			$eventType = 'deck_card_description';
 		}
@@ -385,7 +393,7 @@ class ActivityManager {
 		$event = $this->manager->generateEvent();
 		$event->setApp('deck')
 			->setType($eventType)
-			->setAuthor($this->userId)
+			->setAuthor($author === null ? $this->userId : $author)
 			->setObject($objectType, (int)$object->getId(), $object->getTitle())
 			->setSubject($subject, array_merge($subjectParams, $additionalParams))
 			->setTimestamp(time());

--- a/lib/Activity/DescriptionSetting.php
+++ b/lib/Activity/DescriptionSetting.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Deck\Activity;
+
+
+class DescriptionSetting extends Setting {
+
+	/**
+	 * @return string Lowercase a-z and underscore only identifier
+	 * @since 11.0.0
+	 */
+	public function getIdentifier() {
+		return 'deck_card_description';
+	}
+
+	/**
+	 * @return string A translated string
+	 * @since 11.0.0
+	 */
+	public function getName() {
+		return $this->l->t('A <strong>card description</strong> inside the Deck app has been changed');
+	}
+
+}

--- a/lib/Activity/Setting.php
+++ b/lib/Activity/Setting.php
@@ -24,7 +24,19 @@
 namespace OCA\Deck\Activity;
 
 
+use OCP\IL10N;
+
 class Setting implements \OCP\Activity\ISetting {
+
+	/** @var IL10N */
+	protected $l;
+
+	/**
+	 * @param IL10N $l
+	 */
+	public function __construct(IL10N $l) {
+		$this->l = $l;
+	}
 
 	/**
 	 * @return string Lowercase a-z and underscore only identifier
@@ -39,7 +51,7 @@ class Setting implements \OCP\Activity\ISetting {
 	 * @since 11.0.0
 	 */
 	public function getName() {
-		return 'Deck';
+		return $this->l->t('Changes in the <strong>Deck app</strong>');
 	}
 
 	/**

--- a/lib/Cron/CardDescriptionActivity.php
+++ b/lib/Cron/CardDescriptionActivity.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Deck\Cron;
+
+use OC\BackgroundJob\Job;
+use OCA\Deck\Activity\ActivityManager;
+use OCA\Deck\Activity\ChangeSet;
+use OCA\Deck\Db\AttachmentMapper;
+use OCA\Deck\Db\BoardMapper;
+use OCA\Deck\Db\Card;
+use OCA\Deck\Db\CardMapper;
+use OCA\Deck\InvalidAttachmentType;
+use OCA\Deck\Service\AttachmentService;
+use OCA\Deck\Service\CardService;
+
+class CardDescriptionActivity extends Job {
+
+	/** @var ActivityManager */
+	private $activityManager;
+	/** @var CardMapper */
+	private $cardMapper;
+
+	public function __construct(ActivityManager $activityManager, CardMapper $cardMapper) {
+		$this->activityManager  = $activityManager;
+		$this->cardMapper = $cardMapper;
+	}
+
+	/**
+	 * @param $argument
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+	 */
+	public function run($argument) {
+		$cards = $this->cardMapper->findUnexposedDescriptionChances();
+		foreach ($cards as $card) {
+			$this->activityManager->triggerEvent(
+				ActivityManager::DECK_OBJECT_CARD,
+				$card,
+				ActivityManager::SUBJECT_CARD_UPDATE_DESCRIPTION,
+				[
+					'before' => $card->getDescriptionPrev(),
+					'after' => $card->getDescription()
+				],
+				$card->getLastEditor()
+			);
+
+			$card->setDescriptionPrev(null);
+			$card->setLastEditor(null);
+			$this->cardMapper->update($card, false);
+		}
+	}
+
+}

--- a/lib/Db/Card.php
+++ b/lib/Db/Card.php
@@ -29,9 +29,11 @@ class Card extends RelationalEntity {
 
 	protected $title;
 	protected $description;
+	protected $descriptionPrev;
 	protected $stackId;
 	protected $type;
 	protected $lastModified;
+	protected $lastEditor;
 	protected $createdAt;
 	protected $labels;
 	protected $assignedUsers;
@@ -113,6 +115,7 @@ class Card extends RelationalEntity {
 		}
 		$json['duedate'] = $this->getDuedate(true);
 		unset($json['notified']);
+		unset($json['descriptionPrev']);
 		return $json;
 	}
 

--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -147,6 +147,11 @@ class CardMapper extends DeckMapper implements IPermissionMapper {
 		return $this->findEntities($sql);
 	}
 
+	public function findUnexposedDescriptionChances() {
+		$sql = 'SELECT id,title,duedate,notified,description_prev,last_editor,description from `*PREFIX*deck_cards` WHERE last_editor IS NOT NULL AND description_prev IS NOT NULL';
+		return $this->findEntities($sql);
+	}
+
 	public function delete(Entity $entity) {
 		// delete assigned labels
 		$this->labelMapper->deleteLabelAssignmentsForCard($entity->getId());

--- a/lib/Db/ChangeHelper.php
+++ b/lib/Db/ChangeHelper.php
@@ -41,11 +41,13 @@ class ChangeHelper {
 	public function __construct(
 		IDBConnection $db,
 		ICacheFactory $cacheFactory,
-		IRequest $request
+		IRequest $request,
+		$userId
 	) {
 		$this->db = $db;
 		$this->cache = $cacheFactory->createDistributed('deck_changes');
 		$this->request = $request;
+		$this->userId = $userId;
 	}
 
 	public function boardChanged($boardId) {
@@ -61,8 +63,8 @@ class ChangeHelper {
 		$etag = md5($time . microtime());
 		$this->cache->set(self::TYPE_CARD . '-' .$cardId, $etag);
 		if ($updateCard) {
-			$sql = 'UPDATE `*PREFIX*deck_cards` SET `last_modified` = ? WHERE `id` = ?';
-			$this->db->executeUpdate($sql, [time(), $cardId]);
+			$sql = 'UPDATE `*PREFIX*deck_cards` SET `last_modified` = ?, `last_editor` = ? WHERE `id` = ?';
+			$this->db->executeUpdate($sql, [time(), $this->userId, $cardId]);
 		}
 
 		$sql = 'SELECT s.board_id as id, c.stack_id as stack_id FROM `*PREFIX*deck_stacks` as s inner join `*PREFIX*deck_cards` as c ON c.stack_id = s.id WHERE c.id = ?';

--- a/tests/unit/Activity/SettingTest.php
+++ b/tests/unit/Activity/SettingTest.php
@@ -23,15 +23,20 @@
 
 namespace OCA\Deck\Activity;
 
+use OCP\IL10N;
 use PHPUnit\Framework\TestCase;
 
 class SettingTest extends TestCase {
 
+	/** @var IL10N */
+	private $l10n;
 	/** @var Setting */
 	private $setting;
 
 	public function setUp() {
-		$this->setting = new Setting();
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->expects($this->any())->method('t')->will($this->returnCallback(function ($s) { return $s; }));
+		$this->setting = new Setting($this->l10n);
 	}
 
 	public function testGetIdentifier() {
@@ -39,7 +44,7 @@ class SettingTest extends TestCase {
 	}
 
 	public function testGetName() {
-		$this->assertEquals('Deck', $this->setting->getName());
+		$this->assertEquals('Changes in the <strong>Deck app</strong>', $this->setting->getName());
 	}
 
 	public function testGetPriority() {

--- a/tests/unit/Db/CardTest.php
+++ b/tests/unit/Db/CardTest.php
@@ -83,6 +83,7 @@ class CardTest extends TestCase {
 			'assignedUsers' => null,
 			'deletedAt' => 0,
 			'commentsUnread' => 0,
+			'lastEditor' => null,
 		], $card->jsonSerialize());
 	}
 	public function testJsonSerializeLabels() {
@@ -107,6 +108,7 @@ class CardTest extends TestCase {
 			'assignedUsers' => null,
 			'deletedAt' => 0,
 			'commentsUnread' => 0,
+			'lastEditor' => null,
 		], $card->jsonSerialize());
 	}
 
@@ -141,6 +143,7 @@ class CardTest extends TestCase {
 			'assignedUsers' => ['user1'],
 			'deletedAt' => 0,
 			'commentsUnread' => 0,
+			'lastEditor' => null,
 		], $card->jsonSerialize());
 	}
 


### PR DESCRIPTION
- [x] Move description activity events to a separate type, so it is possible to disable those 
- [x] Only trigger description change events if updates are done by different users or if no further changes have been done for some longer time (fixes #745)