### PR TITLE
Fix reversed permissions for reordering stacks (#1301)

### DIFF
--- a/lib/Service/StackService.php
+++ b/lib/Service/StackService.php
@@ -345,7 +345,7 @@ class StackService {
 			throw new BadRequestException('order must be provided');
 		}
 
-		$this->permissionService->checkPermission($this->stackMapper, $id, Acl::PERMISSION_EDIT);
+		$this->permissionService->checkPermission($this->stackMapper, $id, Acl::PERMISSION_MANAGE);
 		$stackToSort = $this->stackMapper->find($id);
 		$stacks = $this->stackMapper->findAll($stackToSort->getBoardId());
 		$result = [];


### PR DESCRIPTION
Signed-off-by: Jaco Lüken <j.lueken@mhq-services.com>


* Resolves: #1301 
* Target version: master 

### Summary
Fixes the reversed permissions for reordering stacks.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
