### PR TITLE
Adding CSS rule for Markdown Blockquotes

### DIFF
--- a/src/css/markdown.scss
+++ b/src/css/markdown.scss
@@ -100,3 +100,9 @@ table {
 		padding: 3px;
 	}
 }
+
+blockquote {
+	padding-left: 10px;
+	border-left: 3px solid var(--color-border-dark);
+	color: var(--color-text-lighter);
+}


### PR DESCRIPTION
* Resolves: #2064 
* Target version: master 

### Summary

Using a vertical bar next to the text to indicate a blockquote.
Using lighter text color as well (similar to github's blockquotes).

### TODO

- [x] as I said in the issue, the code is not tested other than in the developer console. Please check if that would work. Thank you!

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
