### PR TITLE
Only try to extract first part of the explode result

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -65,7 +65,7 @@ class ConfigService {
 
 	public function get($key) {
 		$result = null;
-		[$scope, $id] = explode(':', $key, 2);
+		[$scope] = explode(':', $key, 2);
 		switch ($scope) {
 			case 'groupLimit':
 				if (!$this->groupManager->isAdmin($this->userId)) {


### PR DESCRIPTION
Fixes #2522 

As we only use the first result anyways we can safely ignore the second part if one exists.

cc @Chartman123 