### PR TITLE
Add hover effect to board list

### DIFF
--- a/src/components/boards/Boards.vue
+++ b/src/components/boards/Boards.vue
@@ -83,6 +83,11 @@ export default {
 			display: flex;
 		}
 
+		.board-list-row:not(.board-list-header-row):hover {
+			transition: background-color 0.3s ease;
+			background-color: var(--color-background-dark);
+		}
+
 		.board-list-header-row {
 			color: var(--color-text-lighter);
 		}


### PR DESCRIPTION
This MR adds a mouse-hover effect to the board list, just as seen in Nextcloud files:

![image](https://user-images.githubusercontent.com/1677436/81851499-da944700-9559-11ea-9114-013829a73eea.png)

This is part of #1880 
