### PR TITLE
Fix unified comments search with postgres

### DIFF
--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -321,7 +321,7 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 		$this->extendQueryByFilter($qb, $query);
 
 		$qb->innerJoin('c', 'comments', 'comments', $qb->expr()->andX(
-			$qb->expr()->eq('comments.object_id', 'c.id', IQueryBuilder::PARAM_STR),
+			$qb->expr()->eq('comments.object_id', $qb->expr()->castColumn('c.id', IQueryBuilder::PARAM_STR)),
 			$qb->expr()->eq('comments.object_type', $qb->createNamedParameter(Application::COMMENT_ENTITY_TYPE, IQueryBuilder::PARAM_STR))
 		));
 		$qb->selectAlias('comments.id', 'comment_id');
@@ -339,7 +339,7 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 			$tokenMatching
 		);
 
-		$qb->groupBy('comments.id');
+		$qb->groupBy('comments.id', 'c.id');
 		$qb->orderBy('comments.id', 'DESC');
 		if ($limit !== null) {
 			$qb->setMaxResults($limit);

--- a/tests/integration/config/behat.yml
+++ b/tests/integration/config/behat.yml
@@ -8,4 +8,5 @@ default:
             baseUrl:  http://localhost:8080/
         - RequestContext
         - BoardContext
+        - CommentContext
         - SearchContext

--- a/tests/integration/features/bootstrap/BoardContext.php
+++ b/tests/integration/features/bootstrap/BoardContext.php
@@ -27,6 +27,10 @@ class BoardContext implements Context {
 		$this->serverContext = $environment->getContext('ServerContext');
 	}
 
+	public function getLastUsedCard() {
+		return $this->card;
+	}
+
 	/**
 	 * @Given /^creates a board named "([^"]*)" with color "([^"]*)"$/
 	 */

--- a/tests/integration/features/bootstrap/CommentContext.php
+++ b/tests/integration/features/bootstrap/CommentContext.php
@@ -1,0 +1,31 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+class CommentContext implements Context {
+	use RequestTrait;
+
+	/** @var BoardContext */
+	protected $boardContext;
+
+	/** @BeforeScenario */
+	public function gatherContexts(BeforeScenarioScope $scope) {
+		$environment = $scope->getEnvironment();
+
+		$this->boardContext = $environment->getContext('BoardContext');
+	}
+
+	/**
+	 * @Given /^post a comment with content "([^"]*)" on the card$/
+	 */
+	public function postACommentWithContentOnTheCard($content) {
+		$card = $this->boardContext->getLastUsedCard();
+		$this->requestContext->sendOCSRequest('POST', '/apps/deck/api/v1.0/cards/' . $card['id'] . '/comments', [
+			'message' => $content,
+			'parentId' => null
+		]);
+	}
+}

--- a/tests/integration/features/search.feature
+++ b/tests/integration/features/search.feature
@@ -257,3 +257,10 @@ Feature: Searching for cards
     Then the card "Example task 1" is not found
     And the card "Labeled card" is not found
     And the card "Multi labeled card" is found
+
+  Scenario: Search for a card comment
+    Given create a card named "Card with comment"
+    And post a comment with content "My first comment" on the card
+    When searching for "My first comment" in comments in unified search
+    Then the comment with "My first comment" is found
+    Then the comment with "Any other" is not found


### PR DESCRIPTION
- [x] First commit should fail to reproduce #2988 on postgres https://github.com/nextcloud/deck/runs/2360374162
- [x] Second commit should fix by doing an implicit cast on the column, integration tests run against all db backends, though oracle support is pending in #2972 