### PR TITLE
Fix ACL and archived REST endpoints

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -36,7 +36,7 @@
         <database min-version="9.4">pgsql</database>
         <database>sqlite</database>
         <database min-version="5.5">mysql</database>
-        <nextcloud min-version="15" max-version="16" />
+        <nextcloud min-version="15" max-version="17" />
     </dependencies>
     <background-jobs>
         <job>OCA\Deck\Cron\DeleteCron</job>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -88,8 +88,8 @@ return [
 		['name' => 'board_api#update', 'url' => '/api/v1.0/boards/{boardId}', 'verb' => 'PUT'],
 		['name' => 'board_api#undo_delete', 'url' => '/api/v1.0/boards/{boardId}/undo_delete', 'verb' => 'POST'],
 		['name' => 'board_api#addAcl', 'url' => '/api/v1.0/boards/{boardId}/acl', 'verb' => 'POST'],
-		['name' => 'board_api#deleteAcl', 'url' => '/api/v1.0/boards/{boardId}/acl', 'verb' => 'DELETE'],
-		['name' => 'board_api#updateAcl', 'url' => '/api/v1.0/boards/{boardId}/acl', 'verb' => 'PUT'],
+		['name' => 'board_api#deleteAcl', 'url' => '/api/v1.0/boards/{boardId}/acl/{aclId}', 'verb' => 'DELETE'],
+		['name' => 'board_api#updateAcl', 'url' => '/api/v1.0/boards/{boardId}/acl/{aclId}', 'verb' => 'PUT'],
 
 
 		['name' => 'stack_api#index', 'url' => '/api/v1.0/boards/{boardId}/stacks', 'verb' => 'GET'],

--- a/js/service/BoardService.js
+++ b/js/service/BoardService.js
@@ -172,7 +172,8 @@ app.factory('BoardService', function (ApiService, $http, $q) {
 		var deferred = $q.defer();
 		var self = this;
 		$http.delete(this.baseUrl + '/' + acl.boardId + '/acl/' + acl.id).then(function (response) {
-			delete board.acl[response.data.id];
+			var index = board.acl.findIndex((item) => item.id === response.data.id);
+			delete board.acl[index];
 			if (response.data.type === OC.Share.SHARE_TYPE_USER) {
 				self._updateUsers();
 			} else {
@@ -192,7 +193,8 @@ app.factory('BoardService', function (ApiService, $http, $q) {
 		var self = this;
 		var _acl = acl;
 		$http.put(this.baseUrl + '/' + acl.boardId + '/acl', _acl).then(function (response) {
-			board.acl[_acl.id] = response.data;
+			var index = board.acl.findIndex((item) => item.id === _acl.id);
+			board.acl[index] = response.data;
 			if (response.data.type === OC.Share.SHARE_TYPE_USER) {
 				self._updateUsers();
 			} else {

--- a/lib/Controller/CardApiController.php
+++ b/lib/Controller/CardApiController.php
@@ -86,8 +86,8 @@ class CardApiController extends ApiController {
 	 *
 	 * Update a card
 	 */
-	public function update($title, $type, $order = 0, $description = '', $owner, $duedate = null) {
-		$card = $this->cardService->update($this->request->getParam('cardId'), $title, $this->request->getParam('stackId'), $type, $order, $description, $owner, $duedate, 0);
+	public function update($title, $type, $order = 0, $description = '', $owner, $duedate = null, $archived = null) {
+		$card = $this->cardService->update($this->request->getParam('cardId'), $title, $this->request->getParam('stackId'), $type, $order, $description, $owner, $duedate, 0, $archived);
 		return new DataResponse($card, HTTP::STATUS_OK);
 	}
 

--- a/lib/Db/Board.php
+++ b/lib/Db/Board.php
@@ -76,7 +76,7 @@ class Board extends RelationalEntity {
 	 */
 	public function setAcl($acl) {
 		foreach ($acl as $a) {
-			$this->acl[$a->id] = $a;
+			$this->acl[] = $a;
 		}
 	}
 }

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -249,7 +249,7 @@ class CardService {
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 * @throws BadRequestException
 	 */
-	public function update($id, $title, $stackId, $type, $order = 0, $description = '', $owner, $duedate = null, $deletedAt) {
+	public function update($id, $title, $stackId, $type, $order = 0, $description = '', $owner, $duedate = null, $deletedAt = null, $archived = null) {
 
 		if (is_numeric($id) === false) {
 			throw new BadRequestException('card id must be a number');
@@ -276,7 +276,7 @@ class CardService {
 			throw new StatusException('Operation not allowed. This board is archived.');
 		}
 		$card = $this->cardMapper->find($id);
-		if ($card->getArchived()) {
+		if ($archived !== null && $card->getArchived() && $archived === true) {
 			throw new StatusException('Operation not allowed. This card is archived.');
 		}
 		$changes = new ChangeSet($card);
@@ -301,7 +301,13 @@ class CardService {
 		$card->setOrder($order);
 		$card->setOwner($owner);
 		$card->setDuedate($duedate);
-		$card->setDeletedAt($deletedAt);
+		if ($deletedAt) {
+			$card->setDeletedAt($deletedAt);
+		}
+		if ($archived !== null) {
+			$card->setArchived($archived);
+		}
+
 
 		// Trigger update events before setting description as it is handled separately
 		$changes->setAfter($card);

--- a/tests/unit/Db/BoardMapperTest.php
+++ b/tests/unit/Db/BoardMapperTest.php
@@ -158,10 +158,7 @@ class BoardMapperTest extends MapperTestUtility  {
 
     public function testFindWithAcl() {
         $actual = $this->boardMapper->find($this->boards[0]->getId(), false, true);
-        $expected = [
-            $this->acls[1]->getId() => $this->acls[1],
-            $this->acls[2]->getId() => $this->acls[2]
-        ];
+        $expected = [$this->acls[1], $this->acls[2]];
         $this->assertEquals($expected, $actual->getAcl());
     }
 

--- a/tests/unit/Db/BoardTest.php
+++ b/tests/unit/Db/BoardTest.php
@@ -57,7 +57,7 @@ class BoardTest extends TestCase {
 		$acl->setId(1);
 		$board = $this->createBoard();
 		$board->setAcl(array($acl));
-		$result = $board->getAcl()[1];
+		$result = $board->getAcl()[0];
 		$this->assertEquals($acl, $result);
 	}
 	public function testSetShared() {

--- a/tests/unit/Service/CardServiceTest.php
+++ b/tests/unit/Service/CardServiceTest.php
@@ -197,7 +197,7 @@ class CardServiceTest extends TestCase {
         $this->cardMapper->expects($this->once())->method('find')->willReturn($card);
         $this->cardMapper->expects($this->never())->method('update');
 		$this->expectException(StatusException::class);
-        $this->cardService->update(123, 'newtitle', 234, 'text', 999, 'foo', 'admin', '2017-01-01 00:00:00', null);
+        $this->cardService->update(123, 'newtitle', 234, 'text', 999, 'foo', 'admin', '2017-01-01 00:00:00', null, true);
     }
 
     public function testRename() {


### PR DESCRIPTION
Fixes:
- REST API Update Board ACL Method Not Found https://github.com/nextcloud/deck/issues/1106
- Setting archived state is not possible though the API https://github.com/nextcloud/deck/issues/1095