### PR TITLE
No need to add url-loader twice

### DIFF
--- a/webpack.js
+++ b/webpack.js
@@ -13,17 +13,6 @@ const config = {
 		jsonpFunction: 'webpackJsonpOCADeck',
 		chunkFilename: '[name].js?v=[contenthash]',
 	},
-	module: {
-		rules: [
-			{
-				test: /\.(png|jpg|gif|svg)$/,
-				loader: 'url-loader',
-				options: {
-					name: '[name].[ext]?[hash]'
-				}
-			}
-		]
-	},
 	resolve: {
 		extensions: ['*', '.js', '.vue', '.json'],
 		modules: [


### PR DESCRIPTION
url-loader is already added by the shared webpack config

Fixes https://github.com/nextcloud/deck/issues/2268