### PR TITLE
Improve search performance

### DIFF
--- a/lib/Service/BoardService.php
+++ b/lib/Service/BoardService.php
@@ -118,8 +118,8 @@ class BoardService {
 	/**
 	 * Get all boards that are shared with a user, their groups or circles
 	 */
-	public function getUserBoards(int $since = -1, bool $includeArchived = true): array {
-		return $this->boardMapper->findAllForUser($this->userId, $since, $includeArchived);
+	public function getUserBoards(int $since = -1, bool $includeArchived = true, ?int $before = null): array {
+		return $this->boardMapper->findAllForUser($this->userId, $since, $includeArchived, $before);
 	}
 
 	/**

--- a/lib/Service/BoardService.php
+++ b/lib/Service/BoardService.php
@@ -118,7 +118,7 @@ class BoardService {
 	/**
 	 * Get all boards that are shared with a user, their groups or circles
 	 */
-	public function getUserBoards(int $since = -1, bool $includeArchived = true, ?int $before = null): array {
+	public function getUserBoards(?int $since = null, bool $includeArchived = true, ?int $before = null): array {
 		return $this->boardMapper->findAllForUser($this->userId, $since, $includeArchived, $before);
 	}
 

--- a/lib/Service/BoardService.php
+++ b/lib/Service/BoardService.php
@@ -118,8 +118,9 @@ class BoardService {
 	/**
 	 * Get all boards that are shared with a user, their groups or circles
 	 */
-	public function getUserBoards(?int $since = null, bool $includeArchived = true, ?int $before = null): array {
-		return $this->boardMapper->findAllForUser($this->userId, $since, $includeArchived, $before);
+	public function getUserBoards(?int $since = null, bool $includeArchived = true, ?int $before = null,
+								  ?string $term = null): array {
+		return $this->boardMapper->findAllForUser($this->userId, $since, $includeArchived, $before, $term);
 	}
 
 	/**

--- a/lib/Service/FullTextSearchService.php
+++ b/lib/Service/FullTextSearchService.php
@@ -59,7 +59,7 @@ class FullTextSearchService {
 
 	/** @var CardMapper */
 	private $cardMapper;
-	
+
 	public function __construct(
 		BoardMapper $boardMapper, StackMapper $stackMapper, CardMapper $cardMapper
 	) {
@@ -187,6 +187,6 @@ class FullTextSearchService {
 	 * @return Board[]
 	 */
 	private function getBoardsFromUser(string $userId): array {
-		return $this->boardMapper->findAllByUser($userId, null, null, -1);
+		return $this->boardMapper->findAllByUser($userId, null, null, null);
 	}
 }

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -90,14 +90,11 @@ class SearchService {
 	}
 
 	public function searchBoards(string $term, ?int $limit, ?int $cursor): array {
-		$boards = $this->boardService->getUserBoards();
+		$boards = $this->boardService->getUserBoards(-1, true, $cursor);
 		// get boards that have a lastmodified date which is lower than the cursor
 		// and which match the search term
 		$filteredBoards = array_filter($boards, static function (Board $board) use ($term, $cursor) {
-			return (
-				($cursor === null || $board->getLastModified() < $cursor)
-				&& mb_stripos(mb_strtolower($board->getTitle()), mb_strtolower($term)) > -1
-			);
+			return mb_stripos(mb_strtolower($board->getTitle()), mb_strtolower($term)) > -1;
 		});
 		// sort the boards, recently modified first
 		usort($filteredBoards, function ($boardA, $boardB) {

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -90,7 +90,7 @@ class SearchService {
 	}
 
 	public function searchBoards(string $term, ?int $limit, ?int $cursor): array {
-		$boards = $this->boardService->getUserBoards(-1, true, $cursor);
+		$boards = $this->boardService->getUserBoards(null, true, $cursor);
 		// get boards that have a lastmodified date which is lower than the cursor
 		// and which match the search term
 		$filteredBoards = array_filter($boards, static function (Board $board) use ($term, $cursor) {

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -90,22 +90,19 @@ class SearchService {
 	}
 
 	public function searchBoards(string $term, ?int $limit, ?int $cursor): array {
-		$boards = $this->boardService->getUserBoards(null, true, $cursor);
-		// get boards that have a lastmodified date which is lower than the cursor
-		// and which match the search term
-		$filteredBoards = array_filter($boards, static function (Board $board) use ($term, $cursor) {
-			return mb_stripos(mb_strtolower($board->getTitle()), mb_strtolower($term)) > -1;
-		});
+		$boards = $this->boardService->getUserBoards(null, true, $cursor, mb_strtolower($term));
+
 		// sort the boards, recently modified first
-		usort($filteredBoards, function ($boardA, $boardB) {
+		usort($boards, function ($boardA, $boardB) {
 			$ta = $boardA->getLastModified();
 			$tb = $boardB->getLastModified();
 			return $ta === $tb
 				? 0
 				: ($ta > $tb ? -1 : 1);
 		});
+
 		// limit the number of results
-		return array_slice($filteredBoards, 0, $limit);
+		return array_slice($boards, 0, $limit);
 	}
 
 	public function searchComments(string $term, ?int $limit = null, ?int $cursor = null): array {


### PR DESCRIPTION
* Move some work from php to the database when searching for boards:
    * search query
    * cursor (max last modified date)
* Avoid `since` in DB queries when not needed
* Harmonize `since` and `before` filter parameters across services