### PR TITLE
Fix double slash in the deck activity links

### DIFF
--- a/lib/Activity/DeckProvider.php
+++ b/lib/Activity/DeckProvider.php
@@ -131,7 +131,7 @@ class DeckProvider implements IProvider {
 
 			if (array_key_exists('board', $subjectParams)) {
 				$archivedParam = $subjectParams['card']['archived'] ? 'archived' : '';
-				$card['link'] = $this->deckUrl('/board/' . $subjectParams['board']['id'] . '/' . $archivedParam . '/card/' . $event->getObjectId());
+				$card['link'] = $this->deckUrl('/board/' . $subjectParams['board']['id'] . $archivedParam . '/card/' . $event->getObjectId());
 			}
 			$params['card'] = $card;
 		}


### PR DESCRIPTION
* Resolves: #2185 
