### PR TITLE
Use proper timezone and locale format for due date activities

### DIFF
--- a/js/controller/ActivityController.js
+++ b/js/controller/ActivityController.js
@@ -20,7 +20,7 @@
  *
  */
 
-/* global OC OCA OCP t escapeHTML Handlebars */
+/* global OC OCA OCP t escapeHTML Handlebars moment */
 
 import CommentCollection from '../legacy/commentcollection';
 import CommentModel from '../legacy/commentmodel';
@@ -279,7 +279,13 @@ class ActivityController {
 		return this.activityservice.getData(this.type, id);
 	}
 
-	parseMessage(subject, parameters) {
+	parseMessage(activity) {
+		let subject = activity.subject_rich[0];
+		let parameters = activity.subject_rich[1];
+		if (parameters.after && parameters.after.id && parameters.after.id.startsWith('dt:')) {
+			let dateTime = parameters.after.id.substr(3);
+			parameters.after.name = moment(dateTime).format('L LTS');
+		}
 		return OCA.Activity.RichObjectStringParser.parseMessage(subject, parameters);
 	}
 

--- a/templates/part.card.activity.html
+++ b/templates/part.card.activity.html
@@ -20,7 +20,7 @@
 		</div>
 		<span class="activitytime has-tooltip live-relative-timestamp"
 			  data-timestamp="{{ activity.timestamp }}">{{ activity.timestamp/1000 | relativeDateFilter }}</span>
-		<div class="activitysubject" ng-if="!activity.commentModel" bind-html-compile="$ctrl.parseMessage(activity.subject_rich[0], activity.subject_rich[1])"></div>
+		<div class="activitysubject" ng-if="!activity.commentModel" bind-html-compile="$ctrl.parseMessage(activity)"></div>
 		<div class="activitysubject commentAuthor" ng-if="activity.commentModel">
 			{{ activity.subject_rich[1].user.name }}
 			<div class="app-popover-menu-utils">

--- a/tests/unit/Activity/DeckProviderTest.php
+++ b/tests/unit/Activity/DeckProviderTest.php
@@ -28,10 +28,12 @@ use OCA\Deck\Db\Acl;
 use OCP\Activity\IEvent;
 use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\L10N\IFactory;
 use OCP\RichObjectStrings\IValidator;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
@@ -62,7 +64,9 @@ class DeckProviderTest extends TestCase {
 		$this->activityManager = $this->createMock(ActivityManager::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->commentsManager = $this->createMock(ICommentsManager::class);
-		$this->provider = new DeckProvider($this->urlGenerator, $this->activityManager, $this->userManager, $this->commentsManager, $this->userId);
+		$this->l10nFactory = $this->createMock(IFactory::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->provider = new DeckProvider($this->urlGenerator, $this->activityManager, $this->userManager, $this->commentsManager, $this->l10nFactory, $this->config, $this->userId);
 	}
 
 	private function mockEvent($objectType, $objectId, $objectName, $subject, $subjectParameters = []) {


### PR DESCRIPTION
Use users locale format and server timezone to set the due date in activities. Inside of the activity stream, we'll use the browsers local time as reference.