### PR TITLE
Use regular groups endpoint to support Nextcloud 13

### DIFF
--- a/js/controller/ListController.js
+++ b/js/controller/ListController.js
@@ -65,9 +65,16 @@ var ListController = function ($scope, $location, $filter, BoardService, $elemen
 		$scope.groupLimitDisabled = true;
 		let fetchGroups = function () {
 			var deferred = $q.defer();
-			$http.get(OC.linkToOCS('cloud', 2) + 'groups/details').then(function (response) {
-				$scope.groups = response.data.ocs.data.groups;
-				deferred.resolve(response.data.ocs.data.groups);
+			// TODO: move to groups/details once 15 is min version
+			$http.get(OC.linkToOCS('cloud', 2) + 'groups').then(function (response) {
+				$scope.groups = response.data.ocs.data.groups.reduce((obj, item) => {
+					obj.push({
+						id: item,
+						displayname: item,
+					});
+					return obj;
+				}, []);
+				deferred.resolve($scope.groups);
 			}, function (error) {
 				deferred.reject('Error while loading groups');
 			});

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -106,10 +106,6 @@ class ConfigController extends Controller {
 			return [
 				'id' => $group->getGID(),
 				'displayname' => $group->getDisplayName(),
-				'usercount' => $group->count(),
-				'disabled' => $group->countDisabled(),
-				'canAdd' => $group->canAddUser(),
-				'canRemove' => $group->canRemoveUser(),
 			];
 		}, $groups);
 		return $groups;

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -68,7 +68,9 @@ class PageController extends Controller {
 		];
 
 		if ($this->defaultBoardService->checkFirstRun($this->userId, $this->appName)) {
-			$this->defaultBoardService->createDefaultBoard($this->l10n->t('Personal'), $this->userId, '000000');
+			if ($this->permissionService->canCreate()) {
+				$this->defaultBoardService->createDefaultBoard($this->l10n->t('Personal'), $this->userId, '000000');
+			}
 		}
 
 		return new TemplateResponse('deck', 'main', $params);

--- a/tests/unit/controller/PageControllerTest.php
+++ b/tests/unit/controller/PageControllerTest.php
@@ -65,7 +65,34 @@ class PageControllerTest extends \Test\TestCase {
 			->method('checkFirstRun')
 			->willReturn(true);
 
+		$this->permissionService->expects($this->any())
+			->method('canCreate')
+			->willReturn(true);
+
 		$this->defaultBoardService->expects($this->once())
+			->method('createDefaultBoard')
+			->willReturn($board);
+
+		$response = $this->controller->index();
+		$this->assertEquals('main', $response->getTemplateName());
+	}
+
+	public function testIndexOnFirstRunNoCreate() {
+
+		$board = new Board();
+		$board->setTitle('Personal');
+		$board->setOwner($this->userId);
+		$board->setColor('000000');
+
+		$this->defaultBoardService->expects($this->once())
+			->method('checkFirstRun')
+			->willReturn(true);
+
+		$this->permissionService->expects($this->any())
+			->method('canCreate')
+			->willReturn(false);
+
+		$this->defaultBoardService->expects($this->never())
 			->method('createDefaultBoard')
 			->willReturn($board);
 


### PR DESCRIPTION
This fixes the group selector on Nextcloud 13 and disables creating a default board if there is no permission to create one.