### PR TITLE
Added optional classes has-tasks, has-tasks-completed, overdue, now and

### DIFF
--- a/templates/part.board.mainView.php
+++ b/templates/part.board.mainView.php
@@ -63,7 +63,7 @@
 					data-as-sortable-item
 					ng-click="$event.stopPropagation()"
 					ui-sref="board.card({boardId: id, cardId: c.id})"
-					ng-class="{'archived': cardservice.get(c.id).archived, 'has-labels': cardservice.get(c.id).labels.length>0, 'current': cardservice.get(c.id).id == params.cardId }"
+					ng-class="{'archived': cardservice.get(c.id).archived, 'has-labels': cardservice.get(c.id).labels.length>0, 'current': cardservice.get(c.id).id == params.cardId, 'overdue': cardservice.get(c.id).overdue == 3, 'now': cardservice.get(c.id).overdue == 2, 'next': cardservice.get(c.id).overdue == 1, 'has-tasks': getCheckboxes(cardservice.get(c.id).description)[1] > 0, 'has-tasks-completed': getCheckboxes(cardservice.get(c.id).description)[1] > 0 && getCheckboxes(cardservice.get(c.id).description)[1] == getCheckboxes(cardservice.get(c.id).description)[0] }"
 					nv-file-drop="" uploader="uploader" options="{cardId: c.id}">
 					<div class="drop-indicator" uploader="uploader" nv-file-over>
 						<p><?php p($l->t('Drop your files here to upload it to the card')); ?></p>


### PR DESCRIPTION
next to li.card in mainView-template.

Signed-off-by: Tinko Bartels <mail@tinkobartels.de>


* Target version: master 

### Summary

This pull request includes a minor change (an addition to one line) to templates/part.board.mainView.php to add the classes has-tasks, has-tasks-completed (where one or more checkboxes exist and all checkboxes are checked), overdue, now and next to the classes of li.card if applicable. I tested the code in my local installation of Nextcloud.

The motivation is to make that information available in the DOM hierarchy at the level card (so that it is available in compact-mode) similar to the existing class "has-labels", so that it might be used for custom styling today (which is my use case) or for additional styling in the future. 

### TODO


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
