### PR TITLE
Delete file shares through attachments API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -959,6 +959,7 @@ For now only `deck_file` is supported as an attachment type.
 
 ### DELETE /boards/{boardId}/stacks/{stackId}/cards/{cardId}/attachments/{attachmentId} - Delete an attachment
 
+    
 #### Request parameters
 
 | Parameter    | Type    | Description                                   |

--- a/src/components/card/AttachmentList.vue
+++ b/src/components/card/AttachmentList.vue
@@ -22,7 +22,7 @@
 
 <template>
 	<AttachmentDragAndDrop :card-id="cardId" class="drop-upload--sidebar">
-		<div class="button-group">
+		<div class="button-group" v-if="!isReadOnly">
 			<button class="icon-upload" @click="uploadNewFile()">
 				{{ t('deck', 'Upload new files') }}
 			</button>
@@ -49,18 +49,25 @@
 			</li>
 			<li v-for="attachment in attachments"
 				:key="attachment.id"
-				class="attachment">
+				class="attachment"
+				:class="{ 'attachment--deleted': attachment.deletedAt > 0 }">
 				<a class="fileicon"
+					:href="internalLink(attachment)"
 					:style="mimetypeForAttachment(attachment)"
 					@click.prevent="showViewer(attachment)" />
 				<div class="details">
-					<a @click.prevent="showViewer(attachment)">
+					<a :href="internalLink(attachment)" @click.prevent="showViewer(attachment)">
 						<div class="filename">
 							<span class="basename">{{ attachment.data }}</span>
 						</div>
-						<span class="filesize">{{ formattedFileSize(attachment.extendedData.filesize) }}</span>
-						<span class="filedate">{{ relativeDate(attachment.createdAt*1000) }}</span>
-						<span class="filedate">{{ attachment.createdBy }}</span>
+						<div v-if="attachment.deletedAt === 0">
+							<span class="filesize">{{ formattedFileSize(attachment.extendedData.filesize) }}</span>
+							<span class="filedate">{{ relativeDate(attachment.createdAt*1000) }}</span>
+							<span class="filedate">{{ attachment.createdBy }}</span>
+						</div>
+						<div v-else>
+							<span class="attachment--info">{{ t('deck', 'Pending share') }}</span>
+						</div>
 					</a>
 				</div>
 				<Actions v-if="selectable">
@@ -68,12 +75,12 @@
 						{{ t('deck', 'Add this attachment') }}
 					</ActionButton>
 				</Actions>
-				<Actions v-if="removable" :force-menu="true">
+				<Actions v-if="removable && !isReadOnly" :force-menu="true">
 					<ActionLink v-if="attachment.extendedData.fileid" icon="icon-folder" :href="internalLink(attachment)">
 						{{ t('deck', 'Show in Files') }}
 					</ActionLink>
-					<ActionButton v-if="attachment.extendedData.fileid" icon="icon-delete" @click="unshareAttachment(attachment)">
-						{{ t('deck', 'Unshare file') }}
+					<ActionButton v-if="attachment.extendedData.fileid && !isReadOnly" icon="icon-delete" @click="unshareAttachment(attachment)">
+						{{ t('deck', 'Remove attachment') }}
 					</ActionButton>
 
 					<ActionButton v-if="!attachment.extendedData.fileid && attachment.deletedAt === 0" icon="icon-delete" @click="$emit('delete-attachment', attachment)">
@@ -143,6 +150,7 @@ export default {
 	},
 	computed: {
 		attachments() {
+			// FIXME sort propertly by last modified / deleted at
 			return [...this.$store.getters.attachmentsByCard(this.cardId)].filter(attachment => attachment.deletedAt >= 0).sort((a, b) => b.id - a.id)
 		},
 		mimetypeForAttachment() {
@@ -320,9 +328,10 @@ export default {
 					opacity: 0.7;
 				}
 			}
+			.attachment--info,
 			.filesize, .filedate {
 				font-size: 90%;
-				color: darkgray;
+				color: var(--color-text-maxcontrast);
 			}
 			.app-popover-menu-utils {
 				position: relative;


### PR DESCRIPTION
Previously the file was deleted in the file structure of the user is not
expected as the file might not only be related to the card.

Fixes https://github.com/nextcloud/deck/issues/2877
