### PR TITLE
Expose boards as calendars

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -64,7 +64,11 @@
             <provider>OCA\Deck\Activity\DeckProvider</provider>
         </providers>
     </activity>
-
+    <sabre>
+        <calendar-plugins>
+            <plugin>OCA\Deck\DAV\CalendarPlugin</plugin>
+        </calendar-plugins>
+    </sabre>
     <fulltextsearch>
         <provider min-version="16">OCA\Deck\Provider\DeckProvider</provider>
     </fulltextsearch>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -64,15 +64,9 @@
             <provider>OCA\Deck\Activity\DeckProvider</provider>
         </providers>
     </activity>
-    <sabre>
-        <calendar-plugins>
-            <plugin>OCA\Deck\DAV\CalendarPlugin</plugin>
-        </calendar-plugins>
-    </sabre>
     <fulltextsearch>
         <provider min-version="16">OCA\Deck\Provider\DeckProvider</provider>
     </fulltextsearch>
-
     <navigations>
         <navigation>
             <name>Deck</name>
@@ -81,5 +75,9 @@
             <order>10</order>
         </navigation>
     </navigations>
-
+    <sabre>
+        <calendar-plugins>
+            <plugin>OCA\Deck\DAV\CalendarPlugin</plugin>
+        </calendar-plugins>
+    </sabre>
 </info>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -26,9 +26,6 @@ return [
 	'routes' => [
 		['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
 
-		['name' => 'Config#get', 'url' => '/config', 'verb' => 'GET'],
-		['name' => 'Config#setValue', 'url' => '/config/{key}', 'verb' => 'POST'],
-
 		// boards
 		['name' => 'board#index', 'url' => '/boards', 'verb' => 'GET'],
 		['name' => 'board#create', 'url' => '/boards', 'verb' => 'POST'],
@@ -125,17 +122,17 @@ return [
 		['name' => 'attachment_api#delete', 'url' => '/api/v1.0/boards/{boardId}/stacks/{stackId}/cards/{cardId}/attachments/{attachmentId}', 'verb' => 'DELETE'],
 		['name' => 'attachment_api#restore', 'url' => '/api/v1.0/boards/{boardId}/stacks/{stackId}/cards/{cardId}/attachments/{attachmentId}/restore', 'verb' => 'PUT'],
 
-
-
 		['name' => 'board_api#preflighted_cors', 'url' => '/api/v1.0/{path}','verb' => 'OPTIONS', 'requirements' => ['path' => '.+']],
 	],
 	'ocs' => [
+		['name' => 'Config#get', 'url' => '/api/v1.0/config', 'verb' => 'GET'],
+		['name' => 'Config#setValue', 'url' => '/api/v1.0/config/{key}', 'verb' => 'POST'],
+
 		['name' => 'comments_api#list', 'url' => '/api/v1.0/cards/{cardId}/comments', 'verb' => 'GET'],
 		['name' => 'comments_api#create', 'url' => '/api/v1.0/cards/{cardId}/comments', 'verb' => 'POST'],
 		['name' => 'comments_api#update', 'url' => '/api/v1.0/cards/{cardId}/comments/{commentId}', 'verb' => 'PUT'],
 		['name' => 'comments_api#delete', 'url' => '/api/v1.0/cards/{cardId}/comments/{commentId}', 'verb' => 'DELETE'],
 
-		// dashboard
 		['name' => 'overview_api#upcomingCards', 'url' => '/api/v1.0/overview/upcoming', 'verb' => 'GET'],
 	]
 ];

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -24,34 +24,33 @@
 namespace OCA\Deck\Controller;
 
 use OCA\Deck\AppInfo\Application;
+use OCA\Deck\Service\ConfigService;
 use OCA\Deck\Service\PermissionService;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\IInitialStateService;
 use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Controller;
-use OCP\IL10N;
 
 class PageController extends Controller {
 	private $permissionService;
 	private $userId;
 	private $l10n;
 	private $initialState;
+	private $configService;
 
 	public function __construct(
 		$AppName,
 		IRequest $request,
 		PermissionService $permissionService,
 		IInitialStateService $initialStateService,
-		IL10N $l10n,
-		$userId
+		ConfigService $configService
 		) {
 		parent::__construct($AppName, $request);
 
-		$this->userId = $userId;
 		$this->permissionService = $permissionService;
 		$this->initialState = $initialStateService;
-		$this->l10n = $l10n;
+		$this->configService = $configService;
 	}
 
 	/**
@@ -64,6 +63,7 @@ class PageController extends Controller {
 	public function index() {
 		$this->initialState->provideInitialState(Application::APP_ID, 'maxUploadSize', (int)\OCP\Util::uploadLimit());
 		$this->initialState->provideInitialState(Application::APP_ID, 'canCreate', $this->permissionService->canCreate());
+		$this->initialState->provideInitialState(Application::APP_ID, 'config', $this->configService->getAll());
 
 		$response = new TemplateResponse('deck', 'main');
 

--- a/lib/DAV/Calendar.php
+++ b/lib/DAV/Calendar.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * @copyright 2020, Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Deck\DAV;
+
+use OCA\DAV\CalDAV\Integration\ExternalCalendar;
+use OCA\DAV\CalDAV\Plugin;
+use OCA\DAV\DAV\Sharing\IShareable;
+use OCA\Deck\Db\Board;
+use OCA\Deck\Db\Card;
+use OCA\Deck\Service\CardService;
+use Sabre\CalDAV\Xml\Property\SupportedCalendarComponentSet;
+use Sabre\DAV\PropPatch;
+
+class Calendar extends ExternalCalendar implements IShareable {
+
+	/** @var string */
+	private $principalUri;
+
+	/** @var string */
+	private $calendarUri;
+
+	/** @var string[] */
+	private $children;
+	/**
+	 * @var \stdClass
+	 */
+	private $cardService;
+
+	/**
+	 * Calendar constructor.
+	 *
+	 * @param string $principalUri
+	 * @param string $calendarUri
+	 */
+	public function __construct(string $principalUri, string $calendarUri, Board $board = null) {
+		parent::__construct('deck', $calendarUri);
+
+		$this->board = $board;
+
+		$this->principalUri = $principalUri;
+		$this->calendarUri = $calendarUri;
+
+
+		if ($board) {
+			/** @var CardService cardService */
+			$cardService = \OC::$server->query(CardService::class);
+			$this->children = $cardService->findCalendarEntries($board->getId());
+		} else {
+			$this->children = [];
+		}
+	}
+
+
+	/**
+	 * @inheritDoc
+	 */
+	function getOwner() {
+		return $this->principalUri;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getACL() {
+		return [
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => $this->getOwner(),
+				'protected' => true,
+			],
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => $this->getOwner() . '/calendar-proxy-write',
+				'protected' => true,
+			],
+			[
+				'privilege' => '{DAV:}read',
+				'principal' => $this->getOwner() . '/calendar-proxy-read',
+				'protected' => true,
+			],
+		];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function setACL(array $acl) {
+		throw new \Sabre\DAV\Exception\Forbidden('Setting ACL is not supported on this node');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getSupportedPrivilegeSet() {
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function calendarQuery(array $filters) {
+		// In a real implementation this should actually filter
+		return array_map(function (Card $card) {
+			return $card->getId() . '.ics';
+		}, $this->children);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function createFile($name, $data = null) {
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getChild($name) {
+		if ($this->childExists($name)) {
+			$card = array_values(array_filter(
+				$this->children,
+				function ($card) use (&$name) {
+					return $card->getId() . '.ics' === $name;
+				}
+			));
+			if (count($card) > 0) {
+				return new CalendarObject($this, $name, $card[0]);
+			}
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getChildren() {
+		$childNames = array_map(function (Card $card) {
+			return $card->getId() . '.ics';
+		}, $this->children);
+
+		$children = [];
+
+		foreach ($childNames as $name) {
+			$children[] = $this->getChild($name);
+		}
+
+		return $children;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function childExists($name) {
+		return count(array_filter(
+			$this->children,
+			function ($card) use (&$name) {
+				return $card->getId() . '.ics' === $name;
+			}
+		)) > 0;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function delete() {
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getLastModified() {
+		return $this->board->getLastModified();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getGroup() {
+		return [];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function propPatch(PropPatch $propPatch) {
+		// We can just return here and let oc_properties handle everything
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getProperties($properties) {
+		// A backend should provide at least minimum properties
+		return [
+			'{DAV:}displayname' => 'Deck: ' . ($this->board ? $this->board->getTitle() : 'no board object provided'),
+			'{http://apple.com/ns/ical/}calendar-color'  => '#' . $this->board->getColor(),
+			'{' . Plugin::NS_CALDAV . '}supported-calendar-component-set' => new SupportedCalendarComponentSet(['VTODO', 'VEVENT']),
+		];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function updateShares(array $add, array $remove) {
+		// TODO: Implement updateShares() method.
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getShares() {
+		return [];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getResourceId() {
+		// TODO: Implement getResourceId() method.
+	}
+}

--- a/lib/DAV/Calendar.php
+++ b/lib/DAV/Calendar.php
@@ -24,72 +24,44 @@ namespace OCA\Deck\DAV;
 
 use OCA\DAV\CalDAV\Integration\ExternalCalendar;
 use OCA\DAV\CalDAV\Plugin;
-use OCA\DAV\DAV\Sharing\IShareable;
+use OCA\Deck\Db\Acl;
 use OCA\Deck\Db\Board;
-use OCA\Deck\Db\Card;
-use OCA\Deck\Db\Stack;
-use OCA\Deck\Service\CardService;
-use OCA\Deck\Service\StackService;
 use Sabre\CalDAV\Xml\Property\SupportedCalendarComponentSet;
+use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\PropPatch;
 
-class Calendar extends ExternalCalendar implements IShareable {
+class Calendar extends ExternalCalendar {
 
 	/** @var string */
 	private $principalUri;
-
-	/** @var string */
-	private $calendarUri;
-
 	/** @var string[] */
 	private $children;
-	/**
-	 * @var \stdClass
-	 */
-	private $cardService;
+	/** @var DeckCalendarBackend */
+	private $backend;
+	/**  @var Board */
+	private $board;
 
-	/**
-	 * Calendar constructor.
-	 *
-	 * @param string $principalUri
-	 * @param string $calendarUri
-	 */
-	public function __construct(string $principalUri, string $calendarUri, Board $board = null) {
+	public function __construct(string $principalUri, string $calendarUri, Board $board, DeckCalendarBackend $backend) {
 		parent::__construct('deck', $calendarUri);
 
+		$this->backend = $backend;
 		$this->board = $board;
 
 		$this->principalUri = $principalUri;
-		$this->calendarUri = $calendarUri;
-
 
 		if ($board) {
-			/** @var CardService $cardService */
-			$cardService = \OC::$server->query(CardService::class);
-			/** @var StackService $stackService */
-			$stackService = \OC::$server->query(StackService::class);
-			$this->children = array_merge(
-				$cardService->findCalendarEntries($board->getId()),
-				$stackService->findCalendarEntries($board->getId())
-			);
+			$this->children = $this->backend->getChildren($board->getId());
 		} else {
 			$this->children = [];
 		}
 	}
 
-
-	/**
-	 * @inheritDoc
-	 */
-	function getOwner() {
+	public function getOwner() {
 		return $this->principalUri;
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	function getACL() {
-		return [
+	public function getACL() {
+		$acl = [
 			[
 				'privilege' => '{DAV:}read',
 				'principal' => $this->getOwner(),
@@ -106,43 +78,41 @@ class Calendar extends ExternalCalendar implements IShareable {
 				'protected' => true,
 			],
 		];
+		if ($this->backend->checkBoardPermission($this->board->getId(), Acl::PERMISSION_EDIT)) {
+			$acl[] = [
+				'privilege' => '{DAV:}write',
+				'principal' => $this->getOwner(),
+				'protected' => true,
+			];
+			$acl[] = [
+				'privilege' => '{DAV:}write-properties',
+				'principal' => $this->getOwner(),
+				'protected' => true,
+			];
+		}
+		return $acl;
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	function setACL(array $acl) {
-		throw new \Sabre\DAV\Exception\Forbidden('Setting ACL is not supported on this node');
+	public function setACL(array $acl) {
+		throw new Forbidden('Setting ACL is not supported on this node');
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	function getSupportedPrivilegeSet() {
+	public function getSupportedPrivilegeSet() {
 		return null;
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	function calendarQuery(array $filters) {
-		// In a real implementation this should actually filter
+	public function calendarQuery(array $filters) {
+		// FIXME: In a real implementation this should actually filter
 		return array_map(function ($card) {
 			return $card->getCalendarPrefix() . '-' . $card->getId() . '.ics';
 		}, $this->children);
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	function createFile($name, $data = null) {
-		return null;
+	public function createFile($name, $data = null) {
+		throw new \Sabre\DAV\Exception\Forbidden('Creating a new entry is not implemented');
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	function getChild($name) {
+	public function getChild($name) {
 		if ($this->childExists($name)) {
 			$card = array_values(array_filter(
 				$this->children,
@@ -151,15 +121,12 @@ class Calendar extends ExternalCalendar implements IShareable {
 				}
 			));
 			if (count($card) > 0) {
-				return new CalendarObject($this, $name, $card[0]);
+				return new CalendarObject($this, $name, $card[0], $this->backend);
 			}
 		}
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	function getChildren() {
+	public function getChildren() {
 		$childNames = array_map(function ($card) {
 			return $card->getCalendarPrefix() . '-' . $card->getId() . '.ics';
 		}, $this->children);
@@ -173,10 +140,7 @@ class Calendar extends ExternalCalendar implements IShareable {
 		return $children;
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	function childExists($name) {
+	public function childExists($name) {
 		return count(array_filter(
 			$this->children,
 			function ($card) use (&$name) {
@@ -185,64 +149,51 @@ class Calendar extends ExternalCalendar implements IShareable {
 		)) > 0;
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	function delete() {
+
+	public function delete() {
 		return null;
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	function getLastModified() {
+	public function getLastModified() {
 		return $this->board->getLastModified();
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	function getGroup() {
+	public function getGroup() {
 		return [];
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	function propPatch(PropPatch $propPatch) {
+	public function propPatch(PropPatch $propPatch) {
+		$properties = [
+			'{DAV:}displayname',
+			'{http://apple.com/ns/ical/}calendar-color'
+		];
+		$propPatch->handle($properties, function ($properties) {
+			foreach ($properties as $key => $value) {
+				switch ($key) {
+					case '{DAV:}displayname':
+						if (mb_substr($value, 0, strlen('Deck: '))) {
+							$value = mb_substr($value, strlen('Deck: '));
+						}
+						$this->board->setTitle($value);
+						break;
+					case '{http://apple.com/ns/ical/}calendar-color':
+						$this->board->setColor(substr($value, 1));
+						break;
+				}
+			}
+			return $this->backend->updateBoard($this->board);
+		});
 		// We can just return here and let oc_properties handle everything
 	}
 
 	/**
 	 * @inheritDoc
 	 */
-	function getProperties($properties) {
-		// A backend should provide at least minimum properties
+	public function getProperties($properties) {
 		return [
 			'{DAV:}displayname' => 'Deck: ' . ($this->board ? $this->board->getTitle() : 'no board object provided'),
 			'{http://apple.com/ns/ical/}calendar-color'  => '#' . $this->board->getColor(),
-			'{' . Plugin::NS_CALDAV . '}supported-calendar-component-set' => new SupportedCalendarComponentSet(['VTODO', 'VEVENT']),
+			'{' . Plugin::NS_CALDAV . '}supported-calendar-component-set' => new SupportedCalendarComponentSet(['VTODO']),
 		];
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	function updateShares(array $add, array $remove) {
-		// TODO: Implement updateShares() method.
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	function getShares() {
-		return [];
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function getResourceId() {
-		// TODO: Implement getResourceId() method.
 	}
 }

--- a/lib/DAV/Calendar.php
+++ b/lib/DAV/Calendar.php
@@ -30,6 +30,7 @@ use Sabre\CalDAV\Xml\Property\SupportedCalendarComponentSet;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\PropPatch;
+use Sabre\VObject\InvalidDataException;
 
 class Calendar extends ExternalCalendar {
 
@@ -164,7 +165,11 @@ class Calendar extends ExternalCalendar {
 						$this->board->setTitle($value);
 						break;
 					case '{http://apple.com/ns/ical/}calendar-color':
-						$this->board->setColor(substr($value, 1));
+						$color = substr($value, 1, 6);
+						if (!preg_match('/[a-f0-9]{6}/i', $color)) {
+							throw new InvalidDataException('No valid color provided');
+						}
+						$this->board->setColor($color);
 						break;
 				}
 			}

--- a/lib/DAV/CalendarObject.php
+++ b/lib/DAV/CalendarObject.php
@@ -36,7 +36,7 @@ class CalendarObject implements \Sabre\CalDAV\ICalendarObject, \Sabre\DAVACL\IAC
 	/**
 	 * @var Card
 	 */
-	private $card;
+	private $sourceItem;
 
 	/**
 	 * CalendarObject constructor.
@@ -44,10 +44,10 @@ class CalendarObject implements \Sabre\CalDAV\ICalendarObject, \Sabre\DAVACL\IAC
 	 * @param Calendar $calendar
 	 * @param string $name
 	 */
-	public function __construct(Calendar $calendar, string $name, Card $card = null) {
+	public function __construct(Calendar $calendar, string $name, $sourceItem = null) {
 		$this->calendar = $calendar;
 		$this->name = $name;
-		$this->card = $card;
+		$this->sourceItem = $sourceItem;
 	}
 
 	/**
@@ -96,8 +96,8 @@ class CalendarObject implements \Sabre\CalDAV\ICalendarObject, \Sabre\DAVACL\IAC
 	 * @inheritDoc
 	 */
 	function get() {
-		if ($this->card) {
-			return $this->card->getCalendarObject()->serialize();
+		if ($this->sourceItem) {
+			return $this->sourceItem->getCalendarObject()->serialize();
 		}
 	}
 
@@ -147,6 +147,6 @@ class CalendarObject implements \Sabre\CalDAV\ICalendarObject, \Sabre\DAVACL\IAC
 	 * @inheritDoc
 	 */
 	function getLastModified() {
-		return $this->card->getLastModified();
+		return $this->sourceItem->getLastModified();
 	}
 }

--- a/lib/DAV/CalendarObject.php
+++ b/lib/DAV/CalendarObject.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * @copyright 2020, Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Deck\DAV;
+
+use OCA\Deck\Db\Card;
+use OCA\Deck\Service\CardService;
+use Sabre\VObject\Component\VCalendar;
+
+class CalendarObject implements \Sabre\CalDAV\ICalendarObject, \Sabre\DAVACL\IACL {
+
+	/** @var Calendar */
+	private $calendar;
+
+	/** @var string */
+	private $name;
+	/**
+	 * @var Card
+	 */
+	private $card;
+
+	/**
+	 * CalendarObject constructor.
+	 *
+	 * @param Calendar $calendar
+	 * @param string $name
+	 */
+	public function __construct(Calendar $calendar, string $name, Card $card = null) {
+		$this->calendar = $calendar;
+		$this->name = $name;
+		$this->card = $card;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getOwner() {
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getGroup() {
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getACL() {
+		return $this->calendar->getACL();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function setACL(array $acl) {
+		throw new \Sabre\DAV\Exception\Forbidden('Setting ACL is not supported on this node');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getSupportedPrivilegeSet() {
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function put($data) {
+		throw new \Sabre\DAV\Exception\Forbidden('This calendar-object is read-only');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function get() {
+		if ($this->card) {
+			return $this->card->getCalendarObject()->serialize();
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getContentType() {
+		return 'text/calendar; charset=utf-8';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getETag() {
+		return '"' . md5($this->get()) . '"';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getSize() {
+		return strlen($this->get());
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function delete() {
+		throw new \Sabre\DAV\Exception\Forbidden('This calendar-object is read-only');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getName() {
+		return $this->name;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function setName($name) {
+		throw new \Sabre\DAV\Exception\Forbidden('This calendar-object is read-only');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	function getLastModified() {
+		return $this->card->getLastModified();
+	}
+}

--- a/lib/DAV/CalendarObject.php
+++ b/lib/DAV/CalendarObject.php
@@ -42,7 +42,7 @@ class CalendarObject implements ICalendarObject, IACL {
 	/** @var VCalendar */
 	private $calendarObject;
 
-	public function __construct(Calendar $calendar, string $name, $sourceItem = null, DeckCalendarBackend $backend) {
+	public function __construct(Calendar $calendar, string $name, DeckCalendarBackend $backend, $sourceItem) {
 		$this->calendar = $calendar;
 		$this->name = $name;
 		$this->sourceItem = $sourceItem;

--- a/lib/DAV/CalendarPlugin.php
+++ b/lib/DAV/CalendarPlugin.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @copyright 2020, Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Deck\DAV;
+
+use OCA\DAV\CalDAV\Integration\ExternalCalendar;
+use OCA\DAV\CalDAV\Integration\ICalendarProvider;
+use OCA\Deck\Db\Board;
+use OCA\Deck\Service\BoardService;
+
+class CalendarPlugin implements ICalendarProvider {
+
+	/**
+	 * @var BoardService
+	 */
+	private $boardService;
+
+	public function __construct(BoardService $boardService) {
+		$this->boardService = $boardService;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getAppId(): string {
+		return 'deck';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function fetchAllForCalendarHome(string $principalUri): array {
+		$boards = $this->boardService->findAll();
+		return array_map(function (Board $board) use ($principalUri) {
+			return new Calendar($principalUri, 'board-' . $board->getId(), $board);
+		}, $boards);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function hasCalendarInCalendarHome(string $principalUri, string $calendarUri): bool {
+		$boards = array_map(function(Board $board) {
+			return 'board-' . $board->getId();
+		}, $this->boardService->findAll());
+		return in_array($calendarUri, $boards, true);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getCalendarInCalendarHome(string $principalUri, string $calendarUri): ?ExternalCalendar {
+		if ($this->hasCalendarInCalendarHome($principalUri, $calendarUri)) {
+			$board = $this->boardService->find(str_replace('board-', '', $calendarUri));
+			return new Calendar($principalUri, $calendarUri, $board);
+		}
+
+		return null;
+	}
+}

--- a/lib/DAV/CalendarPlugin.php
+++ b/lib/DAV/CalendarPlugin.php
@@ -26,6 +26,7 @@ namespace OCA\Deck\DAV;
 use OCA\DAV\CalDAV\Integration\ExternalCalendar;
 use OCA\DAV\CalDAV\Integration\ICalendarProvider;
 use OCA\Deck\Db\Board;
+use Sabre\DAV\Exception\NotFound;
 
 class CalendarPlugin implements ICalendarProvider {
 
@@ -55,10 +56,13 @@ class CalendarPlugin implements ICalendarProvider {
 
 	public function getCalendarInCalendarHome(string $principalUri, string $calendarUri): ?ExternalCalendar {
 		if ($this->hasCalendarInCalendarHome($principalUri, $calendarUri)) {
-			$board = $this->backend->getBoard((int)str_replace('board-', '', $calendarUri));
-			return new Calendar($principalUri, $calendarUri, $board, $this->backend);
+			try {
+				$board = $this->backend->getBoard((int)str_replace('board-', '', $calendarUri));
+				return new Calendar($principalUri, $calendarUri, $board, $this->backend);
+			} catch (NotFound $e) {
+				// We can just return null if we have no matching board
+			}
 		}
-
 		return null;
 	}
 }

--- a/lib/DAV/DeckCalendarBackend.php
+++ b/lib/DAV/DeckCalendarBackend.php
@@ -32,6 +32,7 @@ use OCA\Deck\Service\BoardService;
 use OCA\Deck\Service\CardService;
 use OCA\Deck\Service\PermissionService;
 use OCA\Deck\Service\StackService;
+use Sabre\DAV\Exception\NotFound;
 
 class DeckCalendarBackend {
 
@@ -62,7 +63,11 @@ class DeckCalendarBackend {
 	}
 
 	public function getBoard(int $id): Board {
-		return $this->boardService->find($id);
+		try {
+			return $this->boardService->find($id);
+		} catch (\Exception $e) {
+			throw new NotFound('Board with id ' . $id . ' not found');
+		}
 	}
 
 	public function checkBoardPermission(int $id, int $permission): bool {

--- a/lib/DAV/DeckCalendarBackend.php
+++ b/lib/DAV/DeckCalendarBackend.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+
+namespace OCA\Deck\DAV;
+
+use OCA\Deck\Db\Board;
+use OCA\Deck\Db\BoardMapper;
+use OCA\Deck\Service\BoardService;
+use OCA\Deck\Service\CardService;
+use OCA\Deck\Service\PermissionService;
+use OCA\Deck\Service\StackService;
+
+class DeckCalendarBackend {
+
+	/** @var BoardService */
+	private $boardService;
+	/** @var StackService */
+	private $stackService;
+	/** @var CardService */
+	private $cardService;
+	/** @var PermissionService */
+	private $permissionService;
+	/** @var BoardMapper */
+	private $boardMapper;
+
+	public function __construct(
+		BoardService $boardService, StackService $stackService, CardService $cardService, PermissionService $permissionService,
+		BoardMapper $boardMapper
+	) {
+		$this->boardService = $boardService;
+		$this->stackService = $stackService;
+		$this->cardService = $cardService;
+		$this->permissionService = $permissionService;
+		$this->boardMapper = $boardMapper;
+	}
+
+	public function getBoards(): array {
+		return $this->boardService->findAll();
+	}
+
+	public function getBoard(int $id): Board {
+		return $this->boardService->find($id);
+	}
+
+	public function checkBoardPermission(int $id, int $permission): bool {
+		$permissions = $this->permissionService->getPermissions($id);
+		return isset($permissions[$permission]) ? $permissions[$permission] : false;
+	}
+
+	public function updateBoard(Board $board): bool {
+		$this->boardMapper->update($board);
+		return true;
+	}
+
+	public function getChildren(int $id): array {
+		return array_merge(
+			$this->cardService->findCalendarEntries($id),
+			$this->stackService->findCalendarEntries($id)
+		);
+	}
+}

--- a/lib/Db/Card.php
+++ b/lib/Db/Card.php
@@ -128,7 +128,7 @@ class Card extends RelationalEntity {
 		$event->DTEND = new \DateTime($this->getDuedate());
 		$event->add('RELATED-TO', 'deck-stack-' . $this->getStackId());
 
-		// For write support: CANCELLED / IN-PROCESS handling
+		// FIXME: For write support: CANCELLED / IN-PROCESS handling
 		$event->STATUS = $this->getArchived() ? "COMPLETED" : "NEEDS-ACTION";
 		if ($this->getArchived()) {
 			$date = new DateTime();
@@ -140,6 +140,13 @@ class Card extends RelationalEntity {
 				return $label->getTitle();
 			}, $this->getLabels());
 		}
+		foreach ($this->getAssignedUsers() as $user) {
+			$participant = $user->resolveParticipant();
+			// FIXME use proper uri
+			$event->add('ATTENDEE', 'https://localhost/remote.php/dav/principals/users/:' . $participant->getUID(), [ 'CN' => $participant->getDisplayName()]);
+		}
+
+
 		$event->SUMMARY = $this->getTitle();
 		$calendar->add($event);
 		return $calendar;

--- a/lib/Db/Card.php
+++ b/lib/Db/Card.php
@@ -123,9 +123,12 @@ class Card extends RelationalEntity {
 		$calendar = new VCalendar();
 		$event = $calendar->createComponent('VTODO');
 		$event->UID = 'deck-card-' . $this->getId();
-		$event->DTSTAMP = new \DateTime($this->getDuedate());
-		$event->DTSTART = new \DateTime($this->getDuedate());
-		$event->DTEND = new \DateTime($this->getDuedate());
+		if ($this->getDuedate()) {
+			$event->DTSTAMP = new \DateTime();
+			$event->DTSTART = new \DateTime($this->getDuedate());
+			$event->DTEND = new \DateTime($this->getDuedate());
+			$event->DURATION = "PT1H";
+		}
 		$event->add('RELATED-TO', 'deck-stack-' . $this->getStackId());
 
 		// FIXME: For write support: CANCELLED / IN-PROCESS handling
@@ -134,6 +137,7 @@ class Card extends RelationalEntity {
 			$date = new DateTime();
 			$date->setTimestamp($this->getLastModified());
 			$event->COMPLETED = $date;
+			//$event->add('PERCENT-COMPLETE', 100);
 		}
 		if (count($this->getLabels()) > 0) {
 			$event->CATEGORIES = array_map(function ($label) {
@@ -142,7 +146,7 @@ class Card extends RelationalEntity {
 		}
 		foreach ($this->getAssignedUsers() as $user) {
 			$participant = $user->resolveParticipant();
-			// FIXME use proper uri
+			//  FIXME use proper uri
 			$event->add('ATTENDEE', 'https://localhost/remote.php/dav/principals/users/:' . $participant->getUID(), [ 'CN' => $participant->getDisplayName()]);
 		}
 

--- a/lib/Db/Card.php
+++ b/lib/Db/Card.php
@@ -24,6 +24,7 @@
 namespace OCA\Deck\Db;
 
 use DateTime;
+use Sabre\VObject\Component\VCalendar;
 
 class Card extends RelationalEntity {
 	protected $title;
@@ -117,4 +118,17 @@ class Card extends RelationalEntity {
 		unset($json['descriptionPrev']);
 		return $json;
 	}
+
+	public function getCalendarObject(): VCalendar {
+		$calendar = new VCalendar();
+		$event = $calendar->createComponent('VEVENT');
+		$event->UID = 'deck-cardevent' . $this->getId() . '@example.com';
+		$event->DTSTAMP = new \DateTime($this->getDuedate());
+		$event->DTSTART = new \DateTime($this->getDuedate());
+		$event->DTEND = new \DateTime($this->getDuedate());
+		$event->SUMMARY = $this->getTitle();
+		$calendar->add($event);
+		return $calendar;
+	}
+
 }

--- a/lib/Db/Card.php
+++ b/lib/Db/Card.php
@@ -144,14 +144,9 @@ class Card extends RelationalEntity {
 				return $label->getTitle();
 			}, $this->getLabels());
 		}
-		foreach ($this->getAssignedUsers() as $user) {
-			$participant = $user->resolveParticipant();
-			//  FIXME use proper uri
-			$event->add('ATTENDEE', 'https://localhost/remote.php/dav/principals/users/:' . $participant->getUID(), [ 'CN' => $participant->getDisplayName()]);
-		}
-
 
 		$event->SUMMARY = $this->getTitle();
+		$event->DESCRIPTION = $this->getDescription();
 		$calendar->add($event);
 		return $calendar;
 	}

--- a/lib/Db/Card.php
+++ b/lib/Db/Card.php
@@ -24,6 +24,7 @@
 namespace OCA\Deck\Db;
 
 use DateTime;
+use DateTimeZone;
 use Sabre\VObject\Component\VCalendar;
 
 class Card extends RelationalEntity {
@@ -124,10 +125,10 @@ class Card extends RelationalEntity {
 		$event = $calendar->createComponent('VTODO');
 		$event->UID = 'deck-card-' . $this->getId();
 		if ($this->getDuedate()) {
-			$event->DTSTAMP = new \DateTime();
-			$event->DTSTART = new \DateTime($this->getDuedate());
-			$event->DTEND = new \DateTime($this->getDuedate());
-			$event->DURATION = "PT1H";
+			$creationDate = new DateTime();
+			$creationDate->setTimestamp($this->createdAt);
+			$event->DTSTAMP = $creationDate;
+			$event->DUE = new DateTime($this->getDuedate(true), new DateTimeZone('UTC'));
 		}
 		$event->add('RELATED-TO', 'deck-stack-' . $this->getStackId());
 

--- a/lib/Db/Card.php
+++ b/lib/Db/Card.php
@@ -159,5 +159,4 @@ class Card extends RelationalEntity {
 	public function getCalendarPrefix(): string {
 		return 'card';
 	}
-
 }

--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -175,9 +175,7 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 			->from('deck_cards', 'c')
 			->join('c', 'deck_stacks', 's', 's.id = c.stack_id')
 			->where($qb->expr()->eq('s.board_id', $qb->createNamedParameter($boardId)))
-			->andWhere($qb->expr()->neq('c.archived', $qb->createNamedParameter(true)))
 			->andWhere($qb->expr()->eq('c.deleted_at', $qb->createNamedParameter('0')))
-			->andWhere($qb->expr()->isNotNull('c.duedate'))
 			->orderBy('c.duedate')
 			->setMaxResults($limit)
 			->setFirstResult($offset);

--- a/lib/Db/DeckMapper.php
+++ b/lib/Db/DeckMapper.php
@@ -29,10 +29,11 @@ use OCP\AppFramework\Db\Mapper;
  * Class DeckMapper
  *
  * @package OCA\Deck\Db
+ * @deprecated use QBMapper
  *
  * TODO: Move to QBMapper once Nextcloud 14 is a minimum requirement
  */
-abstract class DeckMapper extends Mapper {
+class DeckMapper extends Mapper {
 
 	/**
 	 * @param $id

--- a/lib/Db/Stack.php
+++ b/lib/Db/Stack.php
@@ -23,6 +23,8 @@
 
 namespace OCA\Deck\Db;
 
+use Sabre\VObject\Component\VCalendar;
+
 class Stack extends RelationalEntity {
 	protected $title;
 	protected $boardId;
@@ -50,4 +52,18 @@ class Stack extends RelationalEntity {
 		}
 		return $json;
 	}
+
+	public function getCalendarObject(): VCalendar {
+		$calendar = new VCalendar();
+		$event = $calendar->createComponent('VTODO');
+		$event->UID = 'deck-stack-' . $this->getId();
+		$event->SUMMARY = '[Stack]: ' . $this->getTitle();
+		$calendar->add($event);
+		return $calendar;
+	}
+
+	public function getCalendarPrefix(): string {
+		return 'stack';
+	}
+
 }

--- a/lib/Db/Stack.php
+++ b/lib/Db/Stack.php
@@ -65,5 +65,4 @@ class Stack extends RelationalEntity {
 	public function getCalendarPrefix(): string {
 		return 'stack';
 	}
-
 }

--- a/lib/Db/Stack.php
+++ b/lib/Db/Stack.php
@@ -57,7 +57,7 @@ class Stack extends RelationalEntity {
 		$calendar = new VCalendar();
 		$event = $calendar->createComponent('VTODO');
 		$event->UID = 'deck-stack-' . $this->getId();
-		$event->SUMMARY = '[Stack]: ' . $this->getTitle();
+		$event->SUMMARY = 'List : ' . $this->getTitle();
 		$calendar->add($event);
 		return $calendar;
 	}

--- a/lib/Service/BoardService.php
+++ b/lib/Service/BoardService.php
@@ -130,6 +130,7 @@ class BoardService {
 			return $this->boardsCache;
 		}
 		$complete = $this->getUserBoards($since);
+		$result = [];
 		/** @var Board $item */
 		foreach ($complete as &$item) {
 			$this->boardMapper->mapOwner($item);
@@ -152,7 +153,7 @@ class BoardService {
 			]);
 			$result[$item->getId()] = $item;
 		}
-		$this->boardsCache = $complete;
+		$this->boardsCache = $result;
 		return array_values($result);
 	}
 
@@ -189,6 +190,7 @@ class BoardService {
 			'PERMISSION_SHARE' => $permissions[Acl::PERMISSION_SHARE] ?? false
 		]);
 		$this->enrichWithUsers($board);
+		$this->boardsCache[$board->getId()] = $board;
 		return $board;
 	}
 

--- a/lib/Service/BoardService.php
+++ b/lib/Service/BoardService.php
@@ -348,7 +348,7 @@ class BoardService {
 			throw new BadRequestException('board id must be a number');
 		}
 
-		$this->permissionService->checkPermission($this->boardMapper, $id, Acl::PERMISSION_READ);
+		$this->permissionService->checkPermission($this->boardMapper, $id, Acl::PERMISSION_MANAGE);
 		$board = $this->find($id);
 		if ($board->getDeletedAt() > 0) {
 			throw new BadRequestException('This board has already been deleted');
@@ -377,7 +377,7 @@ class BoardService {
 			throw new BadRequestException('board id must be a number');
 		}
 
-		$this->permissionService->checkPermission($this->boardMapper, $id, Acl::PERMISSION_READ);
+		$this->permissionService->checkPermission($this->boardMapper, $id, Acl::PERMISSION_MANAGE);
 		$board = $this->find($id);
 		$board->setDeletedAt(0);
 		$board = $this->boardMapper->update($board);
@@ -404,7 +404,7 @@ class BoardService {
 			throw new BadRequestException('id must be a number');
 		}
 
-		$this->permissionService->checkPermission($this->boardMapper, $id, Acl::PERMISSION_READ);
+		$this->permissionService->checkPermission($this->boardMapper, $id, Acl::PERMISSION_MANAGE);
 		$board = $this->find($id);
 		$delete = $this->boardMapper->delete($board);
 

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -146,8 +146,11 @@ class CardService {
 
 	public function findCalendarEntries($boardId) {
 		$this->permissionService->checkPermission($this->boardMapper, $boardId, Acl::PERMISSION_READ);
-
-		return $this->cardMapper->findCalendarEntries($boardId);
+		$cards = $this->cardMapper->findCalendarEntries($boardId);
+		foreach ($cards as $card) {
+			$this->enrich($card);
+		}
+		return $cards;
 	}
 
 	/**

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -144,6 +144,12 @@ class CardService {
 		return $card;
 	}
 
+	public function findCalendarEntries($boardId) {
+		$this->permissionService->checkPermission($this->boardMapper, $boardId, Acl::PERMISSION_READ);
+
+		return $this->cardMapper->findCalendarEntries($boardId);
+	}
+
 	/**
 	 * @param $title
 	 * @param $stackId

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+
+namespace OCA\Deck\Service;
+
+use OCA\Deck\AppInfo\Application;
+use OCA\Deck\NoPermissionException;
+use OCP\IConfig;
+use OCP\IGroup;
+use OCP\IGroupManager;
+
+class ConfigService {
+	private $config;
+	private $userId;
+	private $groupManager;
+
+	public function __construct(
+		IConfig $config,
+		IGroupManager $groupManager,
+		$userId
+	) {
+		$this->userId = $userId;
+		$this->groupManager = $groupManager;
+		$this->config = $config;
+	}
+
+	public function getAll(): array {
+		$data = [
+			'calendar' => $this->get('calendar')
+		];
+		if ($this->groupManager->isAdmin($this->userId)) {
+			$data = [
+				'groupLimit' => $this->get('groupLimit'),
+			];
+		}
+		return $data;
+	}
+
+	public function get($key) {
+		$result = null;
+		switch ($key) {
+			case 'groupLimit':
+				if (!$this->groupManager->isAdmin($this->userId)) {
+					throw new NoPermissionException('You must be admin to get the group limit');
+				}
+				$result = $this->getGroupLimit();
+				break;
+			case 'calendar':
+				$result = (bool)$this->config->getUserValue($this->userId, Application::APP_ID, 'calendar', true);
+				break;
+		}
+		return $result;
+	}
+
+	public function set($key, $value) {
+		$result = null;
+		switch ($key) {
+			case 'groupLimit':
+				if (!$this->groupManager->isAdmin($this->userId)) {
+					throw new NoPermissionException('You must be admin to set the group limit');
+				}
+				$result = $this->setGroupLimit($value);
+				break;
+			case 'calendar':
+				$this->config->setUserValue($this->userId, Application::APP_ID, 'calendar', (int)$value);
+				$result = $value;
+				break;
+		}
+		return $result;
+	}
+
+	private function setGroupLimit($value) {
+		$groups = [];
+		foreach ($value as $group) {
+			$groups[] = $group['id'];
+		}
+		$data = implode(',', $groups);
+		$this->config->setAppValue(Application::APP_ID, 'groupLimit', $data);
+		return $groups;
+	}
+
+	private function getGroupLimitList() {
+		$value = $this->config->getAppValue(Application::APP_ID, 'groupLimit', '');
+		$groups = explode(',', $value);
+		if ($value === '') {
+			return [];
+		}
+		return $groups;
+	}
+
+	private function getGroupLimit() {
+		$groups = $this->getGroupLimitList();
+		$groups = array_map(function ($groupId) {
+			/** @var IGroup $groups */
+			$group = $this->groupManager->get($groupId);
+			if ($group === null) {
+				return null;
+			}
+			return [
+				'id' => $group->getGID(),
+				'displayname' => $group->getDisplayName(),
+			];
+		}, $groups);
+		return array_filter($groups);
+	}
+}

--- a/lib/Service/StackService.php
+++ b/lib/Service/StackService.php
@@ -146,6 +146,11 @@ class StackService {
 		return $stacks;
 	}
 
+	public function findCalendarEntries($boardId) {
+		$this->permissionService->checkPermission(null, $boardId, Acl::PERMISSION_READ);
+		return $this->stackMapper->findAll($boardId);
+	}
+
 	public function fetchDeleted($boardId) {
 		$this->permissionService->checkPermission($this->boardMapper, $boardId, Acl::PERMISSION_READ);
 		$stacks = $this->stackMapper->findDeleted($boardId);

--- a/src/components/navigation/AppNavigation.vue
+++ b/src/components/navigation/AppNavigation.vue
@@ -52,14 +52,28 @@
 		<template #footer>
 			<AppNavigationSettings>
 				<div>
-					<input id="toggle-modal"
-						v-model="cardDetailsInModal"
-						type="checkbox"
-						class="checkbox">
-					<label for="toggle-modal">
-						{{ t('deck', 'Use modal card view') }}
-					</label>
-					<Multiselect v-model="groupLimit"
+					<div>
+						<input id="toggle-modal"
+							v-model="cardDetailsInModal"
+							type="checkbox"
+							class="checkbox">
+						<label for="toggle-modal">
+							{{ t('deck', 'Use modal card view') }}
+						</label>
+					</div>
+
+					<div>
+						<input id="toggle-calendar"
+							v-model="configCalendar"
+							type="checkbox"
+							class="checkbox">
+						<label for="toggle-calendar">
+							{{ t('deck', 'Show boards in calendar/tasks') }}
+						</label>
+					</div>
+
+					<Multiselect v-if="isAdmin"
+						v-model="groupLimit"
 						:class="{'icon-loading-small': groupLimitDisabled}"
 						open-direction="bottom"
 						:options="groups"
@@ -69,7 +83,9 @@
 						label="displayname"
 						track-by="id"
 						@input="updateConfig" />
-					<p>{{ t('deck', 'Limiting Deck will block users not part of those groups from creating their own boards. Users will still be able to work on boards that have been shared with them.') }}</p>
+					<p v-if="isAdmin">
+						{{ t('deck', 'Limiting Deck will block users not part of those groups from creating their own boards. Users will still be able to work on boards that have been shared with them.') }}
+					</p>
 				</div>
 			</AppNavigationSettings>
 		</template>
@@ -84,7 +100,8 @@ import { AppNavigation as AppNavigationVue, AppNavigationItem, AppNavigationSett
 import AppNavigationAddBoard from './AppNavigationAddBoard'
 import AppNavigationBoardCategory from './AppNavigationBoardCategory'
 import { loadState } from '@nextcloud/initial-state'
-import { generateUrl, generateOcsUrl } from '@nextcloud/router'
+import { generateOcsUrl } from '@nextcloud/router'
+import { getCurrentUser } from '@nextcloud/auth'
 
 const canCreateState = loadState('deck', 'canCreate')
 
@@ -123,8 +140,7 @@ export default {
 			'sharedBoards',
 		]),
 		isAdmin() {
-			// eslint-disable-next-line
-			return OC.isUserAdmin()
+			return !!getCurrentUser()?.isAdmin
 		},
 		cardDetailsInModal: {
 			get() {
@@ -134,15 +150,19 @@ export default {
 				this.$store.dispatch('setCardDetailsInModal', newValue)
 			},
 		},
+		configCalendar: {
+			get() {
+				return this.$store.getters.config('calendar')
+			},
+			set(newValue) {
+				this.$store.dispatch('setConfig', { calendar: newValue })
+			},
+		},
 	},
 	beforeMount() {
 		if (this.isAdmin) {
-			axios.get(generateUrl('apps/deck/config')).then((response) => {
-				this.groupLimit = response.data.groupLimit
-				this.groupLimitDisabled = false
-			}, (error) => {
-				console.error('Error while loading groupLimit', error.response)
-			})
+			this.groupLimit = this.$store.getters.config('groupLimit')
+			this.groupLimitDisabled = false
 			axios.get(generateOcsUrl('cloud', 2) + 'groups').then((response) => {
 				this.groups = response.data.ocs.data.groups.reduce((obj, item) => {
 					obj.push({
@@ -157,15 +177,9 @@ export default {
 		}
 	},
 	methods: {
-		updateConfig() {
-			this.groupLimitDisabled = true
-			axios.post(generateUrl('apps/deck/config/groupLimit'), {
-				value: this.groupLimit,
-			}).then(() => {
-				this.groupLimitDisabled = false
-			}, (error) => {
-				console.error('Error while saving groupLimit', error.response)
-			})
+		async updateConfig() {
+			await this.$store.dispatch('setConfig', { groupLimit: this.groupLimit })
+			this.groupLimitDisabled = false
 		},
 	},
 }

--- a/tests/unit/controller/PageControllerTest.php
+++ b/tests/unit/controller/PageControllerTest.php
@@ -24,40 +24,33 @@
 
 namespace OCA\Deck\Controller;
 
+use OCA\Deck\Service\ConfigService;
 use OCA\Deck\Service\PermissionService;
 use OCP\IInitialStateService;
 use OCP\IL10N;
 use OCP\IRequest;
-use OCA\Deck\Db\Board;
-use OCP\IConfig;
 
 class PageControllerTest extends \Test\TestCase {
 	private $controller;
 	private $request;
 	private $l10n;
-	private $userId = 'john';
 	private $permissionService;
 	private $initialState;
-	private $config;
+	private $configService;
 
 	public function setUp(): void {
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->request = $this->createMock(IRequest::class);
 		$this->permissionService = $this->createMock(PermissionService::class);
-		$this->config = $this->createMock(IConfig::class);
+		$this->configService = $this->createMock(ConfigService::class);
 		$this->initialState = $this->createMock(IInitialStateService::class);
 
 		$this->controller = new PageController(
-			'deck', $this->request, $this->permissionService, $this->initialState, $this->l10n, $this->userId
+			'deck', $this->request, $this->permissionService, $this->initialState, $this->configService
 		);
 	}
 
 	public function testIndex() {
-		$board = new Board();
-		$board->setTitle('Personal');
-		$board->setOwner($this->userId);
-		$board->setColor('317CCC');
-
 		$this->permissionService->expects($this->any())
 			->method('canCreate')
 			->willReturn(true);


### PR DESCRIPTION
Implements https://github.com/nextcloud/deck/issues/15

- [x] Requires https://github.com/nextcloud/server/pull/19196 so 19+ only change
- [x] We could switch directly to VTODO entries if https://github.com/nextcloud/calendar/pull/1798 is ready
- [ ] Open deck from the calendar app https://github.com/nextcloud/calendar/pull/2478
