### PR TITLE
Matching color of description cursor with text color

### DIFF
--- a/src/components/card/Description.vue
+++ b/src/components/card/Description.vue
@@ -298,6 +298,10 @@ h5 {
 	color: var(--color-text-maxcontrast);
 }
 
+.CodeMirror-cursor {
+	border-left: 1px solid var(--color-main-text);
+}
+
 .editor-preview,
 .editor-statusbar {
 	display: none;


### PR DESCRIPTION
* Resolves: #2556
* Target version: master 

### Summary
Uses the default text color for the description cursor, which makes the cursor visible in dark mode

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
