### PR TITLE
Get attachment from the user node instead of the share source

### DIFF
--- a/lib/Service/FilesAppService.php
+++ b/lib/Service/FilesAppService.php
@@ -125,7 +125,11 @@ class FilesAppService implements IAttachmentService, ICustomAttachmentService {
 	public function extendData(Attachment $attachment) {
 		$userFolder = $this->rootFolder->getUserFolder($this->userId);
 		$share = $this->shareProvider->getShareById($attachment->getId());
-		$file = $share->getNode();
+		$files = $userFolder->getById($share->getNode()->getId());
+		if (count($files) === 0) {
+			return $attachment;
+		}
+		$file = array_shift($files);
 		$attachment->setExtendedData([
 			'path' => $userFolder->getRelativePath($file->getPath()),
 			'fileid' => $file->getId(),


### PR DESCRIPTION
Fixes https://github.com/nextcloud/deck/issues/2997 where the file path was constructed from the original node instead of the node in share recipients user folder.

Steps to reproduce:
- Share a board with a group
- Share a file with the board
- As a member of the group try to open the file in the attachments list