### PR TITLE
Always pass user id in share provider

### DIFF
--- a/lib/Sharing/DeckShareProvider.php
+++ b/lib/Sharing/DeckShareProvider.php
@@ -271,9 +271,9 @@ class DeckShareProvider implements \OCP\Share\IShareProvider {
 		return $share;
 	}
 
-	private function applyBoardPermission($share, $permissions) {
+	private function applyBoardPermission($share, $permissions, $userId) {
 		try {
-			$this->permissionService->checkPermission($this->cardMapper, $share->getSharedWith(), Acl::PERMISSION_EDIT);
+			$this->permissionService->checkPermission($this->cardMapper, $share->getSharedWith(), Acl::PERMISSION_EDIT, $userId);
 		} catch (NoPermissionException $e) {
 			$permissions &= Constants::PERMISSION_ALL - Constants::PERMISSION_UPDATE;
 			$permissions &= Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE;
@@ -281,7 +281,7 @@ class DeckShareProvider implements \OCP\Share\IShareProvider {
 		}
 
 		try {
-			$this->permissionService->checkPermission($this->cardMapper, $share->getSharedWith(), Acl::PERMISSION_SHARE);
+			$this->permissionService->checkPermission($this->cardMapper, $share->getSharedWith(), Acl::PERMISSION_SHARE, $userId);
 		} catch (NoPermissionException $e) {
 			$permissions &= Constants::PERMISSION_ALL - Constants::PERMISSION_SHARE;
 		}
@@ -646,7 +646,7 @@ class DeckShareProvider implements \OCP\Share\IShareProvider {
 			$stmt = $query->execute();
 
 			while ($data = $stmt->fetch()) {
-				$this->applyBoardPermission($shareMap[$data['parent']], (int)$data['permissions']);
+				$this->applyBoardPermission($shareMap[$data['parent']], (int)$data['permissions'], $userId);
 				$shareMap[$data['parent']]->setTarget($data['file_target']);
 			}
 


### PR DESCRIPTION
Make sure the recipient user id is always passed when checking permissions e.g. when the filesystem is setup in a background job where no user session is available.

fixes #3140 