### PR TITLE
add card in upcoming cards view

### DIFF
--- a/lib/Controller/CardController.php
+++ b/lib/Controller/CardController.php
@@ -78,8 +78,8 @@ class CardController extends Controller {
 	 * @param int $order
 	 * @return \OCP\AppFramework\Db\Entity
 	 */
-	public function create($title, $stackId, $type = 'plain', $order = 999) {
-		return $this->cardService->create($title, $stackId, $type, $order, $this->userId);
+	public function create($title, $stackId, $type = 'plain', $order = 999, $description = '', $duedate = null) {
+		return $this->cardService->create($title, $stackId, $type, $order, $this->userId, $description, $duedate);
 	}
 
 	/**

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -201,6 +201,8 @@
 
 		<Modal v-if="modalShow" :title="t('deck', 'Add card on Today')" @close="modalShow=false">
 			<div class="modal__content">
+				{{ lastBoardId }}
+				{{ lastListId }}
 				<h3>{{ t('deck', 'Add card on Today') }}</h3>
 				<Multiselect v-model="selectedBoard"
 					:placeholder="t('deck', 'Select a board')"
@@ -280,6 +282,8 @@ export default {
 		...mapGetters([
 			'canEdit',
 			'canManage',
+			'lastBoardId',
+			'lastListId',
 		]),
 		...mapState({
 			compactMode: state => state.compactMode,
@@ -317,6 +321,15 @@ export default {
 	watch: {
 		board() {
 			this.clearFilter()
+		},
+		lastBoardId() {
+
+			if (this.lastBoardId === null || this.lastBoardId === 0) {
+				return
+			}
+			this.selectedBoard = this.boards.filter(board => {
+				return board.id === this.lastBoardId
+			})
 		},
 	},
 	methods: {
@@ -390,6 +403,8 @@ export default {
 					duedate: today.toISOString(),
 				})
 				this.newCardTitle = ''
+				this.$store.dispatch('storeLastListId', this.selectedStack.id)
+				this.$store.dispatch('storeLastBoardId', this.selectedBoard.id)
 			} catch (e) {
 				showError('Could not create card: ' + e.response.data.message)
 			}

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -34,7 +34,7 @@
 			<h2><a href="#">{{ overviewName }}</a></h2>
 			<Actions>
 				<ActionButton icon="icon-add" @click.stop="modalShow=true">
-					{{ t('deck', 'Add card') }}
+					{{ t('deck', 'Add card on Today') }}
 				</ActionButton>
 			</Actions>
 		</div>
@@ -199,9 +199,9 @@
 			</div>
 		</div>
 
-		<Modal v-if="modalShow" :title="t('deck', 'Add card')" @close="modalShow=false">
+		<Modal v-if="modalShow" :title="t('deck', 'Add card on Today')" @close="modalShow=false">
 			<div class="modal__content">
-				<h3>{{ t('deck', 'Add card') }}</h3>
+				<h3>{{ t('deck', 'Add card on Today') }}</h3>
 				<Multiselect v-model="selectedBoard"
 					:placeholder="t('deck', 'Select a board')"
 					:options="boards"
@@ -214,7 +214,7 @@
 					:max-height="100"
 					label="title" />
 
-				<label for="new-stack-input-main" class="hidden-visually">{{ t('deck', 'Add card') }}</label>
+				<label for="new-stack-input-main" class="hidden-visually">{{ t('deck', 'Add card on Today') }}</label>
 				<input id="new-stack-input-main"
 					ref="newCardInput"
 					v-model="newCardTitle"
@@ -381,10 +381,13 @@ export default {
 		},
 		async addCard() {
 			try {
+				const today = new Date()
+				today.setHours(23, 59, 59, 999)
 				await this.$store.dispatch('addCard', {
 					title: this.newCardTitle,
 					stackId: this.selectedStack.id,
 					boardId: this.selectedBoard.id,
+					duedate: today.toISOString(),
 				})
 				this.newCardTitle = ''
 			} catch (e) {

--- a/src/components/ControlsModal.vue
+++ b/src/components/ControlsModal.vue
@@ -1,0 +1,168 @@
+<!--
+* @copyright Copyright (c) 2020 Jakob Röhrl <jakob.roehrl@web.de>
+*
+* @author Jakob Röhrl <jakob.roehrl@web.de>
+*
+* @license GNU AGPL version 3 or any later version
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*
+-->
+
+<template>
+	<Modal v-if="modalShow" :title="t('deck', 'Add card on Today')" @close="modalShow=false">
+		<div class="modal__content">
+			{{ lastBoardId - selectedBoard }}
+			{{ lastListId }}
+			<h3>{{ t('deck', 'Add card on Today') }}</h3>
+			<Multiselect v-model="selectedBoard"
+				:placeholder="t('deck', 'Select a board')"
+				:options="boards"
+				:max-height="100"
+				label="title"
+				@select="loadStacksFromBoard" />
+			<Multiselect v-model="selectedStack"
+				:placeholder="t('deck', 'Select a list')"
+				:options="stacksFromBoard"
+				:max-height="100"
+				label="title" />
+
+			<label for="new-stack-input-main" class="hidden-visually">{{ t('deck', 'Add card on Today') }}</label>
+			<input id="new-stack-input-main"
+				ref="newCardInput"
+				v-model="newCardTitle"
+				v-focus
+				type="text"
+				class="no-close"
+				:placeholder="t('deck', 'Card name')">
+
+			<button :disabled="!addCardSetRequiredFields" class="primary" @click="addCard">
+				{{ t('deck', 'Add card') }}
+			</button>
+			<button @click="modalShow=false">
+				{{ t('deck', 'Cancel') }}
+			</button>
+		</div>
+	</Modal>
+</template>
+
+<script>
+import { Modal, Multiselect } from '@nextcloud/vue'
+import labelStyle from '../mixins/labelStyle'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+import { showError } from '@nextcloud/dialogs'
+
+export default {
+	name: 'ControlsModal',
+	components: {
+		Modal, Multiselect,
+	},
+	mixins: [ labelStyle ],
+	props: {
+		modalShow: {
+			default: false,
+			type: Boolean,
+		},
+
+	},
+	data() {
+		return {
+			selectedBoard: '',
+			selectedStack: '',
+			stacksFromBoard: [],
+			newCardTitle: '',
+			lastBoardId: localStorage.getItem('deck.lastBoardId'),
+			lastListId: localStorage.getItem('deck.lastListId'),
+		}
+	},
+	computed: {
+		boards() {
+			return this.$store.getters.boards
+		},
+		addCardSetRequiredFields() {
+			if (this.selectedBoard === '' || this.selectedStack === '' || this.newCardTitle.trim() === '') {
+				return false
+			}
+			return true
+		},
+	},
+	mounted() {
+		this.setLastBoardId()
+	},
+
+	methods: {
+		setLastBoardId() {
+			if (this.lastBoardId === null || this.lastBoardId === 0) {
+				this.selectedBoard = ''
+				return
+			}
+			this.selectedBoard = this.selectedBoard = this.boards.filter(board => {
+				return board.id === this.lastBoardId
+			})
+		},
+		async loadStacksFromBoard(selectedBoard) {
+			try {
+				const url = generateUrl('/apps/deck/stacks/' + selectedBoard.id)
+				const response = await axios.get(url)
+				this.stacksFromBoard = response.data
+			} catch (err) {
+				return err
+			}
+		},
+		async addCard() {
+			try {
+				const today = new Date()
+				today.setHours(23, 59, 59, 999)
+				await this.$store.dispatch('addCard', {
+					title: this.newCardTitle,
+					stackId: this.selectedStack.id,
+					boardId: this.selectedBoard.id,
+					duedate: today.toISOString(),
+				})
+				this.newCardTitle = ''
+				localStorage.setItem('deck.lastBoardId', this.selectedBoard.id)
+				localStorage.setItem('deck.lastListId', this.selectedStack.id)
+
+			} catch (e) {
+				showError('Could not create card: ' + e.response.data.message)
+			}
+			// this.modalShow = false
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+	#new-stack-input-main {
+		width: 100%;
+	}
+
+	.modal__content {
+		width: 25vw;
+		min-width: 250px;
+		min-height: 120px;
+		text-align: center;
+		margin: 20px 20px 100px 20px;
+
+		.multiselect {
+			margin-bottom: 10px;
+		}
+	}
+
+	.modal__content button {
+		float: right;
+		margin-top: 50px;
+	}
+</style>

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -62,6 +62,8 @@ export default new Vuex.Store({
 		navShown: true,
 		compactMode: localStorage.getItem('deck.compactMode') === 'true',
 		cardDetailsInModal: localStorage.getItem('deck.cardDetailsInModal') === 'true',
+		lastBoardId: localStorage.getItem('deck.lastBoardId'),
+		lastListId: localStorage.getItem('deck.lastListId'),
 		sidebarShown: false,
 		currentBoard: null,
 		currentCard: null,
@@ -80,6 +82,12 @@ export default new Vuex.Store({
 		},
 		cardDetailsInModal: state => {
 			return state.cardDetailsInModal
+		},
+		lastBoardId: state => {
+			return state.lastBoardId
+		},
+		lastListId: state => {
+			return state.lastListId
 		},
 		getSearchQuery: state => {
 			return state.searchQuery
@@ -217,6 +225,12 @@ export default new Vuex.Store({
 		setCardDetailsInModal(state) {
 			state.cardDetailsInModal = !state.cardDetailsInModal
 			localStorage.setItem('deck.cardDetailsInModal', state.cardDetailsInModal)
+		},
+		storeLastBoardId(state, boardId) {
+			localStorage.setItem('deck.lastBoardId', boardId)
+		},
+		storeLastListId(state, listId) {
+			localStorage.setItem('deck.lastListId', listId)
 		},
 		setBoards(state, boards) {
 			state.boards = boards
@@ -421,6 +435,12 @@ export default new Vuex.Store({
 		},
 		setCardDetailsInModal({ commit }, show) {
 			commit('setCardDetailsInModal', show)
+		},
+		storeLastBoardId({ commit }, boardId) {
+			commit('storeLastBoardId', boardId)
+		},
+		storeLastListId({ commit }, listId) {
+			commit('storeLastListId', listId)
 		},
 		setCurrentBoard({ commit }, board) {
 			commit('setCurrentBoard', board)

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -62,8 +62,6 @@ export default new Vuex.Store({
 		navShown: true,
 		compactMode: localStorage.getItem('deck.compactMode') === 'true',
 		cardDetailsInModal: localStorage.getItem('deck.cardDetailsInModal') === 'true',
-		lastBoardId: localStorage.getItem('deck.lastBoardId'),
-		lastListId: localStorage.getItem('deck.lastListId'),
 		sidebarShown: false,
 		currentBoard: null,
 		currentCard: null,
@@ -82,12 +80,6 @@ export default new Vuex.Store({
 		},
 		cardDetailsInModal: state => {
 			return state.cardDetailsInModal
-		},
-		lastBoardId: state => {
-			return state.lastBoardId
-		},
-		lastListId: state => {
-			return state.lastListId
 		},
 		getSearchQuery: state => {
 			return state.searchQuery
@@ -225,12 +217,6 @@ export default new Vuex.Store({
 		setCardDetailsInModal(state) {
 			state.cardDetailsInModal = !state.cardDetailsInModal
 			localStorage.setItem('deck.cardDetailsInModal', state.cardDetailsInModal)
-		},
-		storeLastBoardId(state, boardId) {
-			localStorage.setItem('deck.lastBoardId', boardId)
-		},
-		storeLastListId(state, listId) {
-			localStorage.setItem('deck.lastListId', listId)
 		},
 		setBoards(state, boards) {
 			state.boards = boards
@@ -435,12 +421,6 @@ export default new Vuex.Store({
 		},
 		setCardDetailsInModal({ commit }, show) {
 			commit('setCardDetailsInModal', show)
-		},
-		storeLastBoardId({ commit }, boardId) {
-			commit('storeLastBoardId', boardId)
-		},
-		storeLastListId({ commit }, listId) {
-			commit('storeLastListId', listId)
 		},
 		setCurrentBoard({ commit }, board) {
 			commit('setCurrentBoard', board)


### PR DESCRIPTION
Signed-off-by: Jakob Röhrl <jakob.roehrl@web.de>

![grafik](https://user-images.githubusercontent.com/24530680/94790327-69551380-03d6-11eb-9107-8a8ec110bd0d.png)


### Ideas 
- [ ] close modal after card creation
- [ ] preselection of board and list
- [ ] second click on + doesn't open the modal
- [ ] update view after card creation
- [x] save last used board and stack (Android app does it)
