### PR TITLE
Add additional fields to the deck_cards table

### DIFF
--- a/lib/Db/Card.php
+++ b/lib/Db/Card.php
@@ -47,6 +47,12 @@ class Card extends RelationalEntity {
 	protected $notified = false;
 	protected $deletedAt = 0;
 	protected $commentsUnread = 0;
+	protected $timeToComplete;
+	protected $timeToCompleteMinutes;
+	protected $milestone;
+	protected $product;
+	protected $component;
+	protected $pctComplete;
 
 	private $databaseType = 'sqlite';
 
@@ -64,6 +70,8 @@ class Card extends RelationalEntity {
 		$this->addType('archived', 'boolean');
 		$this->addType('notified', 'boolean');
 		$this->addType('deletedAt', 'integer');
+		$this->addType('timeToCompleteMinutes', 'integer');
+		$this->addType('pctComplete', 'integer');
 		$this->addRelation('labels');
 		$this->addRelation('assignedUsers');
 		$this->addRelation('attachments');

--- a/lib/Migration/Version1000Date20201112173419.php
+++ b/lib/Migration/Version1000Date20201112173419.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Deck\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version1000Date20201112173419 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		$schema = $schemaClosure();
+		$table = $schema->getTable('deck_cards');
+
+		$table->addColumn('time_to_complete', 'text', [
+			'notnull' => false,
+		]);
+		$table->addColumn('time_to_complete_minutes', 'integer', [
+			'notnull' => false,
+		]);
+		$table->addColumn('milestone', 'text', [
+			'notnull' => false,
+		]);
+		$table->addColumn('product', 'text', [
+			'notnull' => false,
+		]);
+		$table->addColumn('component', 'text', [
+			'notnull' => false,
+		]);
+		$table->addColumn('pct_complete', 'integer', [
+			'notnull' => false,
+		]);
+
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+	}
+}

--- a/tests/unit/Db/CardTest.php
+++ b/tests/unit/Db/CardTest.php
@@ -85,6 +85,12 @@ class CardTest extends TestCase {
 			'commentsUnread' => 0,
 			'lastEditor' => null,
 			'ETag' => $card->getETag(),
+			'pctComplete' => null,
+			'timeToComplete' => null,
+			'timeToCompleteMinutes' => null,
+			'product' => null,
+			'component' => null,
+			'milestone' => null,
 		], $card->jsonSerialize());
 	}
 	public function testJsonSerializeLabels() {
@@ -111,6 +117,12 @@ class CardTest extends TestCase {
 			'commentsUnread' => 0,
 			'lastEditor' => null,
 			'ETag' => $card->getETag(),
+			'pctComplete' => null,
+			'timeToComplete' => null,
+			'timeToCompleteMinutes' => null,
+			'product' => null,
+			'component' => null,
+			'milestone' => null,
 		], $card->jsonSerialize());
 	}
 
@@ -147,6 +159,12 @@ class CardTest extends TestCase {
 			'commentsUnread' => 0,
 			'lastEditor' => null,
 			'ETag' => $card->getETag(),
+			'pctComplete' => null,
+			'timeToComplete' => null,
+			'timeToCompleteMinutes' => null,
+			'product' => null,
+			'component' => null,
+			'milestone' => null,
 		], $card->jsonSerialize());
 	}
 }


### PR DESCRIPTION
* Resolves: #2525 
* Target version: master 

### Summary

Add additional fields to the deck_cards table to pave the way for future features.  This migration is tied to version 1.0 of the database schema.