### PR TITLE
Circles 22

### DIFF
--- a/lib/Db/Circle.php
+++ b/lib/Db/Circle.php
@@ -36,8 +36,8 @@ class Circle extends RelationalObject {
 	public function getObjectSerialization() {
 		return [
 			'uid' => $this->object->getUniqueId(),
-			'displayname' => $this->object->getName(),
-			'typeString' => $this->object->getTypeString(),
+			'displayname' => $this->object->getDisplayName(),
+			'typeString' => '',
 			'circleOwner' => $this->object->getOwner(),
 			'type' => 7
 		];

--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -268,7 +268,11 @@ class PermissionService {
 						continue;
 					}
 
-					foreach ($circle->getMembers() as $member) {
+					foreach ($circle->getInheritedMembers() as $member) {
+						if ($member->getUserType() !== 1) {
+							// deck currently only supports user members in circles
+							continue;
+						}
 						$user = $this->userManager->get($member->getUserId());
 						if ($user === null) {
 							$this->logger->info('No user found for circle member ' . $member->getUserId());


### PR DESCRIPTION
Restores compatibility with current circles master branch for Nextcloud 22, but needs some more work before merge as in the end we do not need the typeString anymore at all.

@daita @skjnldsv I assume just showing the displayname for anything related to the circle is fine, right? We used to show the type of the circle (personal/public/...) before next to it but that seems to have been dropped now with 22.