### PR TITLE
Fix reversed visibility of 'add stack' field (#1300)

### DIFF
--- a/templates/part.board.headerControls.php
+++ b/templates/part.board.headerControls.php
@@ -1,4 +1,4 @@
-<div id="stack-add" ng-if="boardservice.canEdit() && checkCanEdit()">
+<div id="stack-add" ng-if="boardservice.canManage() && checkCanEdit()">
     <form class="ng-pristine ng-valid" ng-submit="createStack()">
         <label for="new-stack-input-<?php p($_['headerControlsId']); ?>" class="hidden-visually"><?php p($l->t('Add a new stack')); ?></label>
         <input type="text" class="no-close" placeholder="<?php p($l->t('Add a new stack')); ?>"


### PR DESCRIPTION
Signed-off-by: Jaco Lüken <j.lueken@mhq-services.com>


* Resolves: #1300 
* Target version: master 

### Summary
Fixes the reversed visibility of the "add stack" field.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
