### PR TITLE
Improvements to Card Heading Editing

### DIFF
--- a/src/components/cards/CardItem.vue
+++ b/src/components/cards/CardItem.vue
@@ -30,23 +30,21 @@
 		<div class="card-upper">
 			<h3 v-if="showArchived">{{ card.title }}</h3>
 			<h3 v-else-if="!editing" @click.stop="startEditing(card)">{{ card.title }}</h3>
-			<h3 v-else>editing</h3>
-			<transition name="fade" mode="out-in">
-				<form v-click-outside="cancelEdit" v-if="editing" @keyup.esc="cancelEdit"
-					@submit.prevent="finishedEdit(card)">
-					<input v-model="copiedCard.title" type="text" autofocus>
-					<input type="button" class="icon-confirm" @click="finishedEdit(card)">
-				</form>
+			<h3 v-else>&nbsp;</h3>
+			<form v-click-outside="cancelEdit" v-if="editing" @keyup.esc="cancelEdit"
+				@submit.prevent="finishedEdit(card)">
+				<input v-model="copiedCard.title" type="text" autofocus>
+				<input type="button" class="icon-confirm" @click="finishedEdit(card)">
+			</form>
 
-				<Actions @click.stop.prevent>
-					<ActionButton v-if="showArchived === false" icon="icon-user" @click="assignCardToMe()">{{ t('deck', 'Assign to me') }}</ActionButton>
-					<ActionButton icon="icon-archive" @click="archiveUnarchiveCard()">{{ t('deck', (showArchived ? 'Unarchive card' : 'Archive card')) }}</ActionButton>
-					<ActionButton v-if="showArchived === false" icon="icon-delete" @click="deleteCard()">{{ t('deck', 'Delete card') }}</ActionButton>
-					<ActionButton icon="icon-external" @click.stop="modalShow=true">{{ t('deck', 'Move card') }}</ActionButton>
-					<ActionButton icon="icon-settings-dark" @click="openCard">{{ t('deck', 'Card details') }}</ActionButton>
-				</Actions>
+			<Actions v-if="!editing" @click.stop.prevent>
+				<ActionButton v-if="showArchived === false" icon="icon-user" @click="assignCardToMe()">{{ t('deck', 'Assign to me') }}</ActionButton>
+				<ActionButton icon="icon-archive" @click="archiveUnarchiveCard()">{{ t('deck', (showArchived ? 'Unarchive card' : 'Archive card')) }}</ActionButton>
+				<ActionButton v-if="showArchived === false" icon="icon-delete" @click="deleteCard()">{{ t('deck', 'Delete card') }}</ActionButton>
+				<ActionButton icon="icon-external" @click.stop="modalShow=true">{{ t('deck', 'Move card') }}</ActionButton>
+				<ActionButton icon="icon-settings-dark" @click="openCard">{{ t('deck', 'Card details') }}</ActionButton>
+			</Actions>
 
-			</transition>
 			<modal v-if="modalShow" title="Move card to another board" @close="modalShow=false">
 				<div class="modal__content">
 					<Multiselect :placeholder="t('deck', 'Select a board')" v-model="selectedBoard" :options="boards"
@@ -60,7 +58,6 @@
 
 				</div>
 			</modal>
-
 		</div>
 		<ul class="labels" @click="openCard">
 			<li v-for="label in card.labels" :key="label.id" :style="labelStyle(label)"><span>{{ label.title }}</span></li>
@@ -225,7 +222,7 @@ export default {
 				display: flex;
 				padding: 5px 7px;
 				position: absolute;
-				width: calc(100% - 14px);
+				width: 100%;
 				input[type=text] {
 					flex-grow: 1;
 				}
@@ -236,6 +233,8 @@ export default {
 				flex-grow: 1;
 				font-size: 100%;
 				cursor: text;
+				overflow-x: hidden;
+				word-wrap: break-word;
 			}
 		}
 

--- a/src/components/cards/CardItem.vue
+++ b/src/components/cards/CardItem.vue
@@ -1,7 +1,11 @@
 <!--
   - @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
   -
+  - @copyright Copyright (c) 2019 Gary Kim <gary@garykim.dev>
+  -
   - @author Julius Härtl <jus@bitgrid.net>
+  -
+  - @author Gary Kim <gary@garykim.dev>
   -
   - @license GNU AGPL version 3 or any later version
   -
