### PR TITLE
fixed issue #834

### DIFF
--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -68,6 +68,7 @@
 
 		<Container :get-child-payload="payloadForCard(stack.id)"
 			group-name="stack"
+			non-drag-area-selector=".dragDisabled"
 			:drag-handle-selector="dragHandleSelector"
 			@should-accept-drop="canEdit"
 			@drop="($event) => onDropCard(stack.id, $event)">

--- a/src/components/cards/CardItem.vue
+++ b/src/components/cards/CardItem.vue
@@ -41,6 +41,7 @@
 			</h3>
 			<form v-if="editing"
 				v-click-outside="cancelEdit"
+				class="dragDisabled"
 				@keyup.esc="cancelEdit"
 				@submit.prevent="finishedEdit(card)">
 				<input v-model="copiedCard.title" type="text" autofocus>


### PR DESCRIPTION
* Resolves: #834
* Target version: master 

### Summary
simply added a [non-drag-area-selector property](https://github.com/kutlugsahin/vue-smooth-dnd#api-container) on the Draggable container (src/components/board/Stack.vue). So all elements with the css class name .dragDisabled have disabled DnD.

Added the css class name to the title editing form in (src/components/cards(CardItem.vue)

### TODO
Please check 

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
