### PR TITLE
Fix an incorrect/misleading message in lib/Service/BoardService.php

### DIFF
--- a/lib/Service/BoardService.php
+++ b/lib/Service/BoardService.php
@@ -415,7 +415,7 @@ class BoardService {
 		}
 
 		if ($title === false || $title === null) {
-			throw new BadRequestException('color must be provided');
+			throw new BadRequestException('title must be provided');
 		}
 
 		if ($color === false || $color === null) {


### PR DESCRIPTION
Signed-off-by: Jordan Bancino <jordan@bancino.net>

* Target version: master 

### Summary
This fixes a typo in `lib/Service/BoardService.php` that is very misleading.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
