### PR TITLE
Add animations and pin create card input

### DIFF
--- a/src/components/board/Board.vue
+++ b/src/components/board/Board.vue
@@ -23,26 +23,29 @@
 <template>
 	<div class="board-wrapper">
 		<Controls :board="board" />
-		<div v-if="loading" class="emptycontent">
-			<div class="icon icon-loading" />
-			<h2>{{ t('deck', 'Loading board') }}</h2>
-			<p />
-		</div>
-		<div v-else-if="board" class="board">
-			<Container lock-axix="y"
-				orientation="horizontal"
-				:drag-handle-selector="dragHandleSelector"
-				@drop="onDropStack">
-				<Draggable v-for="stack in stacksByBoard" :key="stack.id">
-					<Stack :stack="stack" />
-				</Draggable>
-			</Container>
-		</div>
-		<div v-else class="emptycontent">
-			<div class="icon icon-deck" />
-			<h2>{{ t('deck', 'Board not found') }}</h2>
-			<p />
-		</div>
+		<transition name="fade" mode="out-in">
+			<div v-if="loading" class="emptycontent" key="loading">
+				<div class="icon icon-loading" />
+				<h2>{{ t('deck', 'Loading board') }}</h2>
+				<p />
+			</div>
+			<div v-else-if="board && !loading" class="board" key="board">
+				<Container lock-axix="y"
+					orientation="horizontal"
+					:drag-handle-selector="dragHandleSelector"
+					@drop="onDropStack">
+					<Draggable v-for="stack in stacksByBoard" :key="stack.id">
+						<Stack :stack="stack" />
+					</Draggable>
+				</Container>
+			</div>
+			<div v-else class="emptycontent" key="notfound">
+				<div class="icon icon-deck" />
+				<h2>{{ t('deck', 'Board not found') }}</h2>
+				<p />
+			</div>
+		</transition>
+
 	</div>
 </template>
 
@@ -102,8 +105,12 @@ export default {
 	methods: {
 		async fetchData() {
 			this.loading = true
-			await this.$store.dispatch('loadBoardById', this.id)
-			await this.$store.dispatch('loadStacks', this.id)
+			try {
+				await this.$store.dispatch('loadBoardById', this.id)
+				await this.$store.dispatch('loadStacks', this.id)
+			} catch (e) {
+				console.error(e)
+			}
 			this.loading = false
 		},
 
@@ -124,6 +131,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+
+	@import "../../css/animations.scss";
 
 	$board-spacing: 15px;
 	$stack-spacing: 10px;

--- a/src/components/card/CardSidebar.vue
+++ b/src/components/card/CardSidebar.vue
@@ -236,7 +236,7 @@ export default {
 			descriptionSaveTimeout: null,
 			descriptionSaving: false,
 			hasActivity: capabilities && capabilities.activity,
-			hasComments: !!OC.appswebroots['comments']
+			hasComments: !!OC.appswebroots['comments'],
 		}
 	},
 	computed: {

--- a/src/components/cards/CardItem.vue
+++ b/src/components/cards/CardItem.vue
@@ -48,16 +48,21 @@
 				</form>
 
 				<div v-if="!editing" class="right">
-					<div v-if="card.duedate" :class="dueIcon">
-						<span>{{ relativeDate }}</span>
-					</div>
+					<transition name="zoom">
+						<div v-if="card.duedate" :class="dueIcon">
+							<span>{{ relativeDate }}</span>
+						</div>
+					</transition>
 				</div>
 			</div>
-			<ul v-if="card.labels && card.labels.length > 0" class="labels" @click="openCard">
+			<transition-group name="zoom"
+				tag="ul"
+				class="labels"
+				@click="openCard">
 				<li v-for="label in card.labels" :key="label.id" :style="labelStyle(label)">
 					<span>{{ label.title }}</span>
 				</li>
-			</ul>
+			</transition-group>
 			<div v-show="!compactMode" class="card-controls compact-item" @click="openCard">
 				<CardBadges :id="id" />
 			</div>
@@ -132,6 +137,13 @@ export default {
 			return moment(this.card.duedate).format('LLLL')
 		},
 	},
+	watch: {
+		currentCard(newValue) {
+			if (newValue) {
+				this.$nextTick(() => this.$el.scrollIntoView())
+			}
+		},
+	},
 	methods: {
 		openCard() {
 			this.$router.push({ name: 'card', params: { cardId: this.id } })
@@ -154,6 +166,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+	@import './../../css/animations';
+
 	$card-spacing: 10px;
 	$card-padding: 10px;
 

--- a/src/css/animations.scss
+++ b/src/css/animations.scss
@@ -1,0 +1,25 @@
+.fade-enter-active {
+	transition: opacity 250ms;
+}
+.fade-enter, .fade-leave-to {
+	opacity: 0;
+}
+
+.zoom-appear-active-class,
+.zoom-enter-active {
+	animation: zoom-in var(--animation-quick);
+}
+.zoom-leave-active {
+	animation: zoom-in var(--animation-quick) reverse;
+	will-change: transform;
+}
+@keyframes zoom-in {
+	0% {
+		transform: scale(0);
+		opacity: 0;
+	}
+	100% {
+		transform: scale(1);
+		opacity: 1;
+	}
+}


### PR DESCRIPTION
![Peek 2020-04-22 18-03](https://user-images.githubusercontent.com/3404133/80005287-a8944580-84c3-11ea-935e-9c5247bc7551.gif)

- Make card input sticky at the top
- Keep card input open when submitting
- Open card directly after creation
- Adding some small animations for loading board, adding cards, showing card input, adding/removing labels/duedate

cc @nextcloud/designers 