### PR TITLE
Use uid instead of displayname for sharee results

### DIFF
--- a/src/components/board/SharingTabSidebar.vue
+++ b/src/components/board/SharingTabSidebar.vue
@@ -102,7 +102,7 @@ export default {
 		formatedSharees() {
 			return this.unallocatedSharees.map(item => {
 				const sharee = {
-					user: item.label,
+					user: item.value.shareWith,
 					displayName: item.label,
 					icon: 'icon-user',
 					multiselectKey: item.shareType + ':' + item.primaryKey,


### PR DESCRIPTION
Otherwise avatars will not be shown properly for users where the displayname is different