### PR TITLE
Fix select queries

### DIFF
--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -228,7 +228,7 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 
 	public function findOverdue() {
 		$qb = $this->db->getQueryBuilder();
-		$qb->select('id,title,duedate,notified')
+		$qb->select('id', 'title', 'duedate', 'notified')
 			->from('deck_cards')
 			->where($qb->expr()->lt('duedate', $qb->createFunction('NOW()')))
 			->andWhere($qb->expr()->eq('archived', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)))
@@ -238,7 +238,7 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 
 	public function findUnexposedDescriptionChances() {
 		$qb = $this->db->getQueryBuilder();
-		$qb->select('id,title,duedate,notified,description_prev,last_editor,description')
+		$qb->select('id', 'title', 'duedate', 'notified', 'description_prev', 'last_editor', 'description')
 			->from('deck_cards')
 			->where($qb->expr()->isNotNull('last_editor'))
 			->andWhere($qb->expr()->isNotNull('description_prev'));


### PR DESCRIPTION
```
{"reqId":"KRyfh7ltjTQGgchypjQ4","level":3,"time":"2020-09-07T23:30:02+00:00","remoteAddr":"","user":"--","app":"core","method":"","url":"--","message":{"Exception":"Doctrine\\DBAL\\Exception\\InvalidFieldNameException","Message":"An exception occurred while executing 'SELECT `id,title,duedate,notified` FROM `oc_deck_cards` WHERE (`duedate` < NOW()) AND (`archived` = ?) AND (`deleted_at` = ?)' with params [false, 0]:\n\nSQLSTATE[42S22]: Column not found: 1054 Unknown column 'id,title,duedate,notified' in 'field list'","Code":0,"Trace":[{"file":"/data/nextcloud/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php","line":169,"function":"convertException","class":"Doctrine\\DBAL
```

Found in some logs