### PR TITLE
Move circle checks to a unified service and improve member checks

### DIFF
--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.7.3@38c452ae584467e939d55377aaf83b5a26f19dd1">
+<files psalm-version="4.8.1@f73f2299dbc59a3e6c4d66cff4605176e728ee69">
   <file src="lib/Activity/ActivityManager.php">
     <TypeDoesNotContainType occurrences="1">
       <code>$message !== null</code>
@@ -147,8 +147,7 @@
     <UndefinedClass occurrences="1">
       <code>\OCA\Circles\Model\Circle</code>
     </UndefinedClass>
-    <UndefinedDocblockClass occurrences="5">
-      <code>$this-&gt;object</code>
+    <UndefinedDocblockClass occurrences="4">
       <code>$this-&gt;object</code>
       <code>$this-&gt;object</code>
       <code>$this-&gt;object</code>
@@ -202,10 +201,12 @@
     </UndefinedDocblockClass>
   </file>
   <file src="lib/Service/CirclesService.php">
-    <UndefinedClass occurrences="2">
-      <code>\OCA\Circles\Api\v1\Circles</code>
+    <UndefinedClass occurrences="1">
       <code>\OCA\Circles\Api\v1\Circles</code>
     </UndefinedClass>
+    <UndefinedDocblockClass occurrences="1">
+      <code>$circlesManager</code>
+    </UndefinedDocblockClass>
   </file>
   <file src="lib/Service/CommentService.php">
     <UndefinedThisPropertyAssignment occurrences="2">
@@ -258,7 +259,7 @@
   </file>
   <file src="lib/Service/PermissionService.php">
     <UndefinedClass occurrences="2">
-      <code>\OCA\Circles\Api\v1\Circles</code>
+      <code>Member</code>
       <code>\OCA\Circles\Api\v1\Circles</code>
     </UndefinedClass>
   </file>

--- a/tests/unit/Service/PermissionServiceTest.php
+++ b/tests/unit/Service/PermissionServiceTest.php
@@ -35,6 +35,7 @@ use OCP\IConfig;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\ILogger;
+use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Share\IManager;
@@ -62,7 +63,9 @@ class PermissionServiceTest extends \Test\TestCase {
 
 	public function setUp(): void {
 		parent::setUp();
-		$this->logger = $this->request = $this->createMock(ILogger::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->request = $this->createMock(IRequest::class);
+		$this->circlesService = $this->createMock(CirclesService::class);
 		$this->aclMapper = $this->createMock(AclMapper::class);
 		$this->boardMapper = $this->createMock(BoardMapper::class);
 		$this->userManager = $this->createMock(IUserManager::class);
@@ -72,6 +75,7 @@ class PermissionServiceTest extends \Test\TestCase {
 
 		$this->service = new PermissionService(
 			$this->logger,
+			$this->circlesService,
 			$this->aclMapper,
 			$this->boardMapper,
 			$this->userManager,


### PR DESCRIPTION
Some improvements in reducing the amount of old Circles APIs being called and unifying their use through a service class.