### PR TITLE
Always use server results from sharee search

### DIFF
--- a/src/components/board/SharingTabSidebar.vue
+++ b/src/components/board/SharingTabSidebar.vue
@@ -8,6 +8,7 @@
 			:user-select="true"
 			label="displayName"
 			track-by="user"
+			:internal-search="false"
 			@input="clickAddAcl"
 			@search-change="asyncFind" />
 


### PR DESCRIPTION
Make sure to always use the server results when searching. This has caused issues when sharing autocompletion is disabled and you search for an exact match by uid.

Fixes https://github.com/nextcloud/deck/issues/1340