### PR TITLE
Allow deck to be limited to groups again

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@
     <author>Julius Härtl</author>
     <namespace>Deck</namespace>
     <types>
-        <logging/>
+        <dav />
     </types>
     <category>organization</category>
     <category>office</category>


### PR DESCRIPTION
This requires https://github.com/nextcloud/server/pull/12448 so the deck app is properly loaded on the dav endpoints for comments. This can be merged once the patch is released in the next minor versions 14.0.5 and 13.0.9. If this PR is merged, comments will require those versions to work for Deck.