### PR TITLE
Only offer stack creation in emptycontent with proper permissions

### DIFF
--- a/src/components/board/Board.vue
+++ b/src/components/board/Board.vue
@@ -32,7 +32,7 @@
 			</div>
 			<EmptyContent v-else-if="isEmpty" key="empty" icon="icon-deck">
 				{{ t('deck', 'No lists available') }}
-				<template #desc>
+				<template v-if="canManage" #desc>
 					{{ t('deck', 'Create a new list to add cards to this board') }}
 					<form @submit.prevent="addNewStack()">
 						<input id="new-stack-input-main"
@@ -110,6 +110,7 @@ export default {
 		}),
 		...mapGetters([
 			'canEdit',
+			'canManage',
 		]),
 		stacksByBoard() {
 			return this.$store.getters.stacksByBoard(this.board.id)


### PR DESCRIPTION
- Share an empty board with read only
- Open the board as the recipient

This makes sure the input in the empty content view is properly hidden if the user cannot create lists.