### PR TITLE
Bugfix for missing dbtableprefix in 'cardChanged' function in /lib/Db…

### DIFF
--- a/lib/Db/ChangeHelper.php
+++ b/lib/Db/ChangeHelper.php
@@ -65,7 +65,7 @@ class ChangeHelper {
 			$this->db->executeUpdate($sql, [time(), $cardId]);
 		}
 
-		$sql = 'SELECT s.board_id as id, c.stack_id as stack_id FROM oc_deck_stacks as s inner join oc_deck_cards as c ON c.stack_id = s.id WHERE c.id = ?';
+		$sql = 'SELECT s.board_id as id, c.stack_id as stack_id FROM `*PREFIX*deck_stacks` as s inner join `*PREFIX*deck_cards` as c ON c.stack_id = s.id WHERE c.id = ?';
 		$result = $this->db->executeQuery($sql, [$cardId]);
 		if ($row = $result->fetch()) {
 			$this->boardChanged($row['id']);


### PR DESCRIPTION
…/ChangeHelper.php (68)


* Resolves: #705 
* Target version: master 

### Summary


### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [] Documentation (manuals or wiki) has been updated or is not required
