### PR TITLE
Do not reset filter when staying on the same board

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -259,8 +259,10 @@ export default {
 		},
 	},
 	watch: {
-		board() {
-			this.clearFilter()
+		board(current, previous) {
+			if (current?.id !== previous?.id) {
+				this.clearFilter()
+			}
 		},
 	},
 	methods: {


### PR DESCRIPTION
Otherwise we would reset the filter when reloading the board data from the API, e.g. when adding a sharee

Fixes https://github.com/nextcloud/deck/issues/2535