### PR TITLE
Adjust board background to new design of tasks app

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -98,6 +98,7 @@ export default {
 			position: relative;
 			overflow-x: hidden;
 			align-items: stretch;
+			background-color: var(--color-background-dark) !important;
 		}
 
 		#app-sidebar {

--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -240,7 +240,6 @@ export default {
 		margin-right: -10px;
 		margin-top: 0;
 		margin-bottom: 3px;
-		background-color: var(--color-main-background-translucent);
 		cursor: grab;
 
 		h3, form {
@@ -267,7 +266,6 @@ export default {
 		height: 52px;
 		z-index: 100;
 		display: flex;
-		background-color: var(--color-main-background);
 		margin-left: -10px;
 		margin-right: -10px;
 		padding-top: 3px;
@@ -279,6 +277,7 @@ export default {
 			margin-top: 0;
 			margin-bottom: 10px;
 			box-shadow: 0 0 3px var(--color-box-shadow);
+			background-color: var(--color-main-background);
 			border-radius: 3px;
 		}
 


### PR DESCRIPTION
* Target version: master 
* Resolves #1892

### Summary

This adjusts the background of boards to be slightly darker, following the recent design change in the Tasks app (https://github.com/nextcloud/tasks/pull/1136). i think the individual cards stick out better from this background.

![image](https://user-images.githubusercontent.com/1677436/89104776-200b3680-d41c-11ea-9f9a-d38df9d7bb1b.png)

This would of course be quite a change that, I guess, should be discussed (also cc'ing @jancborchardt here...)

Also, with stronger visual distinction between board and app sidebar, it feels like the sidebar elements are too close to its edge.

### Checklist

- [X] Code is properly formatted
- [X] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [X] Documentation (manuals or wiki) has been updated or is not required
