### PR TITLE
Use mixing for relative date in card sidebar

### DIFF
--- a/src/components/card/CardSidebar.vue
+++ b/src/components/card/CardSidebar.vue
@@ -261,8 +261,6 @@ export default {
 				autosave: { enabled: false, uniqueId: 'unique' },
 				toolbar: false,
 			},
-			lastModifiedRelative: null,
-			lastCreatedRemative: null,
 			descriptionSaveTimeout: null,
 			descriptionSaving: false,
 			hasActivity: capabilities && capabilities.activity,
@@ -301,7 +299,7 @@ export default {
 			return this.$store.getters.cardById(this.id)
 		},
 		subtitle() {
-			return t('deck', 'Modified') + ': ' + this.lastModifiedRelative + ' ' + t('deck', 'Created') + ': ' + this.lastCreatedRemative
+			return t('deck', 'Modified') + ': ' + this.relativeDate(this.currentCard.lastModified * 1000) + ' ' + t('deck', 'Created') + ': ' + this.relativeDate(this.currentCard.createdAt * 1000)
 		},
 		formatedAssignables() {
 			return this.assignables.map(item => {
@@ -348,12 +346,6 @@ export default {
 			this.initialize()
 		},
 	},
-	created() {
-		setInterval(this.updateRelativeTimestamps, 10000)
-	},
-	destroyed() {
-		clearInterval(this.updateRelativeTimestamps)
-	},
 	mounted() {
 		this.initialize()
 	},
@@ -381,7 +373,6 @@ export default {
 			}
 
 			this.desc = this.currentCard.description
-			this.updateRelativeTimestamps()
 		},
 		showEditor() {
 			if (!this.canEdit) {
@@ -425,10 +416,6 @@ export default {
 				})
 				this.updateDescription(updatedDescription)
 			}
-		},
-		updateRelativeTimestamps() {
-			this.lastModifiedRelative = OC.Util.relativeModifiedDate(this.currentCard.lastModified * 1000)
-			this.lastCreatedRemative = OC.Util.relativeModifiedDate(this.currentCard.createdAt * 1000)
 		},
 		setDue() {
 			this.$store.dispatch('updateCardDue', this.copiedCard)

--- a/src/store/card.js
+++ b/src/store/card.js
@@ -147,6 +147,7 @@ export default {
 			if (existingIndex !== -1) {
 				Vue.set(state.cards[existingIndex], property, card[property])
 			}
+			Vue.set(state.cards[existingIndex], 'lastModified', Date.now() / 1000)
 		},
 		cardIncreaseAttachmentCount(state, cardId) {
 			const existingIndex = state.cards.findIndex(_card => _card.id === cardId)


### PR DESCRIPTION
Reduce console log spam due to deprecated function and makes sure the lastModified date is always updated.