### PR TITLE
Reduce duplicate queries when fetching user boards an permissions

### DIFF
--- a/tests/unit/Service/PermissionServiceTest.php
+++ b/tests/unit/Service/PermissionServiceTest.php
@@ -146,7 +146,7 @@ class PermissionServiceTest extends \Test\TestCase {
 	}
 
 	public function testUserIsBoardOwnerNull() {
-		$this->boardMapper->expects($this->once())->method('find')->willReturn(null);
+		$this->boardMapper->expects($this->once())->method('find')->willThrowException(new DoesNotExistException('board does not exist'));
 		$this->assertEquals(false, $this->service->userIsBoardOwner(123));
 	}
 
@@ -225,11 +225,8 @@ class PermissionServiceTest extends \Test\TestCase {
 		$board = new Board();
 		$board->setId($boardId);
 		$board->setOwner($owner);
+		$board->setAcl($this->getAcls($boardId));
 		$this->boardMapper->expects($this->any())->method('find')->willReturn($board);
-
-		// acl check
-		$acls = $this->getAcls($boardId);
-		$this->aclMapper->expects($this->any())->method('findAll')->willReturn($acls);
 
 		$this->shareManager->expects($this->any())
 			->method('sharingDisabledForUser')
@@ -250,14 +247,12 @@ class PermissionServiceTest extends \Test\TestCase {
 		$board = new Board();
 		$board->setId($boardId);
 		$board->setOwner($owner);
+		$board->setAcl($this->getAcls($boardId));
 		if ($boardId === null) {
 			$this->boardMapper->expects($this->any())->method('find')->willThrowException(new DoesNotExistException('not found'));
 		} else {
 			$this->boardMapper->expects($this->any())->method('find')->willReturn($board);
 		}
-		$acls = $this->getAcls($boardId);
-		$this->aclMapper->expects($this->any())->method('findAll')->willReturn($acls);
-
 
 		if ($result) {
 			$actual = $this->service->checkPermission($mapper, 1234, $permission);


### PR DESCRIPTION
First step to reduce the amounts of queries that happened during collecting incoming shares when setting up the filesystem for users.

Already gives quite some improvement in test setup with 1 shared board having 3 cards with a handful of attachments on each:
https://blackfire.io/profiles/compare/67ec272e-9530-491b-afb2-0fb2c9b06f59/graph

![image](https://user-images.githubusercontent.com/3404133/124269317-05b16f80-db3b-11eb-8f08-35ce41ab846b.png)
