### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,13 @@ updates:
     versions:
     - "< 16"
     - ">= 15.a"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "03:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 10
+  reviewers:
+  - juliushaertl

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,7 +39,7 @@ updates:
     versions:
     - "< 16"
     - ">= 15.a"
-- package-ecosystem: "github-actions"
+- package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: weekly


### PR DESCRIPTION
This change instructs Dependabot to create pull request on GitHub Action Updates.

See it in action: https://github.com/splitt3r/deck/pulls

Signed-off-by: splitt3r <splitt3r@users.noreply.github.com>