### PR TITLE
Fix checkmark regex to apply for lists only

### DIFF
--- a/src/components/cards/CardBadges.vue
+++ b/src/components/cards/CardBadges.vue
@@ -107,10 +107,10 @@ export default {
 			currentBoard: state => state.currentBoard,
 		}),
 		checkListCount() {
-			return (this.card.description.match(/\[\s*\x*\]/g) || []).length
+			return (this.card.description.match(/^\s*(\*|-|(\d\.))\s+\[\s*(\s|x)\s*\](.*)$/gim) || []).length
 		},
 		checkListCheckedCount() {
-			return (this.card.description.match(/\[\s*x\s*\]/g) || []).length
+			return (this.card.description.match(/^\s*(\*|-|(\d\.))\s+\[\s*x\s*\](.*)$/gim) || []).length
 		},
 		compactMode() {
 			return false


### PR DESCRIPTION
As mentioned in #1731 this makes sure that the checkbox counter only takes list items into account.

cc @stefan-niedermann for the android app