### PR TITLE
Activity fixes

### DIFF
--- a/lib/Activity/ActivityManager.php
+++ b/lib/Activity/ActivityManager.php
@@ -246,6 +246,19 @@ class ActivityManager {
 		try {
 			$event = $this->createEvent($objectType, $entity, $subject, $additionalParams, $author);
 			if ($event !== null) {
+				$json = json_encode($event->getSubjectParameters());
+				if (mb_strlen($json) > 4000) {
+					$params = json_decode(json_encode($event->getSubjectParameters()), true);
+
+					$newContent = $params['after'];
+					unset($params['before'], $params['after'], $params['card']['description']);
+
+					$params['after'] = mb_substr($newContent, 0, 2000);
+					if (mb_strlen($newContent) > 2000) {
+						$params['after'] .= '...';
+					}
+					$event->setSubject($event->getSubject(), $params);
+				}
 				$this->sendToUsers($event);
 			}
 		} catch (\Exception $e) {

--- a/lib/Activity/ActivityManager.php
+++ b/lib/Activity/ActivityManager.php
@@ -240,6 +240,9 @@ class ActivityManager {
 	}
 
 	public function triggerEvent($objectType, $entity, $subject, $additionalParams = [], $author = null) {
+		if ($author === null) {
+			$author = $this->userId;
+		}
 		try {
 			$event = $this->createEvent($objectType, $entity, $subject, $additionalParams, $author);
 			if ($event !== null) {

--- a/lib/Activity/DeckProvider.php
+++ b/lib/Activity/DeckProvider.php
@@ -329,8 +329,8 @@ class DeckProvider implements IProvider {
 		if (array_key_exists('diff', $subjectParams) && $subjectParams['diff']) {
 			$diff = new Diff();
 			// Don't add diff as message since we are limited to 255 chars here
-			//$event->setMessage($subjectParams['after']);
-			$event->setParsedMessage('<pre class="visualdiff">' . $diff->render($subjectParams['before'], $subjectParams['after']) . '</pre>');
+			$event->setParsedMessage($subjectParams['after']);
+			//$event->setParsedMessage('<pre class="visualdiff">' . $diff->render($subjectParams['before'], $subjectParams['after']) . '</pre>');
 			return $params;
 		}
 		if (array_key_exists('before', $subjectParams)) {

--- a/lib/Activity/DeckProvider.php
+++ b/lib/Activity/DeckProvider.php
@@ -96,6 +96,7 @@ class DeckProvider implements IProvider {
 			unset($subjectParams['author']);
 		}
 		$user = $this->userManager->get($author);
+		$params = [];
 		if ($user !== null) {
 			$params = [
 				'user' => [

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -415,8 +415,11 @@ class CardService {
 		if ($card->getArchived()) {
 			throw new StatusException('Operation not allowed. This card is archived.');
 		}
+		$changes = new ChangeSet($card);
 		$card->setStackId($stackId);
 		$this->cardMapper->update($card);
+		$changes->setAfter($card);
+		$this->activityManager->triggerUpdateEvents(ActivityManager::DECK_OBJECT_CARD, $changes, ActivityManager::SUBJECT_CARD_UPDATE);
 
 		$cards = $this->cardMapper->findAll($stackId);
 		$result = [];

--- a/tests/unit/Activity/DeckProviderTest.php
+++ b/tests/unit/Activity/DeckProviderTest.php
@@ -287,7 +287,7 @@ class DeckProviderTest extends TestCase {
 		$this->assertEquals('test string Card', $event->getParsedSubject());
 		$this->assertEquals('test string {card}', $event->getRichSubject());
 		$this->assertEquals('BCD', $event->getMessage());
-		$this->assertEquals('<pre class="visualdiff"><del>A</del>BC<ins>D</ins></pre>', $event->getParsedMessage());
+		$this->assertEquals('BCD', $event->getParsedMessage());
 	}
 
 	public function testParseParamForBoard() {


### PR DESCRIPTION
- [x] Emit activity on stack change 
- [x] Fallback to current user when triggering activities 
- [x] Fix undefined variable params
- [x] Properly handle description updates that produce a longer json than 4000chars that oc_activity_mq supports
- [x] Fix visual diff that is no longer working due to security reasons in activity https://github.com/nextcloud/deck/issues/1557

fixes https://github.com/nextcloud/deck/issues/1755
fixes https://github.com/nextcloud/deck/issues/721
fixes https://github.com/nextcloud/deck/issues/1254