### PR TITLE
Use displayname instead of uid for mentions

### DIFF
--- a/src/components/card/CommentForm.vue
+++ b/src/components/card/CommentForm.vue
@@ -26,7 +26,7 @@
 			<At ref="at"
 				v-model="commentText"
 				:members="members"
-				name-key="uid"
+				name-key="displayname"
 				:tab-select="true">
 				<template #item="s">
 					<Avatar class="atwho-li--avatar" :user="s.item.uid" :size="24" />


### PR DESCRIPTION
Signed-off-by: Paweł Kuffel <pawel@kuffel.io>

* Resolves: #3389
* Target version: stable22 

### Summary

This PR changes `At` user mentions in card comments so that they match potential users based on their display name instead of their username/uid. Successfully tested in one NC22 sandbox instance and one production NC21 instance.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included (from what I have seen, this project doesn't use frontend testing)
- [x] Documentation (manuals or wiki) has been updated or is not required
