### PR TITLE
Fix codemirror description width

### DIFF
--- a/src/components/card/Description.vue
+++ b/src/components/card/Description.vue
@@ -306,6 +306,7 @@ h5 {
 	padding: 0;
 	background-color: var(--color-main-background);
 	color: var(--color-main-text);
+	width: 100%;
 }
 
 .CodeMirror-placeholder {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/deck/issues/2739
Fixes https://github.com/nextcloud/deck/issues/2617

@aktivde I could not reproduce the exact same case but a similar one when having the browser zommed in to anything >100%