### PR TITLE
Do not use custom resolve order

### DIFF
--- a/webpack.js
+++ b/webpack.js
@@ -16,10 +16,6 @@ const config = {
 	},
 	resolve: {
 		extensions: ['*', '.js', '.vue', '.json'],
-		modules: [
-			path.resolve(__dirname, 'node_modules'),
-			'node_modules',
-		],
 	},
 	stats: {
 		context: path.resolve(__dirname, 'src'),


### PR DESCRIPTION
Fixes a regression caused by #2962 and we should first attempt to use the dependencies package version as it is the default