### PR TITLE
Do not show both bullets and checkboxes for checklists

### DIFF
--- a/src/css/markdown.scss
+++ b/src/css/markdown.scss
@@ -72,7 +72,7 @@ img {
 }
 
 input[type=checkbox] {
-	margin: 0px 10px 0px 0px;
+	margin: 0px 3px 0px 0px;
 	line-height: 10px;
 	font-size: 10px;
 	display: inline-block;

--- a/src/css/markdown.scss
+++ b/src/css/markdown.scss
@@ -21,6 +21,11 @@ ul {
 
 ul {
 	list-style-type: disc;
+
+	.task-list-item {
+		margin-left: -20px;
+		list-style-type: none;
+	}
 }
 
 h1 {


### PR DESCRIPTION
Signed-off-by: Dmitriy Ivanko <tmwsls12@gmail.com>


* Resolves: https://github.com/nextcloud/deck/issues/2928
* Target version: master 

### Summary

I removed the markers from checkboxes, this is a hotfix, I would suggest making changes to [markdown-it-task-lists](https://www.npmjs.com/package/markdown-it-task-lists) or replacing it.

**This is how it looks now:**
![image](https://user-images.githubusercontent.com/49566826/133766335-5f83d0cc-9297-4c12-999d-fbf668a27366.png)

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
