### PR TITLE
Deck now remembers the side menu state

### DIFF
--- a/js/.jshintrc
+++ b/js/.jshintrc
@@ -1,4 +1,6 @@
 {
+  "esversion": 6,
+
   "globals": {
     "jasmine"    : false,
     "spyOn"      : false,
@@ -21,7 +23,6 @@
   "devel"     : true,
   "eqeqeq"    : true,
   "eqnull"    : false,
-  "es5"       : true,
   "evil"      : false,
   "forin"     : true,
   "immed"     : true,
@@ -39,7 +40,6 @@
   "plusplus"  : false,
   "quotmark"  : "single",
   "regexp"    : false,
-  "strict"    : true,
   "sub"       : true,
   "trailing"  : true,
   "undef"     : true,

--- a/js/controller/AppController.js
+++ b/js/controller/AppController.js
@@ -22,7 +22,7 @@
 
 import app from '../app/App.js';
 
-/** global: OC */
+/* globals oc_current_user: false */
 app.controller('AppController', function ($scope, $location, $http, $log, $rootScope, $attrs) {
 	$rootScope.sidebar = {
 		show: false
@@ -32,13 +32,13 @@ app.controller('AppController', function ($scope, $location, $http, $log, $rootS
 	$rootScope.config = JSON.parse($attrs.config);
 
 	$rootScope.compactMode = localStorage.getItem('deck.compactMode') === 'true';
-
-	$scope.appNavigationHide = false;
+	$scope.appNavigationHide = localStorage.getItem('deck.appNavigationHide') === 'true';
 
 	$scope.toggleSidebar = function() {
 		if ($(window).width() > 768) {
+			$log.debug($scope.appNavigationHide);
 			$scope.appNavigationHide = !$scope.appNavigationHide;
-			console.log($scope.appNavigationHide);
+			localStorage.setItem('deck.appNavigationHide', JSON.stringify($scope.appNavigationHide));
 		}
 	};
 });


### PR DESCRIPTION
* Resolves: #631 
* Target version: master 

### Summary

The side menu state is now stored in local storage.  
I've also updated the jshint file and at least the code I touched to make it compliant.

### Checklist

- [X] Code is properly formatted
- [X] Sign-off message is added to all commits
- [X] Tests (unit, integration, api and/or acceptance) are included - none
- [X] Documentation (manuals or wiki) has been updated or is not required - I don't think it's required
