### PR TITLE
Use new viewer syntax with destructuring object

### DIFF
--- a/src/components/card/AttachmentList.vue
+++ b/src/components/card/AttachmentList.vue
@@ -227,7 +227,7 @@ export default {
 		},
 		showViewer(attachment) {
 			if (attachment.extendedData.fileid && window.OCA.Viewer.availableHandlers.map(handler => handler.mimes).flat().includes(attachment.extendedData.mimetype)) {
-				window.OCA.Viewer.open(attachment.extendedData.path)
+				window.OCA.Viewer.open({ path: attachment.extendedData.path })
 				return
 			}
 


### PR DESCRIPTION
Signed-off-by: Azul <azul@riseup.net>

* Target version: master 

### Summary

With nextcloud/viewer#936 and Nextcloud 22 the old syntax will not be supported anymore.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
