### PR TITLE
Add key do description to not leak any state through card change

### DIFF
--- a/src/components/card/CardSidebarTabDetails.vue
+++ b/src/components/card/CardSidebarTabDetails.vue
@@ -117,7 +117,7 @@
 				type="deck-card" />
 		</div>
 
-		<Description :card="card" />
+		<Description :key="card.id" :card="card" />
 	</div>
 </template>
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/deck/issues/2568

Steps to reproduce:
- Create two cards A and B
- Open card A and edit the description
- while editing, switch to card B