### PR TITLE
add board categories

### DIFF
--- a/lib/Controller/BoardApiController.php
+++ b/lib/Controller/BoardApiController.php
@@ -118,11 +118,13 @@ class BoardApiController extends ApiController {
 	 * @params $title
 	 * @params $color
 	 * @params $archived
+	 * @params $category
 	 *
-	 * Update a board with the specified boardId, title and color, and archived state.
+	 * Update a board with the specified boardId.
 	 */
-	public function update($title, $color, $archived = false) {
-		$board = $this->boardService->update($this->request->getParam('boardId'), $title, $color, $archived);
+	public function update($title, $color, $archived = false, $category = null) {
+		$board = $this->boardService->
+			update($this->request->getParam('boardId'), $title, $color, $archived, $category);
 		return new DataResponse($board, HTTP::STATUS_OK);
 	}
 

--- a/lib/Controller/BoardController.php
+++ b/lib/Controller/BoardController.php
@@ -31,7 +31,12 @@ use OCP\IRequest;
 
 class BoardController extends ApiController {
 	private $userId;
+
+	/**
+	 * @var BoardService
+	 */
 	private $boardService;
+
 	private $permissionService;
 
 	public function __construct($appName, IRequest $request, BoardService $boardService, PermissionService $permissionService, $userId) {
@@ -73,10 +78,11 @@ class BoardController extends ApiController {
 	 * @param $title
 	 * @param $color
 	 * @param $archived
+	 * @param $category
 	 * @return \OCP\AppFramework\Db\Entity
 	 */
-	public function update($id, $title, $color, $archived) {
-		return $this->boardService->update($id, $title, $color, $archived);
+	public function update($id, $title, $color, $archived, $category = null) {
+		return $this->boardService->update($id, $title, $color, $archived, $category);
 	}
 
 	/**
@@ -150,7 +156,7 @@ class BoardController extends ApiController {
 	/**
 	 * @NoAdminRequired
 	 * @param $boardId
-	 * @return \OCP\Deck\DB\Board
+	 * @return \OCA\Deck\Db\Board
 	 */
 	public function clone($boardId) {
 		return $this->boardService->clone($boardId, $this->userId);

--- a/lib/Db/Board.php
+++ b/lib/Db/Board.php
@@ -36,6 +36,7 @@ class Board extends RelationalEntity {
 	protected $stacks = [];
 	protected $deletedAt = 0;
 	protected $lastModified = 0;
+	protected $category = null;
 
 	protected $settings = [];
 

--- a/lib/Db/BoardMapper.php
+++ b/lib/Db/BoardMapper.php
@@ -75,7 +75,7 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 	 * @throws DoesNotExistException
 	 */
 	public function find($id, $withLabels = false, $withAcl = false) {
-		$sql = 'SELECT id, title, owner, color, archived, deleted_at, last_modified FROM `*PREFIX*deck_boards` ' .
+		$sql = 'SELECT id, title, owner, color, archived, deleted_at, last_modified, category FROM `*PREFIX*deck_boards` ' .
 			'WHERE `id` = ?';
 		$board = $this->findEntity($sql, [$id]);
 
@@ -122,12 +122,12 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 	 */
 	public function findAllByUser($userId, $limit = null, $offset = null, $since = -1, $includeArchived = true) {
 		// FIXME: One moving to QBMapper we should allow filtering the boards probably by method chaining for additional where clauses
-		$sql = 'SELECT id, title, owner, color, archived, deleted_at, 0 as shared, last_modified FROM `*PREFIX*deck_boards` WHERE owner = ? AND last_modified > ?';
+		$sql = 'SELECT id, title, owner, color, archived, deleted_at, 0 as shared, last_modified, category FROM `*PREFIX*deck_boards` WHERE owner = ? AND last_modified > ?';
 		if (!$includeArchived) {
 			$sql .= ' AND NOT archived AND deleted_at = 0';
 		}
 		$sql .= ' UNION ' .
-			'SELECT boards.id, title, owner, color, archived, deleted_at, 1 as shared, last_modified FROM `*PREFIX*deck_boards` as boards ' .
+			'SELECT boards.id, title, owner, color, archived, deleted_at, 1 as shared, last_modified, category FROM `*PREFIX*deck_boards` as boards ' .
 			'JOIN `*PREFIX*deck_board_acl` as acl ON boards.id=acl.board_id WHERE acl.participant=? AND acl.type=? AND boards.owner != ? AND last_modified > ?';
 		if (!$includeArchived) {
 			$sql .= ' AND NOT archived AND deleted_at = 0';
@@ -159,7 +159,7 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 		if (count($groups) <= 0) {
 			return [];
 		}
-		$sql = 'SELECT boards.id, title, owner, color, archived, deleted_at, 2 as shared, last_modified FROM `*PREFIX*deck_boards` as boards ' .
+		$sql = 'SELECT boards.id, title, owner, color, archived, deleted_at, 2 as shared, last_modified, category FROM `*PREFIX*deck_boards` as boards ' .
 			'INNER JOIN `*PREFIX*deck_board_acl` as acl ON boards.id=acl.board_id WHERE owner != ? AND type=? AND (';
 		for ($i = 0, $iMax = count($groups); $i < $iMax; $i++) {
 			$sql .= 'acl.participant = ? ';
@@ -191,7 +191,7 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 			return [];
 		}
 
-		$sql = 'SELECT boards.id, title, owner, color, archived, deleted_at, 2 as shared, last_modified FROM `*PREFIX*deck_boards` as boards ' .
+		$sql = 'SELECT boards.id, title, owner, color, archived, deleted_at, 2 as shared, last_modified, category FROM `*PREFIX*deck_boards` as boards ' .
 			'INNER JOIN `*PREFIX*deck_board_acl` as acl ON boards.id=acl.board_id WHERE owner != ? AND type=? AND (';
 		for ($i = 0, $iMax = count($circles); $i < $iMax; $i++) {
 			$sql .= 'acl.participant = ? ';
@@ -220,7 +220,7 @@ class BoardMapper extends DeckMapper implements IPermissionMapper {
 	public function findToDelete() {
 		// add buffer of 5 min
 		$timeLimit = time() - (60 * 5);
-		$sql = 'SELECT id, title, owner, color, archived, deleted_at, last_modified FROM `*PREFIX*deck_boards` ' .
+		$sql = 'SELECT id, title, owner, color, archived, deleted_at, last_modified, category FROM `*PREFIX*deck_boards` ' .
 			'WHERE `deleted_at` > 0 AND `deleted_at` < ?';
 		return $this->findEntities($sql, [$timeLimit]);
 	}

--- a/lib/Migration/Version1600Date20210904194623.php
+++ b/lib/Migration/Version1600Date20210904194623.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @copyright Copyright (c) 2021 Michael Weimann <mail@michael-weimann.eu>
+ * @author Michael Weimann <mail@michael-weimann.eu>
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Deck\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1600Date20210904194623 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$boardsTable = $schema->getTable('deck_boards');
+
+		$boardsTable->addColumn('category', 'string', [
+			'notnull' => false,
+			'length' => 50,
+		]);
+
+		$boardsTable->addIndex(['category'], 'deck_boards_category_idx');
+
+		return $schema;
+	}
+}

--- a/lib/Service/BoardService.php
+++ b/lib/Service/BoardService.php
@@ -411,7 +411,7 @@ class BoardService {
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 * @throws BadRequestException
 	 */
-	public function update($id, $title, $color, $archived) {
+	public function update($id, $title, $color, $archived, $category) {
 		if (is_numeric($id) === false) {
 			throw new BadRequestException('board id must be a number');
 		}
@@ -434,6 +434,7 @@ class BoardService {
 		$board->setTitle($title);
 		$board->setColor($color);
 		$board->setArchived($archived);
+		$board->setCategory(empty($category) ? null : $category);
 		$changes->setAfter($board);
 		$this->boardMapper->update($board); // operate on clone so we can check for updated fields
 		$this->boardMapper->mapOwner($board);
@@ -638,6 +639,7 @@ class BoardService {
 		$newBoard->setTitle($board->getTitle() . ' (' . $this->l10n->t('copy') . ')');
 		$newBoard->setOwner($userId);
 		$newBoard->setColor($board->getColor());
+		$newBoard->setCategory($board->getCategory());
 		$permissions = $this->permissionService->matchPermissions($board);
 		$newBoard->setPermissions([
 			'PERMISSION_READ' => $permissions[Acl::PERMISSION_READ] ?? false,

--- a/src/components/board/BoardSidebar.vue
+++ b/src/components/board/BoardSidebar.vue
@@ -32,8 +32,17 @@
 			<SharingTabSidebar :board="board" />
 		</AppSidebarTab>
 
-		<AppSidebarTab id="tags"
+		<!-- The id cannot simply be "settings" because that would apply some CSS breaking the layout -->
+		<AppSidebarTab v-if="canEdit"
+			id="board-settings"
 			:order="1"
+			:name="t('deck', 'Settings')"
+			icon="icon-settings">
+			<SettingsTabsSidebar :board="board" />
+		</AppSidebarTab>
+
+		<AppSidebarTab id="tags"
+			:order="2"
 			:name="t('deck', 'Tags')"
 			icon="icon-tag">
 			<TagsTabSidebar :board="board" />
@@ -41,7 +50,7 @@
 
 		<AppSidebarTab v-if="canEdit"
 			id="deleted"
-			:order="2"
+			:order="3"
 			:name="t('deck', 'Deleted items')"
 			icon="icon-delete">
 			<DeletedTabSidebar :board="board" />
@@ -49,7 +58,7 @@
 
 		<AppSidebarTab v-if="hasActivity"
 			id="activity"
-			:order="3"
+			:order="4"
 			:name="t('deck', 'Timeline')"
 			icon="icon-activity">
 			<TimelineTabSidebar :board="board" />
@@ -59,6 +68,7 @@
 
 <script>
 import { mapState, mapGetters } from 'vuex'
+import SettingsTabsSidebar from './SettingsTabsSidebar'
 import SharingTabSidebar from './SharingTabSidebar'
 import TagsTabSidebar from './TagsTabSidebar'
 import DeletedTabSidebar from './DeletedTabSidebar'
@@ -72,6 +82,7 @@ export default {
 	components: {
 		AppSidebar,
 		AppSidebarTab,
+		SettingsTabsSidebar,
 		SharingTabSidebar,
 		TagsTabSidebar,
 		DeletedTabSidebar,

--- a/src/components/board/SettingsTabsSidebar.vue
+++ b/src/components/board/SettingsTabsSidebar.vue
@@ -1,0 +1,63 @@
+<template>
+	<div>
+		<label for="settings-category">{{ t('deck', 'Category') }}</label>
+		<Multiselect
+			id="settings-category"
+			v-model="category"
+			:placeholder="t('deck', 'select category')"
+			:options="selectCategories"
+			:taggable="true"
+			:clear-on-select="false"
+			@tag="onNewCategory" />
+	</div>
+</template>
+<script>
+
+import { mapGetters } from 'vuex'
+import { Multiselect } from '@nextcloud/vue'
+
+export default {
+	name: 'SettingsTabsSidebar',
+	components: {
+		Multiselect,
+	},
+	props: {
+		board: {
+			type: Object,
+			default: undefined,
+		},
+	},
+	computed: {
+		...mapGetters(['categories']),
+		selectCategories() {
+			return [this.t('deck', 'uncategorised')].concat(this.categories)
+		},
+		category: {
+			get() {
+				if (!this.board.category) {
+					return this.t('deck', 'uncategorised')
+				}
+				return this.board.category
+			},
+			set(category) {
+				const boardCopy = JSON.parse(JSON.stringify(this.board))
+
+				if (category === this.t('deck', 'uncategorised')) {
+					boardCopy.category = null
+				} else {
+					boardCopy.category = category
+				}
+
+				this.$store.dispatch('updateBoard', boardCopy)
+				this.$store.dispatch('setCurrentBoard', boardCopy)
+			},
+		},
+	},
+	methods: {
+		onNewCategory(category) {
+			this.category = category
+		},
+	},
+}
+
+</script>

--- a/src/components/boards/Boards.vue
+++ b/src/components/boards/Boards.vue
@@ -57,6 +57,10 @@ export default {
 			type: String,
 			default: '',
 		},
+		navFilterCategory: {
+			type: String,
+			default: null,
+		},
 	},
 	computed: {
 		boardsSorted() {
@@ -72,6 +76,9 @@ export default {
 	watch: {
 		navFilter(value) {
 			this.$store.commit('setBoardFilter', value)
+		},
+		navFilterCategory(value) {
+			this.$store.commit('setBoardFilterCategory', value)
 		},
 	},
 }

--- a/src/components/card/AttachmentList.vue
+++ b/src/components/card/AttachmentList.vue
@@ -22,7 +22,7 @@
 
 <template>
 	<AttachmentDragAndDrop :card-id="cardId" class="drop-upload--sidebar">
-		<div class="button-group" v-if="!isReadOnly">
+		<div v-if="!isReadOnly" class="button-group">
 			<button class="icon-upload" @click="uploadNewFile()">
 				{{ t('deck', 'Upload new files') }}
 			</button>

--- a/src/components/navigation/AppNavigation.vue
+++ b/src/components/navigation/AppNavigation.vue
@@ -31,9 +31,17 @@
 			<AppNavigationBoardCategory
 				id="deck-navigation-all"
 				to="/board"
-				:text="t('deck', 'All boards')"
-				:boards="noneArchivedBoards"
+				:text="allBoardsLabel"
+				:boards="nonArchivedUncategorisedBoards"
 				:open-on-add-boards="true"
+				icon="icon-deck" />
+			<AppNavigationBoardCategory
+				v-for="category in nonArchivedBoardCategories"
+				:id="`deck-navigation-cat-${category}`"
+				:key="category"
+				:to="`/board/category/${urlEncode(category)}`"
+				:text="category"
+				:boards="nonArchivedBoardsByCategory[category]"
 				icon="icon-deck" />
 			<AppNavigationBoardCategory
 				id="deck-navigation-archived"
@@ -136,8 +144,11 @@ export default {
 	computed: {
 		...mapGetters([
 			'noneArchivedBoards',
+			'nonArchivedUncategorisedBoards',
 			'archivedBoards',
 			'sharedBoards',
+			'nonArchivedBoardCategories',
+			'nonArchivedBoardsByCategory',
 		]),
 		isAdmin() {
 			return !!getCurrentUser()?.isAdmin
@@ -157,6 +168,13 @@ export default {
 			set(newValue) {
 				this.$store.dispatch('setConfig', { calendar: newValue })
 			},
+		},
+		allBoardsLabel() {
+			if (this.nonArchivedBoardCategories.length > 0) {
+				return this.t('deck', 'Uncategorised boards')
+			}
+
+			return this.t('deck', 'All boards')
 		},
 	},
 	beforeMount() {
@@ -180,6 +198,9 @@ export default {
 		async updateConfig() {
 			await this.$store.dispatch('setConfig', { groupLimit: this.groupLimit })
 			this.groupLimitDisabled = false
+		},
+		urlEncode(value) {
+			return encodeURIComponent(value)
 		},
 	},
 }

--- a/src/router.js
+++ b/src/router.js
@@ -65,6 +65,15 @@ export default new Router({
 			},
 		},
 		{
+			path: '/board/category/:category',
+			name: 'boards.category',
+			component: Boards,
+			props: route => ({
+				navFilter: BOARD_FILTERS.CATEGORY,
+				navFilterCategory: decodeURIComponent(route.params.category),
+			}),
+		},
+		{
 			path: '/board/archived',
 			name: 'boards.archived',
 			component: Boards,

--- a/tests/unit/Db/BoardTest.php
+++ b/tests/unit/Db/BoardTest.php
@@ -33,6 +33,7 @@ class BoardTest extends TestCase {
 			'users' => ['user1', 'user2'],
 			'settings' => [],
 			'ETag' => $board->getETag(),
+			'category' => null,
 		], $board->jsonSerialize());
 	}
 
@@ -54,6 +55,7 @@ class BoardTest extends TestCase {
 			'users' => [],
 			'settings' => [],
 			'ETag' => $board->getETag(),
+			'category' => null,
 		], $board->jsonSerialize());
 	}
 	public function testSetAcl() {
@@ -83,6 +85,7 @@ class BoardTest extends TestCase {
 			'users' => [],
 			'settings' => [],
 			'ETag' => $board->getETag(),
+			'category' => null,
 		], $board->jsonSerialize());
 	}
 }

--- a/tests/unit/controller/BoardApiControllerTest.php
+++ b/tests/unit/controller/BoardApiControllerTest.php
@@ -52,6 +52,7 @@ class BoardApiControllerTest extends \Test\TestCase {
 		$this->exampleBoard['id'] = 1;
 		$this->exampleBoard['title'] = 'titled';
 		$this->exampleBoard['color'] = '000000';
+		$this->exampleBoard['category'] = 'test category';
 
 		$this->deniedBoard['id'] = 2;
 		$this->deniedBoard['owner'] = 'someone else';
@@ -114,6 +115,7 @@ class BoardApiControllerTest extends \Test\TestCase {
 		$board->setId($this->exampleBoard['id']);
 		$board->setTitle($this->exampleBoard['title']);
 		$board->setColor($this->exampleBoard['color']);
+		$board->setCategory($this->exampleBoard['category']);
 		$this->boardService->expects($this->once())
 			->method('update')
 			->willReturn($board);
@@ -124,7 +126,12 @@ class BoardApiControllerTest extends \Test\TestCase {
 			->will($this->returnValue($this->exampleBoard['id']));
 
 		$expected = new DataResponse($board, HTTP::STATUS_OK);
-		$actual = $this->controller->update($this->exampleBoard['title'], $this->exampleBoard['color']);
+		$actual = $this->controller->update(
+			$this->exampleBoard['title'],
+			$this->exampleBoard['color'],
+			false,
+			$this->exampleBoard['category']
+		);
 		$this->assertEquals($expected, $actual);
 	}
 

--- a/tests/unit/controller/BoardControllerTest.php
+++ b/tests/unit/controller/BoardControllerTest.php
@@ -106,9 +106,9 @@ class BoardControllerTest extends \Test\TestCase {
 	public function testUpdate() {
 		$this->boardService->expects($this->once())
 			->method('update')
-			->with(1, 2, 3, false)
+			->with(1, 2, 3, false, 'TestCategory')
 			->willReturn(1);
-		$this->assertEquals(1, $this->controller->update(1, 2, 3, false));
+		$this->assertEquals(1, $this->controller->update(1, 2, 3, false, 'TestCategory'));
 	}
 
 	public function testDelete() {


### PR DESCRIPTION
* Resolves: #2006
* Target version: master 

### Summary

Adds board categories

- Uncategorised boards are will be displayed under "Uncategorised"
- If there are no categories the section will be named "All boards" as before
- Archived boards will be displayed under "Archived"
- Board categegories can be set in a new section in the board details

![image](https://user-images.githubusercontent.com/6216686/133754752-d699f725-24e2-4347-ae05-51b54fe99b85.png)


### TODO

- [ ] The settings icon has a wrong colour. Is there any icon I can use?
- [ ] "Approval" of the category selection field in the sidebar (I had no idea where else to put it)

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
