### PR TITLE
add autofocus on board edit

### DIFF
--- a/src/components/navigation/AppNavigationBoard.vue
+++ b/src/components/navigation/AppNavigationBoard.vue
@@ -125,7 +125,10 @@
 			<div :style="{ backgroundColor: getColor }" class="color0 icon-colorpicker app-navigation-entry-bullet" />
 		</ColorPicker>
 		<form @submit.prevent.stop="applyEdit">
-			<input v-model="editTitle" type="text" required>
+			<input v-model="editTitle"
+				v-focus
+				type="text"
+				required>
 			<input type="submit" value="" class="icon-confirm">
 			<Actions><ActionButton icon="icon-close" @click.stop.prevent="cancelEdit" /></Actions>
 		</form>


### PR DESCRIPTION
* Target version: master 

### Summary

After clicking "board edit" the board name will be focused.  
Super tiny change - but this one was bugging me ;)

![focus](https://user-images.githubusercontent.com/6216686/133758561-fd795b8d-2d9f-47d3-9ded-6876c4f766a3.gif)

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
