### PR TITLE
Do not query the lookupserver when looking for sharees

### DIFF
--- a/src/store/main.js
+++ b/src/store/main.js
@@ -420,6 +420,7 @@ export default new Vuex.Store({
 			params.append('format', 'json')
 			params.append('perPage', 20)
 			params.append('itemType', [0, 1, 4, 7])
+			params.append('lookup', false)
 
 			const response = await axios.get(generateOcsUrl('apps/files_sharing/api/v1/sharees'), { params })
 			commit('setSharees', response.data.ocs.data)


### PR DESCRIPTION
There is no handling in deck for remote shares as of now so querying the lookupserver doesn't make sense.