### PR TITLE
Fix search pagination cursor

### DIFF
--- a/lib/Search/DeckProvider.php
+++ b/lib/Search/DeckProvider.php
@@ -81,11 +81,11 @@ class DeckProvider implements IProvider {
 				$results
 			);
 		}
-		
+
 		return SearchResult::paginated(
 			'Deck',
 			$results,
-			$cardResults[count($results) - 1]->getLastModified()
+			$cardResults[count($cardResults) - 1]->getLastModified()
 		);
 	}
 


### PR DESCRIPTION
If we get both boards and cards when searching and the number of cards is higher than the limit, the wrong index is used to get the pagination cursor.
This avoids the crash but the search is still not completely ok because we get the same boards in each page. Board search does not use the cursor.