### PR TITLE
l10n:add translation to card placeholder

### DIFF
--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -82,7 +82,7 @@
 						type="text"
 						class="no-close"
 						:disabled="stateCardCreating"
-						placeholder="Add a new card"
+						:placeholder="t('deck', 'Card name')"
 						required
 						@keydown.esc="stopCardCreation">
 


### PR DESCRIPTION
Signed-off-by: Michiel Janssens <michiel@nexigon.net>

- Make the card placeholder translatable.
- Adjusted placeholder text similar to "list name" in controls.vue