### PR TITLE
Add date format to If-Modified-Since documentation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -52,7 +52,7 @@ Example curl request:
 curl -u admin:admin -X GET \
     'http://localhost:8000/index.php/apps/deck/api/v1.0/boards/2/stacks' \
     -H "OCS-APIRequest: true" \
-    -H "If-Modified-Since: Mon, 5 Nov 2018 09:28:00 GMT"
+    -H "If-Modified-Since: Mon, 05 Nov 2018 09:28:00 GMT"
 ```
 
 # Endpoints

--- a/docs/API.md
+++ b/docs/API.md
@@ -45,6 +45,11 @@ In any case a user doesn't have access to a requested entity, a 403 error will b
 ### If-Modified-Since
 
 Some index endpoints support limiting the result set to entries that have been changed since the given time.
+The supported date formats are:
+
+* IMF-fixdate:      `Sun, 03 Aug 2019 10:34:12 GMT`
+* RFC 850:          `Sunday, 03-Aug-19 10:34:12 GMT`
+* ANSI C asctime(): `Sun Aug  3 10:34:12 2019`
 
 Example curl request:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -47,9 +47,11 @@ In any case a user doesn't have access to a requested entity, a 403 error will b
 Some index endpoints support limiting the result set to entries that have been changed since the given time.
 The supported date formats are:
 
-* IMF-fixdate:      `Sun, 03 Aug 2019 10:34:12 GMT`
-* RFC 850:          `Sunday, 03-Aug-19 10:34:12 GMT`
-* ANSI C asctime(): `Sun Aug  3 10:34:12 2019`
+* IMF-fixdate:                 `Sun, 03 Aug 2019 10:34:12 GMT`
+* (obsolete) RFC 850:          `Sunday, 03-Aug-19 10:34:12 GMT`
+* (obsolete) ANSI C asctime(): `Sun Aug  3 10:34:12 2019`
+
+It is highly recommended to only use the IMF-fixdate format.
 
 Example curl request:
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Fixes an error in the curl example in API.md, and adds a small list with supported date formats for the If-Modified-Since headers.

See https://github.com/sabre-io/http/blob/4.2/lib/functions.php#L16 for the definition of the invoked function.

### Checklist

- [X] Code is properly formatted
- [X] Sign-off message is added to all commits
- [X] Tests (unit, integration, api and/or acceptance) are included
- [X] Documentation (manuals or wiki) has been updated or is not required
