### PR TITLE
WIP: Naive approach on content sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5254,29 +5254,24 @@
 			}
 		},
 		"@nextcloud/event-bus": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.1.4.tgz",
-			"integrity": "sha512-It27KzmUaSQ7w22nHFwOn8XgeVG0HYYOSNG9gs4UkP5VqcZ16m4ydt3GkMpWcyFec4OUjJc+yf7omRc3pNxsSw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.2.0.tgz",
+			"integrity": "sha512-pNS0R6Mvgj4WnbJQ8LYjxRjCbRndpwjHNyZYm0zl8U71gbHsUvQIIzTdW7WYg6Nz/FjAlrdmDXJDFLh1DDcIFA==",
 			"requires": {
-				"@types/semver": "^6.2.1",
+				"@types/semver": "^7.1.0",
 				"core-js": "^3.6.2",
-				"semver": "^6.3.0"
+				"semver": "^7.3.2"
 			},
 			"dependencies": {
-				"@types/semver": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.1.tgz",
-					"integrity": "sha512-+beqKQOh9PYxuHvijhVl+tIHvT6tuwOrE9m14zd+MT2A38KoKZhh7pYJ0SNleLtwDsiIxHDsIk9bv01oOxvSvA=="
-				},
 				"core-js": {
 					"version": "3.6.5",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
 					"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
 				},
 				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 				}
 			}
 		},
@@ -5635,8 +5630,7 @@
 		"@types/node": {
 			"version": "13.13.4",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
-			"integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
-			"dev": true
+			"integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -5655,6 +5649,14 @@
 			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.1.tgz",
 			"integrity": "sha512-boy4xPNEtiw6N3abRhBi/e7hNvy3Tt8E9ZRAQrwAGzoCGZS/1wjo9KY7JHhnfnEsG5wSjDbymCozUM9a3ea7OQ==",
 			"dev": true
+		},
+		"@types/semver": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.1.tgz",
+			"integrity": "sha512-ooD/FJ8EuwlDKOI6D9HWxgIgJjMg2cuziXm/42npDC8y4NjxplBUn9loewZiBNCt44450lHAU0OSb51/UqXeag==",
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/stack-utils": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"@nextcloud/auth": "^1.3.0",
 		"@nextcloud/axios": "^1.3.2",
 		"@nextcloud/dialogs": "^1.4.0",
+		"@nextcloud/event-bus": "^1.2.0",
 		"@nextcloud/files": "^1.1.0",
 		"@nextcloud/initial-state": "^1.1.2",
 		"@nextcloud/l10n": "^1.3.0",

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -317,6 +317,11 @@ export default new Vuex.Store({
 			const storedBoard = await apiClient.updateBoard(board)
 			commit('addBoard', storedBoard)
 		},
+		updateBoardLastModified({ commit }, board) {
+			commit('addBoard', board)
+			commit('setCurrentBoard', board)
+
+		},
 		createBoard({ commit }, boardData) {
 			apiClient.createBoard(boardData)
 				.then((board) => {


### PR DESCRIPTION
First attempt to tackle https://github.com/nextcloud/deck/issues/256

- [x] Currently uses the lastModified date to detect changes with polling
- [ ] Optionally sent current server time with responses (can be avoided when switching to etags)

UI wise we currently don't trigger an update of the user interface to avoid ui element that are changing places without user interaction, so instead a small banner is shown that the view is outdated which allows the user to trigger a refresh manually. cc @nextcloud/designers Does that make sense? I guess ideally we could just update all data that doesn't affect any item position changes. So a card reordering would still trigger the banner while simple label or text changes would be shown immediately in the UI.

![image](https://user-images.githubusercontent.com/3404133/89096602-237cce80-d3d8-11ea-9918-e352f459e716.png)


## Possibly better approaches
- Use https://github.com/nextcloud/push once available
- Block updates and detect changes on ETag mismatch (#1650 #925)
  - https://fideloper.com/etags-and-optimistic-concurrency-control
