### PR TITLE
Catch any error during circle detail fetching

### DIFF
--- a/lib/Db/BoardMapper.php
+++ b/lib/Db/BoardMapper.php
@@ -25,9 +25,9 @@ namespace OCA\Deck\Db;
 
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IDBConnection;
-use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\IGroupManager;
+use Psr\Log\LoggerInterface;
 
 class BoardMapper extends DeckMapper implements IPermissionMapper {
 	private $labelMapper;
@@ -35,6 +35,7 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 	private $stackMapper;
 	private $userManager;
 	private $groupManager;
+	private $logger;
 
 	private $circlesEnabled;
 
@@ -44,7 +45,8 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 		AclMapper $aclMapper,
 		StackMapper $stackMapper,
 		IUserManager $userManager,
-		IGroupManager $groupManager
+		IGroupManager $groupManager,
+		LoggerInterface $logger
 	) {
 		parent::__construct($db, 'deck_boards', Board::class);
 		$this->labelMapper = $labelMapper;
@@ -52,6 +54,7 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 		$this->stackMapper = $stackMapper;
 		$this->userManager = $userManager;
 		$this->groupManager = $groupManager;
+		$this->logger = $logger;
 
 		$this->circlesEnabled = \OC::$server->getAppManager()->isEnabledForUser('circles');
 	}
@@ -248,7 +251,7 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 				if ($user !== null) {
 					return new User($user);
 				}
-				\OC::$server->getLogger()->debug('User ' . $acl->getId() . ' not found when mapping acl ' . $acl->getParticipant());
+				$this->logger->debug('User ' . $acl->getId() . ' not found when mapping acl ' . $acl->getParticipant());
 				return null;
 			}
 			if ($acl->getType() === Acl::PERMISSION_TYPE_GROUP) {
@@ -256,7 +259,7 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 				if ($group !== null) {
 					return new Group($group);
 				}
-				\OC::$server->getLogger()->debug('Group ' . $acl->getId() . ' not found when mapping acl ' . $acl->getParticipant());
+				$this->logger->debug('Group ' . $acl->getId() . ' not found when mapping acl ' . $acl->getParticipant());
 				return null;
 			}
 			if ($acl->getType() === Acl::PERMISSION_TYPE_CIRCLE) {
@@ -268,11 +271,12 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 					if ($circle) {
 						return new Circle($circle);
 					}
-				} catch (\Exception $e) {
+				} catch (\Throwable $e) {
+					$this->logger->error('Failed to get circle details when building ACL', ['exception' => $e]);
 				}
 				return null;
 			}
-			\OC::$server->getLogger()->log(ILogger::WARN, 'Unknown permission type for mapping acl ' . $acl->getId());
+			$this->logger->warning('Unknown permission type for mapping acl ' . $acl->getId());
 			return null;
 		});
 	}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -105,7 +105,8 @@
     <ParamNameMismatch occurrences="1">
       <code>$boardId</code>
     </ParamNameMismatch>
-    <UndefinedClass occurrences="1">
+    <UndefinedClass occurrences="2">
+      <code>\OCA\Circles\Api\v1\Circles</code>
       <code>\OCA\Circles\Api\v1\Circles</code>
     </UndefinedClass>
   </file>
@@ -170,20 +171,12 @@
       <code>$stackId</code>
     </ParamNameMismatch>
   </file>
-  <file src="lib/Notification/NotificationHelper.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>$board-&gt;getId()</code>
-    </InvalidScalarArgument>
-  </file>
   <file src="lib/Notification/Notifier.php">
-    <RedundantCast occurrences="7">
+    <RedundantCast occurrences="4">
       <code>(string) $l-&gt;t('%s has mentioned you in a comment on "%s".', [$dn, $params[0]])</code>
       <code>(string) $l-&gt;t('The board "%s" has been shared with you by %s.', [$params[0], $dn])</code>
       <code>(string) $l-&gt;t('The card "%s" on "%s" has been assigned to you by %s.', [$params[0], $params[1], $dn])</code>
       <code>(string) $l-&gt;t('The card "%s" on "%s" has reached its due date.', $params)</code>
-      <code>(string) $l-&gt;t('{user} has assigned the card "%s" on "%s" to you.', [$params[0], $params[1]])</code>
-      <code>(string) $l-&gt;t('{user} has mentioned you in a comment on "%s".', [$params[0]])</code>
-      <code>(string) $l-&gt;t('{user} has shared the board %s with you.', [$params[0]])</code>
     </RedundantCast>
   </file>
   <file src="lib/Provider/DeckProvider.php">
@@ -196,12 +189,6 @@
       <code>$cardId</code>
       <code>$cardId</code>
     </InvalidScalarArgument>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;currentUser</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="1">
-      <code>$this-&gt;currentUser</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="lib/Service/BoardService.php">
     <TooManyArguments occurrences="2">
@@ -265,7 +252,6 @@
     </RedundantCondition>
   </file>
   <file src="lib/Service/FilesAppService.php">
-    <InvalidCatch occurrences="1"/>
     <MissingDependency occurrences="4">
       <code>$this-&gt;rootFolder</code>
       <code>$this-&gt;rootFolder</code>
@@ -278,13 +264,6 @@
       <code>\OCA\Circles\Api\v1\Circles</code>
       <code>\OCA\Circles\Api\v1\Circles</code>
     </UndefinedClass>
-  </file>
-  <file src="lib/Service/SearchService.php">
-    <UndefinedThisPropertyFetch occurrences="3">
-      <code>$this-&gt;l10n</code>
-      <code>$this-&gt;urlGenerator</code>
-      <code>$this-&gt;userManager</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="lib/Service/StackService.php">
     <UndefinedClass occurrences="1">

--- a/tests/unit/Db/AclMapperTest.php
+++ b/tests/unit/Db/AclMapperTest.php
@@ -25,6 +25,7 @@ namespace OCA\Deck\Db;
 
 use OCP\IGroupManager;
 use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
 use Test\AppFramework\Db\MapperTestUtility;
 
 /**
@@ -54,7 +55,8 @@ class AclMapperTest extends MapperTestUtility {
 			$this->aclMapper,
 			\OC::$server->query(StackMapper::class),
 			$this->userManager,
-			$this->groupManager
+			$this->groupManager,
+			$this->createMock(LoggerInterface::class)
 		);
 
 		$this->boards = [

--- a/tests/unit/Db/BoardMapperTest.php
+++ b/tests/unit/Db/BoardMapperTest.php
@@ -26,6 +26,7 @@ namespace OCA\Deck\Db;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
 use Test\AppFramework\Db\MapperTestUtility;
 
 /**
@@ -61,7 +62,8 @@ class BoardMapperTest extends MapperTestUtility {
 			\OC::$server->query(AclMapper::class),
 			\OC::$server->query(StackMapper::class),
 			$this->userManager,
-			$this->groupManager
+			$this->groupManager,
+			$this->createMock(LoggerInterface::class)
 		);
 		$this->aclMapper = \OC::$server->query(AclMapper::class);
 		$this->labelMapper = \OC::$server->query(LabelMapper::class);


### PR DESCRIPTION
Make sure that deck continues to work even if there are issues with getting the circle details. The circles issue is fixed with https://github.com/nextcloud/circles/pull/577

Fixes https://github.com/nextcloud/deck/issues/3029
Fixes https://github.com/nextcloud/deck/issues/3024
Fixes https://github.com/nextcloud/deck/issues/3027