### PR TITLE
Properly check if FTSEvent has an argument set

### DIFF
--- a/lib/Event/FTSEvent.php
+++ b/lib/Event/FTSEvent.php
@@ -42,7 +42,7 @@ class FTSEvent extends Event {
 	}
 
 	public function getArgument($key) {
-		if ($this->hasArgument($key)) {
+		if (isset($this->arguments[$key])) {
 			return $this->arguments[$key];
 		}
 


### PR DESCRIPTION
Fixes #2344

Regression from migrating to a typed event class in https://github.com/nextcloud/deck/pull/1629