### PR TITLE
Check group limit in the proper way

### DIFF
--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -248,12 +248,15 @@ class PermissionService {
 
 	public function canCreate() {
 		$groups = $this->getGroupLimitList();
+		if (count($groups) === 0) {
+			return true;
+		}
 		foreach ($groups as $group) {
 			if ($this->groupManager->isInGroup($this->userId, $group)) {
-				return false;
+				return true;
 			}
 		}
-		return true;
+		return false;
 	}
 
 	private function getGroupLimitList() {


### PR DESCRIPTION
We allow users in the group limit to create boards, not forbid it to them.