### PR TITLE
Extend drag-and-drop zone in card sidebar

### DIFF
--- a/src/components/AttachmentDragAndDrop.vue
+++ b/src/components/AttachmentDragAndDrop.vue
@@ -131,6 +131,12 @@ export default {
 		position: relative;
 	}
 
+	.attachments-drag-zone.drop-upload--sidebar {
+		display: flex;
+		flex-direction: column;
+		flex-basis: 100%;
+	}
+
 	.dragover {
 		position: absolute;
 		background: var(--color-primary-light);

--- a/src/components/card/CardSidebar.vue
+++ b/src/components/card/CardSidebar.vue
@@ -185,6 +185,13 @@ export default {
 
 <style lang="scss" scoped>
 
+	section.app-sidebar__tab--active {
+		min-height: auto;
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+	}
+
 	// FIXME: Obivously we should at some point not randomly reuse the sidebar component
 	// since this is not oficially supported
 	.modal__card .app-sidebar {
@@ -212,12 +219,6 @@ export default {
 				margin: 0;
 				z-index: 100;
 				background-color: var(--color-main-background);
-			}
-
-			section.app-sidebar__tab--active {
-				min-height: auto;
-				display: flex;
-				flex-direction: column;
 			}
 
 			#emptycontent, .emptycontent {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/deck/issues/3230
* Target version: master 

### Summary
Add properties to .attachments-drag-zone and its parent element 

<b>Before:</b>

![Before](https://user-images.githubusercontent.com/72407830/133741059-9333c7eb-50dc-4c7c-9065-0ef9c25a2b7b.gif)

<b>After:</b>

![After](https://user-images.githubusercontent.com/72407830/133741084-d1d472bc-87cc-495e-afac-c6406e34689f.gif)

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
