### PR TITLE
Fix information in activity emails

### DIFF
--- a/lib/Activity/ActivityManager.php
+++ b/lib/Activity/ActivityManager.php
@@ -377,6 +377,9 @@ class ActivityManager {
 			$subjectParams['stackBefore'] = $this->stackMapper->find($additionalParams['before']);
 		}
 
+		$subjectParams['author'] = $this->userId;
+
+
 		$event = $this->manager->generateEvent();
 		$event->setApp('deck')
 			->setType('deck')

--- a/lib/Activity/ActivityManager.php
+++ b/lib/Activity/ActivityManager.php
@@ -322,11 +322,13 @@ class ActivityManager {
 			// case self::SUBJECT_BOARD_UPDATE_COLOR
 				break;
 			case self::SUBJECT_CARD_COMMENT_CREATE:
-				/** @var IComment $entity */
-				$subjectParams = [
-					'comment' => $entity->getMessage()
-				];
-				$message = '{comment}';
+				$subjectParams = $this->findDetailsForCard($entity->getId());
+				if (array_key_exists('comment', $additionalParams)) {
+					/** @var IComment $entity */
+					$comment = $additionalParams['comment'];
+					$subjectParams['comment'] = $comment->getId();
+					unset($additionalParams['comment']);
+				}
 				break;
 
 			case self::SUBJECT_STACK_CREATE:

--- a/lib/Activity/CommentEventHandler.php
+++ b/lib/Activity/CommentEventHandler.php
@@ -23,8 +23,10 @@
 
 namespace OCA\Deck\Activity;
 
+use OCA\Deck\Db\CardMapper;
 use OCA\Deck\Notification\NotificationHelper;
 use OCP\Comments\CommentsEvent;
+use OCP\Comments\IComment;
 use \OCP\Comments\ICommentsEventHandler;
 
 class CommentEventHandler implements ICommentsEventHandler {
@@ -35,9 +37,13 @@ class CommentEventHandler implements ICommentsEventHandler {
 	/** @var NotificationHelper */
 	private $notificationHelper;
 
-	public function __construct(ActivityManager $activityManager, NotificationHelper $notificationHelper) {
+	/** @var CardMapper */
+	private $cardMapper;
+
+	public function __construct(ActivityManager $activityManager, NotificationHelper $notificationHelper, CardMapper $cardMapper) {
 		$this->notificationHelper = $notificationHelper;
 		$this->activityManager = $activityManager;
+		$this->cardMapper = $cardMapper;
 	}
 
 	/**
@@ -71,8 +77,10 @@ class CommentEventHandler implements ICommentsEventHandler {
 	 * @param CommentsEvent $event
 	 */
 	private function activityHandler(CommentsEvent $event) {
+		/** @var IComment $comment */
 		$comment = $event->getComment();
-		$this->activityManager->triggerEvent(ActivityManager::DECK_OBJECT_CARD, $comment, ActivityManager::SUBJECT_CARD_COMMENT_CREATE, ['comment' => $comment->getId()]);
+		$card = $this->cardMapper->find($comment->getObjectId());
+		$this->activityManager->triggerEvent(ActivityManager::DECK_OBJECT_CARD, $card, ActivityManager::SUBJECT_CARD_COMMENT_CREATE, ['comment' => $comment]);
 
 	}
 

--- a/lib/Activity/DeckProvider.php
+++ b/lib/Activity/DeckProvider.php
@@ -81,6 +81,11 @@ class DeckProvider implements IProvider {
 		 */
 
 		$author = $event->getAuthor();
+		// get author if
+		if ($author === '' && array_key_exists('author', $subjectParams)) {
+			$author = $subjectParams['author'];
+			unset($subjectParams['author']);
+		}
 		$user = $this->userManager->get($author);
 		$params = [
 			'user' => [
@@ -90,6 +95,9 @@ class DeckProvider implements IProvider {
 			],
 		];
 		if ($event->getObjectType() === ActivityManager::DECK_OBJECT_BOARD) {
+			if ($event->getObjectName() === '') {
+				$event->setObject($event->getObjectType(), $event->getObjectId(), $subjectParams['board']['title']);
+			}
 			$board = [
 				'type' => 'highlight',
 				'id' => $event->getObjectId(),
@@ -100,6 +108,9 @@ class DeckProvider implements IProvider {
 		}
 
 		if ($event->getObjectType() === ActivityManager::DECK_OBJECT_CARD) {
+			if ($event->getObjectName() === '') {
+				$event->setObject($event->getObjectType(), $event->getObjectId(), $subjectParams['card']['title']);
+			}
 			$card = [
 				'type' => 'highlight',
 				'id' => $event->getObjectId(),
@@ -149,6 +160,7 @@ class DeckProvider implements IProvider {
 
 		$event->setParsedSubject(str_replace($placeholders, $replacements, $subject))
 			->setRichSubject($subject, $parameters);
+		$event->setSubject($subject, $parameters);
 	}
 
 	private function getIcon(IEvent $event) {
@@ -301,6 +313,6 @@ class DeckProvider implements IProvider {
 	}
 
 	public function deckUrl($endpoint) {
-		return $this->urlGenerator->linkToRoute('deck.page.index') . '#!' . $endpoint;
+		return $this->urlGenerator->linkToRouteAbsolute('deck.page.index') . '#!' . $endpoint;
 	}
 }

--- a/tests/unit/Activity/CommentEventHandlerTest.php
+++ b/tests/unit/Activity/CommentEventHandlerTest.php
@@ -53,13 +53,17 @@ class CommentEventHandlerTest extends TestCase {
 	private $activityManager;
 	/** @var NotificationHelper */
 	private $notificationHelper;
+	/** @var CardMapper */
+	private $cardMapper;
 
 	public function setUp() {
 		$this->activityManager = $this->createMock(ActivityManager::class);
 		$this->notificationHelper = $this->createMock(NotificationHelper::class);
+		$this->cardMapper = $this->createMock(CardMapper::class);
 		$this->commentEventHandler = new CommentEventHandler(
 			$this->activityManager,
-			$this->notificationHelper
+			$this->notificationHelper,
+			$this->cardMapper
 		);
 	}
 
@@ -67,10 +71,15 @@ class CommentEventHandlerTest extends TestCase {
 		$comment = $this->createMock(IComment::class);
 		$comment->expects($this->any())->method('getId')->willReturn(1);
 		$comment->expects($this->any())->method('getObjectType')->willReturn('deckCard');
+		$comment->expects($this->any())->method('getMessage')->willReturn('Hello world');
+		$card = $this->createMock(Card::class);
+		$this->cardMapper->expects($this->once())
+			->method('find')
+			->willReturn($card);
 		$commentsEvent = new CommentsEvent(CommentsEvent::EVENT_ADD, $comment);
 		$this->activityManager->expects($this->once())
 			->method('triggerEvent')
-			->with(ActivityManager::DECK_OBJECT_CARD, $comment, ActivityManager::SUBJECT_CARD_COMMENT_CREATE, ['comment' => 1]);
+			->with(ActivityManager::DECK_OBJECT_CARD, $card, ActivityManager::SUBJECT_CARD_COMMENT_CREATE, ['comment' => $comment]);
 		$this->notificationHelper->expects($this->once())
 			->method('sendMention')
 			->with($comment);

--- a/tests/unit/Activity/DeckProviderTest.php
+++ b/tests/unit/Activity/DeckProviderTest.php
@@ -139,7 +139,7 @@ class DeckProviderTest extends TestCase {
 
 	public function testDeckUrl() {
 		$this->urlGenerator->expects($this->once())
-			->method('linkToRoute')
+			->method('linkToRouteAbsolute')
 			->with('deck.page.index')
 			->willReturn('http://localhost/index.php/apps/deck/');
 		$this->assertEquals(


### PR DESCRIPTION
Since the author of the activity and the events object name are not available on the activity_mq table, we need to use the data in the subject parameters to properly get all information when parsing the activity events for emails.

This also fixes comments using the wrong entity object and therefore not being added to the proper activity stream.

Fixes #721

