### PR TITLE
enable linkify in description renderer

### DIFF
--- a/src/components/card/CardSidebar.vue
+++ b/src/components/card/CardSidebar.vue
@@ -203,7 +203,9 @@ import { formatFileSize } from '@nextcloud/files'
 import relativeDate from '../../mixins/relativeDate'
 import AttachmentList from './AttachmentList'
 
-const markdownIt = new MarkdownIt()
+const markdownIt = new MarkdownIt({
+	linkify: true,
+})
 markdownIt.use(MarkdownItTaskLists, { enabled: true, label: true, labelAfter: true })
 
 const capabilities = window.OC.getCapabilities()
@@ -602,6 +604,10 @@ export default {
 
 		&::v-deep input {
 			min-height: auto;
+		}
+
+		&::v-deep a {
+			text-decoration: underline;
 		}
 	}
 


### PR DESCRIPTION
### Summary

this restores the old behaviour of parsing plain text links into html link

Before:
![Screenshot_20200514_162750](https://user-images.githubusercontent.com/1283854/81949008-dc114e00-95f1-11ea-86ca-f8ea4d8cfea2.png)

After:
![Screenshot_20200514_164649](https://user-images.githubusercontent.com/1283854/81949021-e16e9880-95f1-11ea-9b3b-14a2de46a132.png)


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
