### PR TITLE
Redirect from previously used routes to the current ones

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -121,5 +121,22 @@ export default new Router({
 				},
 			],
 		},
+		// redirects to keep compatibility to 1.0.0 routes
+		{
+			path: '/boards/:id',
+			redirect: '/board/:id',
+		},
+		{
+			path: '/boards/:id/cards/:cardId',
+			redirect: '/board/:id/card/:cardId',
+		},
+		{
+			path: '/!/board/:id',
+			redirect: '/board/:id',
+		},
+		{
+			path: '/!/board/:id/card/:cardId',
+			redirect: '/board/:id/card/:cardId',
+		},
 	],
 })


### PR DESCRIPTION
Let's hope this saves @stefan-niedermann some hassle :wink: 

We basically used different frontend routes in deck:

| Version | Board URL | Card URL |  
| --- | --- | --- |
| < 1.0.0 | `#!/board/:id` | `#!/board/:id/card/:cardId` |
| 1.0.0 beta/rc | `#/boards/:id` | `#/boards/:id/cards/:cardId` |
| >= 1.0.0 | `#/board/:id`  | `#/board/:id/card/:cardId` |

This PR makes sure that all previously announced route formats keep working by redirecting to the correct one.