### PR TITLE
Only extract additional attributes from query when doing a raw search

### DIFF
--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -149,8 +149,7 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 
 	public function queryCardsByBoards(array $boardIds): IQueryBuilder {
 		$qb = $this->db->getQueryBuilder();
-		$qb->select('c.*', 's.board_id')
-			->selectAlias('s.title', 'stack_title')
+		$qb->select('c.*')
 			->from('deck_cards', 'c')
 			->innerJoin('c', 'deck_stacks', 's', $qb->expr()->eq('s.id', 'c.stack_id'))
 			->andWhere($qb->expr()->in('s.board_id', $qb->createNamedParameter($boardIds, IQueryBuilder::PARAM_INT_ARRAY)));
@@ -281,7 +280,9 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 	}
 
 	public function searchRaw($boardIds, $term, $limit = null, $offset = null) {
-		$qb = $this->queryCardsByBoards($boardIds);
+		$qb = $this->queryCardsByBoards($boardIds)
+			->select('s.board_id', 'board_id')
+			->selectAlias('s.title', 'stack_title');
 		$qb->andWhere($qb->expr()->eq('c.deleted_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
 		$qb->andWhere(
 			$qb->expr()->orX(


### PR DESCRIPTION
Otherwise the regular search method fails when tying to wrap the result into the entity on the unified search endpoint.

Fixes #2841 