### PR TITLE
docs: Fix table in section "GET /api/v1.0/config"

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1000,7 +1000,7 @@ Deck stores user and app configuration values globally and per board. The GET en
 
 #### Response
 
-| Config key | Description | Value |
+| Config key | Description |
 | --- | --- |
 | calendar | Determines if the calendar/tasks integration through the CalDAV backend is enabled for the user (boolean) | 
 | groupLimit | Determines if creating new boards is limited to certain groups of the instance. The resulting output is an array of group objects with the id and the displayname (Admin only)|  


### PR DESCRIPTION
* Resolves: (I didn't file an issue about the docs rendering problem fixed here. Should I?) <!-- related github issue -->
* Target version: `master`

### Summary

If the number of columns doesn't agree between the rows, the MarkDown table markup seems to be broken and rendered incorrectly in both, the GitHub preview and on https://deck.readthedocs.io. This change fixes this for the table at https://deck.readthedocs.io/en/latest/API/#config, by removing a field in the title row that didn't have corresponding fields in the other rows of the table.

### TODO

(I'm unaware of anything left to do about this.)

- [ ] ...

### Checklist

- [ ] Code is properly formatted
  - (Are there guidelines on how to format MarkDown for the manual?)
- [x] Sign-off message is added to all commits
  - [x] 8e4da4e0a3b39cad00a476b1e54ca98e66ca74f3 signed-off-by: Raphael Borun Das Gupta &lt;git@raphael.dasgupta.ch> 
- [ ] Tests (unit, integration, api and/or acceptance) are included
  - (Not really applicable here, I guess.) 
- [x] Documentation (manuals or wiki) has been updated or is not required
  - (This is a documentation-only change.)
