### PR TITLE
Properly set author for activity events that are triggered by cron

### DIFF
--- a/lib/Activity/ActivityManager.php
+++ b/lib/Activity/ActivityManager.php
@@ -404,13 +404,12 @@ class ActivityManager {
 			$subjectParams['stack'] = $this->stackMapper->find($additionalParams['after']);
 		}
 
-		$subjectParams['author'] = $this->userId;
-
+		$subjectParams['author'] = $author === null ? $this->userId : $author;
 
 		$event = $this->manager->generateEvent();
 		$event->setApp('deck')
 			->setType($eventType)
-			->setAuthor($author === null ? $this->userId : $author)
+			->setAuthor($subjectParams['author'])
 			->setObject($objectType, (int)$object->getId(), $object->getTitle())
 			->setSubject($subject, array_merge($subjectParams, $additionalParams))
 			->setTimestamp(time());


### PR DESCRIPTION
Since the author is not stored in oc_activity_mq we still need to preserve it in the subject parameters. This makes sure that we also pick up the provided author provided by the cronjob for later use as part of a subject.