@@ -27,7 +31,7 @@
 			<h3 v-if="showArchived">{{ card.title }}</h3>
 			<h3 v-else @click.stop="startEditing(card)">{{ card.title }}</h3>
 			<transition name="fade" mode="out-in">
-				<form v-if="editing">
+				<form v-if="editing" v-click-outside="cancelEdit">
 					<input v-model="copiedCard.title" type="text" autofocus>
 					<input type="button" class="icon-confirm" @click="finishedEdit(card)">
 				</form>
@@ -155,6 +159,9 @@ export default {
 			if (this.copiedCard.title !== card.title) {
 				this.$store.dispatch('updateCard', this.copiedCard)
 			}
+			this.editing = false
+		},
+		cancelEdit() {
 			this.editing = false
 		},
 		deleteCard() {

--- a/src/components/cards/CardItem.vue
+++ b/src/components/cards/CardItem.vue
@@ -31,7 +31,7 @@
 			<h3 v-if="showArchived">{{ card.title }}</h3>
 			<h3 v-else @click.stop="startEditing(card)">{{ card.title }}</h3>
 			<transition name="fade" mode="out-in">
-				<form v-if="editing" v-click-outside="cancelEdit">
+				<form v-if="editing" v-click-outside="cancelEdit" @submit.prevent="finishedEdit(card)">
 					<input v-model="copiedCard.title" type="text" autofocus>
 					<input type="button" class="icon-confirm" @click="finishedEdit(card)">
 				</form>

--- a/src/components/cards/CardItem.vue
+++ b/src/components/cards/CardItem.vue
@@ -29,9 +29,11 @@
 		@click.self="openCard">
 		<div class="card-upper">
 			<h3 v-if="showArchived">{{ card.title }}</h3>
-			<h3 v-else @click.stop="startEditing(card)">{{ card.title }}</h3>
+			<h3 v-else-if="!editing" @click.stop="startEditing(card)">{{ card.title }}</h3>
+			<h3 v-else>editing</h3>
 			<transition name="fade" mode="out-in">
-				<form v-if="editing" v-click-outside="cancelEdit" @keyup.esc="cancelEdit" @submit.prevent="finishedEdit(card)">
+				<form v-click-outside="cancelEdit" v-if="editing" @keyup.esc="cancelEdit"
+					@submit.prevent="finishedEdit(card)">
 					<input v-model="copiedCard.title" type="text" autofocus>
 					<input type="button" class="icon-confirm" @click="finishedEdit(card)">
 				</form>

--- a/src/components/cards/CardItem.vue
+++ b/src/components/cards/CardItem.vue
@@ -31,7 +31,7 @@
 			<h3 v-if="showArchived">{{ card.title }}</h3>
 			<h3 v-else @click.stop="startEditing(card)">{{ card.title }}</h3>
 			<transition name="fade" mode="out-in">
-				<form v-if="editing" v-click-outside="cancelEdit" @submit.prevent="finishedEdit(card)">
+				<form v-if="editing" v-click-outside="cancelEdit" @keyup.esc="cancelEdit" @submit.prevent="finishedEdit(card)">
 					<input v-model="copiedCard.title" type="text" autofocus>
 					<input type="button" class="icon-confirm" @click="finishedEdit(card)">
 				</form>


### PR DESCRIPTION
* Target version: vue

### Summary
Changes
* Cancel card heading edit on user clicking outside input
  * Also cancel on user pressing `esc`
* Submit card heading edit on user pressing `enter` or otherwise submitting the form
* Prevent wrapped heading being visible underneath input while editing long card heading.
  * Before: ![Screenshot from 2019-09-17 19-26-38](https://user-images.githubusercontent.com/47195730/65038189-fec76600-d981-11e9-8945-5543c3f8da74.png)
  * After: ![Screenshot from 2019-09-17 19-25-11](https://user-images.githubusercontent.com/47195730/65038201-0424b080-d982-11e9-876c-e52bd0dc7375.png)
* Prevent long headings from pushing interface elements off the card
  * Before: ![Screenshot from 2019-09-18 00-05-00](https://user-images.githubusercontent.com/47195730/65059166-14e81d00-d9a8-11e9-88d4-149ef7795f7c.png)

  * After: ![Screenshot from 2019-09-18 00-02-08](https://user-images.githubusercontent.com/47195730/65059144-0e59a580-d9a8-11e9-8bb7-dbaaa93c330b.png)


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
