### PR TITLE
Allow searching for filters without a query to match all that have a given filter set

### DIFF
--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -383,6 +383,10 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 		foreach ($query->getDuedate() as $duedate) {
 			$dueDateColumn = $this->databaseType === 'sqlite3' ? $qb->createFunction('DATETIME(`c`.`duedate`)') : 'c.duedate';
 			$date = $duedate->getValue();
+			if ($date === "") {
+				$qb->andWhere($qb->expr()->isNotNull('c.duedate'));
+				continue;
+			}
 			$supportedFilters = ['overdue', 'today', 'week', 'month', 'none'];
 			if (in_array($date, $supportedFilters, true)) {
 				$currentDate = new DateTime();
@@ -430,6 +434,10 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 			foreach ($query->getAssigned() as $index => $assignment) {
 				$qb->innerJoin('c', 'deck_assigned_users', 'au' . $index, $qb->expr()->eq('c.id', 'au' . $index . '.card_id'));
 				$assignedQueryValue = $assignment->getValue();
+				if ($assignedQueryValue === "") {
+					$qb->andWhere($qb->expr()->isNotNull('au' . $index . '.participant'));
+					continue;
+				}
 				$searchUsers = $this->userManager->searchDisplayName($assignment->getValue());
 				$users = array_filter($searchUsers, function (IUser $user) use ($assignedQueryValue) {
 					return (mb_strtolower($user->getDisplayName()) === mb_strtolower($assignedQueryValue) || $user->getUID() === $assignedQueryValue);

--- a/lib/Search/Query/AQueryParameter.php
+++ b/lib/Search/Query/AQueryParameter.php
@@ -37,7 +37,7 @@ class AQueryParameter {
 	
 	public function getValue() {
 		if (is_string($this->value) && mb_strlen($this->value) > 1) {
-			$param = ($this->value[0] === '"' && $this->value[mb_strlen($this->value) - 1] === '"') ? mb_substr($this->value, 1, -1): $this->value;
+			$param = (mb_substr($this->value, 0, 1) === '"' && mb_substr($this->value, -1, 1) === '"') ? mb_substr($this->value, 1, -1): $this->value;
 			return $param;
 		}
 		return $this->value;

--- a/src/store/card.js
+++ b/src/store/card.js
@@ -97,19 +97,34 @@ export default {
 						return q
 					}
 					for (const match of matches) {
-						let [filter, query] = match.indexOf(':') !== -1 ? match.split(/:(.+)/) : [null, match]
+						let [filter, query] = match.indexOf(':') !== -1 ? match.split(/:(.*)/) : [null, match]
+						const isEmptyQuery = typeof query === 'undefined' || filterOutQuotes(query) === ''
 
 						if (filter === 'title') {
+							if (isEmptyQuery) {
+								continue
+							}
 							hasMatch = hasMatch && card.title.toLowerCase().includes(filterOutQuotes(query).toLowerCase())
 						} else if (filter === 'description') {
+							if (isEmptyQuery) {
+								hasMatch = hasMatch && !!card.description
+								continue
+							}
 							hasMatch = hasMatch && card.description.toLowerCase().includes(filterOutQuotes(query).toLowerCase())
 						} else if (filter === 'list') {
-							const stack = this.getters.stackById(card.stackId)
+							if (isEmptyQuery) {
+								continue
+							}
+							const stack = getters.stackById(card.stackId)
 							if (!stack) {
 								return false
 							}
 							hasMatch = hasMatch && stack.title.toLowerCase().includes(filterOutQuotes(query).toLowerCase())
 						} else if (filter === 'tag') {
+							if (isEmptyQuery) {
+								hasMatch = hasMatch && card.labels.length > 0
+								continue
+							}
 							hasMatch = hasMatch && card.labels.findIndex((label) => label.title.toLowerCase().includes(filterOutQuotes(query).toLowerCase())) !== -1
 						} else if (filter === 'date') {
 							const datediffHour = ((new Date(card.duedate) - new Date()) / 3600 / 1000)
@@ -158,6 +173,10 @@ export default {
 							}
 
 						} else if (filter === 'assigned') {
+							if (isEmptyQuery) {
+								hasMatch = hasMatch && card.assignedUsers.length > 0
+								continue
+							}
 							hasMatch = hasMatch && card.assignedUsers.findIndex((assignment) => {
 								return assignment.participant.primaryKey.toLowerCase() === filterOutQuotes(query).toLowerCase()
 									|| assignment.participant.displayname.toLowerCase() === filterOutQuotes(query).toLowerCase()

--- a/src/store/card.js
+++ b/src/store/card.js
@@ -92,7 +92,7 @@ export default {
 
 					const filterOutQuotes = (q) => {
 						if (q[0] === '"' && q[q.length - 1] === '"') {
-							return q.substr(1, -1)
+							return q.substr(1, q.length - 2)
 						}
 						return q
 					}

--- a/tests/unit/Search/Query/AQueryParameterTest.php
+++ b/tests/unit/Search/Query/AQueryParameterTest.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * @copyright Copyright (c) 2021 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Deck\Search\Query;
+
+use PHPUnit\Framework\TestCase;
+
+class AQueryParameterTest extends TestCase {
+	public function dataValue() {
+		return [
+			['foo', 'foo'],
+			['spätial character', 'spätial character'],
+			['"spätial character"', 'spätial character'],
+			['"spätial "character"', 'spätial "character'],
+			['"spätial 🐘"', 'spätial 🐘'],
+			['\'spätial character\'', '\'spätial character\''],
+		];
+	}
+
+	/** @dataProvider dataValue */
+	public function testValue($input, $expectedValue) {
+		$parameter = new StringQueryParameter('test', 0, $input);
+		$this->assertEquals($expectedValue, $parameter->getValue());
+	}
+}


### PR DESCRIPTION
- Allow searching for filters without a query to match all that have a given filter set (e.g. `tag:` will list all cards with a tag assigned)
- Fix handling of quotes due to an off by one error
- Catch canceled tokens and make sure the UI does end up in a stale state
- Show loading indicator when requests are pending where the placeholder might be hidden in the non-visible area