### PR TITLE
add stack button on empty board

### DIFF
--- a/src/components/board/Board.vue
+++ b/src/components/board/Board.vue
@@ -25,8 +25,9 @@
 		<Controls :board="board" />
 
 		<EmptyContent v-if="stacksByBoard.length === 0" icon="icon-pause">
-			{{ t('deck', 'No lists, add one') }}
+			{{ t('deck', 'No lists available') }}
 			<template #desc>
+				{{ t('deck', 'Create a new list to add cards to this board') }}
 				<form @submit.prevent="addNewStack()">
 					<input id="new-stack-input-main"
 						v-model="newStackTitle"
@@ -159,6 +160,10 @@ export default {
 	$board-spacing: 15px;
 	$stack-spacing: 10px;
 	$stack-width: 300px;
+
+	form {
+		text-align: center;
+	}
 
 	.board-wrapper {
 		position: relative;

--- a/src/components/board/Board.vue
+++ b/src/components/board/Board.vue
@@ -25,7 +25,7 @@
 		<Controls :board="board" />
 
 		<EmptyContent v-if="stacksByBoard.length === 0" icon="icon-pause">
-			No lists, add one
+			{{ t('deck', 'No lists, add one') }}
 			<template #desc>
 				<form @submit.prevent="addNewStack()">
 					<input id="new-stack-input-main"
@@ -146,6 +146,7 @@ export default {
 				boardId: this.id,
 			}
 			this.$store.dispatch('createStack', newStack)
+			this.newStackTitle = ''
 		},
 	},
 }

--- a/src/components/board/Board.vue
+++ b/src/components/board/Board.vue
@@ -24,33 +24,32 @@
 	<div class="board-wrapper">
 		<Controls :board="board" />
 
-		<EmptyContent v-if="stacksByBoard.length === 0" icon="icon-pause">
-			{{ t('deck', 'No lists available') }}
-			<template #desc>
-				{{ t('deck', 'Create a new list to add cards to this board') }}
-				<form @submit.prevent="addNewStack()">
-					<input id="new-stack-input-main"
-						v-model="newStackTitle"
-						v-focus
-						type="text"
-						class="no-close"
-						:placeholder="t('deck', 'List name')"
-						required>
-					<input v-tooltip="t('deck', 'Add new list')"
-						class="icon-confirm"
-						type="submit"
-						value="">
-				</form>
-			</template>
-		</EmptyContent>
-
 		<transition name="fade" mode="out-in">
 			<div v-if="loading" key="loading" class="emptycontent">
 				<div class="icon icon-loading" />
 				<h2>{{ t('deck', 'Loading board') }}</h2>
 				<p />
 			</div>
-			<div v-else-if="board && !loading" key="board" class="board">
+			<EmptyContent v-else-if="isEmpty" key="empty" icon="icon-deck">
+				{{ t('deck', 'No lists available') }}
+				<template #desc>
+					{{ t('deck', 'Create a new list to add cards to this board') }}
+					<form @submit.prevent="addNewStack()">
+						<input id="new-stack-input-main"
+							v-model="newStackTitle"
+							v-focus
+							type="text"
+							class="no-close"
+							:placeholder="t('deck', 'List name')"
+							required>
+						<input v-tooltip="t('deck', 'Add new list')"
+							class="icon-confirm"
+							type="submit"
+							value="">
+					</form>
+				</template>
+			</EmptyContent>
+			<div v-else-if="!isEmpty && !loading" key="board" class="board">
 				<Container lock-axix="y"
 					orientation="horizontal"
 					:drag-handle-selector="dragHandleSelector"
@@ -115,6 +114,9 @@ export default {
 		dragHandleSelector() {
 			return this.canEdit ? null : '.no-drag'
 		},
+		isEmpty() {
+			return this.stacksByBoard.length === 0
+		},
 	},
 	watch: {
 		id: 'fetchData',
@@ -163,6 +165,15 @@ export default {
 
 	form {
 		text-align: center;
+		display: flex;
+		width: 100%;
+		max-width: 200px;
+		margin: auto;
+		margin-top: 20px;
+
+		input[type=text] {
+			flex-grow: 1;
+		}
 	}
 
 	.board-wrapper {

--- a/src/components/board/Board.vue
+++ b/src/components/board/Board.vue
@@ -23,6 +23,26 @@
 <template>
 	<div class="board-wrapper">
 		<Controls :board="board" />
+
+		<EmptyContent v-if="stacksByBoard.length === 0" icon="icon-pause">
+			No lists, add one
+			<template #desc>
+				<form @submit.prevent="addNewStack()">
+					<input id="new-stack-input-main"
+						v-model="newStackTitle"
+						v-focus
+						type="text"
+						class="no-close"
+						:placeholder="t('deck', 'List name')"
+						required>
+					<input v-tooltip="t('deck', 'Add new list')"
+						class="icon-confirm"
+						type="submit"
+						value="">
+				</form>
+			</template>
+		</EmptyContent>
+
 		<transition name="fade" mode="out-in">
 			<div v-if="loading" key="loading" class="emptycontent">
 				<div class="icon icon-loading" />
@@ -54,6 +74,7 @@ import { Container, Draggable } from 'vue-smooth-dnd'
 import { mapState, mapGetters } from 'vuex'
 import Controls from '../Controls'
 import Stack from './Stack'
+import { EmptyContent } from '@nextcloud/vue'
 
 export default {
 	name: 'Board',
@@ -62,6 +83,7 @@ export default {
 		Container,
 		Draggable,
 		Stack,
+		EmptyContent,
 	},
 	inject: [
 		'boardApi',
@@ -75,6 +97,7 @@ export default {
 	data() {
 		return {
 			loading: true,
+			newStackTitle: '',
 		}
 	},
 	computed: {
@@ -117,11 +140,10 @@ export default {
 			this.$store.dispatch('orderStack', { stack: this.stacksByBoard[removedIndex], removedIndex, addedIndex })
 		},
 
-		createStack() {
+		addNewStack() {
 			const newStack = {
-				title: 'FooBar',
+				title: this.newStackTitle,
 				boardId: this.id,
-				order: this.stacksByBoard().length,
 			}
 			this.$store.dispatch('createStack', newStack)
 		},

--- a/webpack.js
+++ b/webpack.js
@@ -32,5 +32,5 @@ const config = {
 	}
 };
 
-module.exports = merge(config, webpackConfig)
+module.exports = merge(webpackConfig, config)
 


### PR DESCRIPTION
Signed-off-by: Jakob Röhrl <jakob.roehrl@web.de>
* Resolves: https://github.com/nextcloud/deck/issues/1655
* Target version: master 

It shows only on empty board up:
![grafik](https://user-images.githubusercontent.com/24530680/86905121-ea6f7800-c111-11ea-9b51-48e0d0693669.png)

