### PR TITLE
Fix empty content view to align with other widgets

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -48,7 +48,9 @@
 			<EmptyContent
 				id="deck-widget-empty-content"
 				icon="icon-deck">
-				{{ t('deck', 'No upcoming cards') }}
+				<template #desc>
+					{{ t('deck', 'No upcoming cards') }}
+				</template>
 			</EmptyContent>
 		</template>
 	</DashboardWidget>
@@ -110,6 +112,11 @@ export default {
 
 <style lang="scss" scoped>
 	@import './../css/labels';
+
+	#deck-widget-empty-content {
+		text-align: center;
+		margin-top: 5vh;
+	}
 
 	.card {
 		display: block;


### PR DESCRIPTION
Implements what was described in https://github.com/nextcloud/server/issues/22339

![image](https://user-images.githubusercontent.com/3404133/92365706-80188b00-f0f4-11ea-92dd-3e798cbf2463.png)
