### PR TITLE
Improve hovering response in board

### DIFF
--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -237,7 +237,7 @@ export default {
 		margin: 3px -3px;
 		margin-right: -10px;
 		margin-top: 0;
-		margin-bottom: 0;
+		margin-bottom: 3px;
 		background-color: var(--color-main-background-translucent);
 		cursor: grab;
 

--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -239,10 +239,12 @@ export default {
 		margin-top: 0;
 		margin-bottom: 0;
 		background-color: var(--color-main-background-translucent);
+		cursor: grab;
 
 		h3, form {
 			flex-grow: 1;
 			display: flex;
+			cursor: inherit;
 
 			input[type=text] {
 				flex-grow: 1;

--- a/src/components/cards/CardItem.vue
+++ b/src/components/cards/CardItem.vue
@@ -176,7 +176,7 @@ export default {
 	}
 
 	.card:hover {
-		box-shadow: 0 0 2px 2px var(--color-box-shadow);
+		box-shadow: 0 0 5px 1px var(--color-box-shadow);
 	}
 
 	.card {

--- a/src/components/cards/CardItem.vue
+++ b/src/components/cards/CardItem.vue
@@ -175,6 +175,10 @@ export default {
 		border: 1px solid var(--color-border);
 	}
 
+	.card:hover {
+		box-shadow: 0 0 2px 2px var(--color-box-shadow);
+	}
+
 	.card {
 		transition: box-shadow 0.1s ease-in-out;
 		box-shadow: 0 0 2px 0 var(--color-box-shadow);


### PR DESCRIPTION
Add "grab" cursor for stack titles.

I wanted to add the same for cards and a "grabbing" while moving, but I'm still fighting with scoped CSS.

Ref #1880 