### PR TITLE
[stable1.2] Always fetch attachments

### DIFF
--- a/src/components/card/AttachmentList.vue
+++ b/src/components/card/AttachmentList.vue
@@ -151,8 +151,13 @@ export default {
 			}
 		},
 	},
-	created() {
-		this.$store.dispatch('fetchAttachments', this.cardId)
+	watch: {
+		cardId: {
+			immediate: true,
+			handler() {
+				this.$store.dispatch('fetchAttachments', this.cardId)
+			},
+		},
 	},
 	methods: {
 		handleUploadFile(event) {


### PR DESCRIPTION
Backporting a bugfix that was part of https://github.com/nextcloud/deck/pull/2638 which would also help on the 1.2 release branch to always load the attachment list when switching the sidebar to a different card.