### PR TITLE
Only remove card padding for editable cards

### DIFF
--- a/src/components/cards/AvatarList.vue
+++ b/src/components/cards/AvatarList.vue
@@ -144,17 +144,19 @@ export default {
 		}
 	}
 
+	$avatar-offset: 12px;
+
 	.avatar-list {
 		float: right;
 		display: inline-flex;
-		padding-right: 8px;
+		padding-right: $avatar-offset;
 		flex-direction: row-reverse;
 		.avatardiv,
 		/deep/ .avatardiv {
 			width: 36px;
 			height: 36px;
 			box-sizing: content-box !important;
-			margin-right: -12px;
+			margin-right: -$avatar-offset;
 			transition: margin-right 0.2s ease-in-out;
 
 			&.icon-more {

--- a/src/components/cards/CardBadges.vue
+++ b/src/components/cards/CardBadges.vue
@@ -121,10 +121,6 @@ export default {
 		}
 	}
 
-	.card:not(.card__editable) .avatars {
-		margin-right: 10px;
-	}
-
 	.fade-enter-active, .fade-leave-active {
 		transition: opacity .125s;
 	}

--- a/src/components/cards/CardItem.vue
+++ b/src/components/cards/CardItem.vue
@@ -115,10 +115,10 @@ export default {
 		]),
 		canEdit() {
 			if (this.currentBoard) {
-				return this.$store.getters.canEdit
+				return !this.currentBoard.archived && this.$store.getters.canEdit
 			}
 			const board = this.$store.getters.boards.find((item) => item.id === this.card.boardId)
-			return board ? board.permissions.PERMISSION_EDIT : false
+			return board ? !board.archived && board.permissions.PERMISSION_EDIT : false
 		},
 		card() {
 			return this.item ? this.item : this.$store.getters.cardById(this.id)
@@ -212,10 +212,15 @@ export default {
 		.card-controls {
 			display: flex;
 			margin-left: $card-padding;
+			margin-right: $card-padding;
+
 			& > div {
 				display: flex;
 				max-height: 44px;
 			}
+		}
+		&.card__editable .card-controls {
+			margin-right: 0;
 		}
 	}
 

--- a/src/components/cards/CardMenu.vue
+++ b/src/components/cards/CardMenu.vue
@@ -108,7 +108,7 @@ export default {
 				return this.$store.getters.canEdit
 			}
 			const board = this.$store.getters.boards.find((item) => item.id === this.card.boardId)
-			return board.permissions.PERMISSION_EDIT
+			return !!board?.permissions?.PERMISSION_EDIT
 		},
 		isBoardAndStackChoosen() {
 			if (this.selectedBoard === '' || this.selectedStack === '') {


### PR DESCRIPTION
Fixes #2356

Make sure that the card badges are properly aligned with or without edit permissions / on archived boards

![image](https://user-images.githubusercontent.com/3404133/95835206-3992fd80-0d3e-11eb-81eb-598dc3745dae.png)
![image](https://user-images.githubusercontent.com/3404133/95835224-3f88de80-0d3e-11eb-958d-a5d054678757.png)
