### PR TITLE
Revert "Do not use getDisplayName for groups"

### DIFF
--- a/lib/Db/Group.php
+++ b/lib/Db/Group.php
@@ -35,7 +35,7 @@ class Group extends RelationalObject {
 	public function getObjectSerialization() {
 		return [
 			'uid' => $this->object->getGID(),
-			'displayname' => $this->object->getGID()
+			'displayname' => $this->object->getDisplayName()
 		];
 	}
 }

--- a/tests/unit/Db/GroupTest.php
+++ b/tests/unit/Db/GroupTest.php
@@ -33,10 +33,13 @@ class GroupTest extends \Test\TestCase {
 		$group->expects($this->any())
 			->method('getGID')
 			->willReturn('mygroup');
+		$group->expects($this->any())
+			->method('getDisplayName')
+			->willReturn('My Group');
 		$groupRelationalObject = new Group($group);
 		$expected = [
 			'uid' => 'mygroup',
-			'displayname' => 'mygroup'
+			'displayname' => 'My Group'
 		];
 		$this->assertEquals($expected, $groupRelationalObject->getObjectSerialization());
 	}
@@ -47,12 +50,19 @@ class GroupTest extends \Test\TestCase {
 		$group->expects($this->any())
 			->method('getGID')
 			->willReturn('mygroup');
+		$group->expects($this->any())
+			->method('getDisplayName')
+			->willReturn('My Group');
 		$groupRelationalObject = new Group($group);
 		$expected = [
 			'uid' => 'mygroup',
-			'displayname' => 'mygroup',
+			'displayname' => 'My Group',
 			'primaryKey' => 'mygroup'
 		];
-		$this->assertEquals($expected, $groupRelationalObject->jsonSerialize());
+
+		$actual = $groupRelationalObject->jsonSerialize();
+		asort($expected);
+		asort($actual);
+		$this->assertEquals($expected, $actual);
 	}
 }


### PR DESCRIPTION
* Target version: master 

### Summary

Nextcloud 11 is long dead and unsupported, and instead LDAP group display name support is on the brink: https://github.com/nextcloud/server/pull/15704

### Checklist

- [X] Code is properly formatted
- [X] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [X] Documentation (manuals or wiki) has been updated or is not required
