### PR TITLE
Store cardDetailsInModal in config instead of state

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1004,6 +1004,7 @@ Deck stores user and app configuration values globally and per board. The GET en
 | Config key | Description |
 | --- | --- |
 | calendar | Determines if the calendar/tasks integration through the CalDAV backend is enabled for the user (boolean) | 
+| cardDetailsInModal | Determines if the bigger view is used (boolean) | 
 | groupLimit | Determines if creating new boards is limited to certain groups of the instance. The resulting output is an array of group objects with the id and the displayname (Admin only)|  
 
 ```
@@ -1016,6 +1017,7 @@ Deck stores user and app configuration values globally and per board. The GET en
     },
     "data": {
       "calendar": true,
+      "cardDetailsInModal": true,
       "groupLimit": [
         {
           "id": "admin",
@@ -1045,6 +1047,7 @@ Deck stores user and app configuration values globally and per board. The GET en
 | --- | ----- |
 | notify-due | `off`, `assigned` or `all` |
 | calendar | Boolean |
+| cardDetailsInModal | Boolean |
  
 #### Example request
 

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -66,7 +66,8 @@ class ConfigService {
 		}
 
 		$data = [
-			'calendar' => $this->isCalendarEnabled()
+			'calendar' => $this->isCalendarEnabled(),
+			'cardDetailsInModal' => $this->isCardDetailsInModal(),
 		];
 		if ($this->groupManager->isAdmin($this->getUserId())) {
 			$data['groupLimit'] = $this->get('groupLimit');
@@ -88,6 +89,11 @@ class ConfigService {
 					return false;
 				}
 				return (bool)$this->config->getUserValue($this->getUserId(), Application::APP_ID, 'calendar', true);
+			case 'cardDetailsInModal':
+			  if ($this->getUserId() === null) {
+			  	return false;
+			  }
+				return (bool)$this->config->getUserValue($this->getUserId(), Application::APP_ID, 'cardDetailsInModal', true);
 		}
 	}
 
@@ -102,6 +108,19 @@ class ConfigService {
 		}
 
 		return (bool)$this->config->getUserValue($this->getUserId(), Application::APP_ID, 'board:' . $boardId . ':calendar', $defaultState);
+	}
+
+	public function isCardDetailsInModal(int $boardId = null): bool {
+		if ($this->getUserId() === null) {
+			return false;
+		}
+
+		$defaultState = (bool)$this->config->getUserValue($this->getUserId(), Application::APP_ID, 'cardDetailsInModal', true);
+		if ($boardId === null) {
+			return $defaultState;
+		}
+
+		return (bool)$this->config->getUserValue($this->getUserId(), Application::APP_ID, 'board:' . $boardId . ':cardDetailsInModal', $defaultState);
 	}
 
 	public function set($key, $value) {
@@ -120,6 +139,10 @@ class ConfigService {
 				break;
 			case 'calendar':
 				$this->config->setUserValue($this->getUserId(), Application::APP_ID, 'calendar', (string)$value);
+				$result = $value;
+				break;
+			case 'cardDetailsInModal':
+				$this->config->setUserValue($this->getUserId(), Application::APP_ID, 'cardDetailsInModal', (string)$value);
 				$result = $value;
 				break;
 			case 'board':

--- a/src/App.vue
+++ b/src/App.vue
@@ -88,7 +88,6 @@ export default {
 			navShown: state => state.navShown,
 			sidebarShownState: state => state.sidebarShown,
 			currentBoard: state => state.currentBoard,
-			cardDetailsInModal: state => state.cardDetailsInModal,
 		}),
 		// TODO: properly handle sidebar showing for route subview and board sidebar
 		sidebarRouterView() {
@@ -97,6 +96,14 @@ export default {
 		},
 		sidebarShown() {
 			return this.sidebarRouterView || this.sidebarShownState
+		},
+		cardDetailsInModal: {
+			get() {
+				return this.$store.getters.config('cardDetailsInModal')
+			},
+			set(newValue) {
+				this.$store.dispatch('setConfig', { cardDetailsInModal: newValue })
+			},
 		},
 	},
 	created() {

--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -162,7 +162,6 @@ export default {
 		]),
 		...mapState({
 			showArchived: state => state.showArchived,
-			cardDetailsInModal: state => state.cardDetailsInModal,
 		}),
 		cardsByStack() {
 			return this.$store.getters.cardsByStack(this.stack.id).filter((card) => {
@@ -174,6 +173,14 @@ export default {
 		},
 		dragHandleSelector() {
 			return this.canEdit ? null : '.no-drag'
+		},
+		cardDetailsInModal: {
+			get() {
+				return this.$store.getters.config('cardDetailsInModal')
+			},
+			set(newValue) {
+				this.$store.dispatch('setConfig', { cardDetailsInModal: newValue })
+			},
 		},
 	},
 

--- a/src/components/card/CardSidebar.vue
+++ b/src/components/card/CardSidebar.vue
@@ -31,7 +31,7 @@
 		@submit-title="handleSubmitTitle"
 		@close="closeSidebar">
 		<template #secondary-actions>
-			<ActionButton v-if="cardDetailsInModal" icon="icon-menu-sidebar" @click.stop="showModal()">
+			<ActionButton v-if="cardDetailsInModal" icon="icon-menu-sidebar" @click.stop="closeModal()">
 				{{ t('deck', 'Open in sidebar view') }}
 			</ActionButton>
 			<ActionButton v-else icon="icon-external" @click.stop="showModal()">
@@ -131,7 +131,6 @@ export default {
 	computed: {
 		...mapState({
 			currentBoard: state => state.currentBoard,
-			cardDetailsInModal: state => state.cardDetailsInModal,
 		}),
 		...mapGetters(['canEdit', 'assignables', 'cardActions', 'stackById']),
 		title() {
@@ -151,6 +150,14 @@ export default {
 				stackname: this.stackById(this.currentCard.stackId)?.title,
 				link: window.location.protocol + '//' + window.location.host + generateUrl('/apps/deck/') + `#/board/${this.currentBoard.id}/card/${this.currentCard.id}`,
 			}
+		},
+		cardDetailsInModal: {
+			get() {
+				return this.$store.getters.config('cardDetailsInModal')
+			},
+			set(newValue) {
+				this.$store.dispatch('setConfig', { cardDetailsInModal: newValue })
+			},
 		},
 	},
 	methods: {
@@ -177,7 +184,10 @@ export default {
 		},
 
 		showModal() {
-			this.$store.dispatch('setCardDetailsInModal', true)
+			this.$store.dispatch('setConfig', { cardDetailsInModal: true })
+		},
+		closeModal() {
+			this.$store.dispatch('setConfig', { cardDetailsInModal: false })
 		},
 	},
 }

--- a/src/components/card/CardSidebarTabDetails.vue
+++ b/src/components/card/CardSidebarTabDetails.vue
@@ -224,7 +224,6 @@ export default {
 	computed: {
 		...mapState({
 			currentBoard: state => state.currentBoard,
-			cardDetailsInModal: state => state.cardDetailsInModal,
 		}),
 		...mapGetters(['canEdit', 'assignables']),
 		formatedAssignables() {
@@ -249,6 +248,14 @@ export default {
 
 				return assignable
 			})
+		},
+		cardDetailsInModal: {
+			get() {
+				return this.$store.getters.config('cardDetailsInModal')
+			},
+			set(newValue) {
+				this.$store.dispatch('setConfig', { cardDetailsInModal: newValue })
+			},
 		},
 		duedate: {
 			get() {

--- a/src/components/card/Description.vue
+++ b/src/components/card/Description.vue
@@ -132,7 +132,6 @@ export default {
 	computed: {
 		...mapState({
 			currentBoard: state => state.currentBoard,
-			cardDetailsInModal: state => state.cardDetailsInModal,
 		}),
 		...mapGetters(['canEdit']),
 		attachments() {

--- a/src/components/navigation/AppNavigation.vue
+++ b/src/components/navigation/AppNavigation.vue
@@ -144,10 +144,10 @@ export default {
 		},
 		cardDetailsInModal: {
 			get() {
-				return this.$store.getters.cardDetailsInModal
+				return this.$store.getters.config('cardDetailsInModal')
 			},
 			set(newValue) {
-				this.$store.dispatch('setCardDetailsInModal', newValue)
+				this.$store.dispatch('setConfig', { cardDetailsInModal: newValue })
 			},
 		},
 		configCalendar: {

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -62,7 +62,6 @@ export default new Vuex.Store({
 		showArchived: false,
 		navShown: localStorage.getItem('deck.navShown') === 'true',
 		compactMode: localStorage.getItem('deck.compactMode') === 'true',
-		cardDetailsInModal: localStorage.getItem('deck.cardDetailsInModal') === 'true',
 		sidebarShown: false,
 		currentBoard: null,
 		currentCard: null,
@@ -78,9 +77,6 @@ export default new Vuex.Store({
 	getters: {
 		config: state => (key) => {
 			return state.config[key]
-		},
-		cardDetailsInModal: state => {
-			return state.cardDetailsInModal
 		},
 		getSearchQuery: state => {
 			return state.searchQuery
@@ -232,10 +228,6 @@ export default new Vuex.Store({
 		toggleCompactMode(state) {
 			state.compactMode = !state.compactMode
 			localStorage.setItem('deck.compactMode', state.compactMode)
-		},
-		setCardDetailsInModal(state) {
-			state.cardDetailsInModal = !state.cardDetailsInModal
-			localStorage.setItem('deck.cardDetailsInModal', state.cardDetailsInModal)
 		},
 		setBoards(state, boards) {
 			state.boards = boards
@@ -440,9 +432,6 @@ export default new Vuex.Store({
 		},
 		toggleCompactMode({ commit }) {
 			commit('toggleCompactMode')
-		},
-		setCardDetailsInModal({ commit }, show) {
-			commit('setCardDetailsInModal', show)
 		},
 		setCurrentBoard({ commit }, board) {
 			commit('setCurrentBoard', board)


### PR DESCRIPTION
* Resolves: #3371
* Target version: master 

### Summary

The variable, responsible for remembering whether the bigger view is used, is stored in localStorage. So, after logging out it resets. I moved it to the backend side to remember if the bigger view is used even after logging out.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
