### PR TITLE
Clone cards together with the board

### DIFF
--- a/cypress/e2e/boardFeatures.js
+++ b/cypress/e2e/boardFeatures.js
@@ -5,6 +5,7 @@
 import { randUser } from '../utils/index.js'
 const user = randUser()
 const recipient = randUser()
+import { sampleBoard } from '../utils/sampleBoard'
 
 describe('Board', function() {
 
@@ -56,5 +57,75 @@ describe('Board', function() {
 		cy.get('#app-navigation-vue .app-navigation__list .app-navigation-entry')
 			.contains('Upcoming cards')
 			.should('be.visible')
+	})
+})
+
+describe('Board cloning', function() {
+	before(function() {
+		cy.createUser(user)
+	})
+
+	it('Clones a board without cards', function() {
+		const boardName = 'Clone board original'
+		const board = sampleBoard(boardName)
+		cy.createExampleBoard({ user, board }).then((board) => {
+			const boardId = board.id
+			cy.visit(`/apps/deck/board/${boardId}`)
+			cy.get('.app-navigation__list .app-navigation-entry:contains("' + boardName + '")')
+				.parent()
+				.find('button[aria-label="Actions"]')
+				.click()
+			cy.get('button:contains("Clone board")')
+				.click()
+
+			cy.get('.modal-container button:contains("Clone")')
+				.click()
+
+			cy.get('.app-navigation__list .app-navigation-entry:contains("' + boardName + '")')
+				.should('be.visible')
+
+			cy.get('.app-navigation__list .app-navigation-entry:contains("' + boardName + ' (copy)")')
+				.should('be.visible')
+
+			cy.get('.board-title h2').contains(boardName + ' (copy)')
+
+			cy.get('h3[aria-label="TestList"]')
+				.should('be.visible')
+		})
+	})
+
+	it('Clones a board with cards', function() {
+		const boardName = 'Clone with cards'
+		const board = sampleBoard(boardName)
+		cy.createExampleBoard({ user, board }).then((board) => {
+			const boardId = board.id
+			cy.visit(`/apps/deck/board/${boardId}`)
+			cy.get('.app-navigation__list .app-navigation-entry:contains("' + boardName + '")')
+				.parent()
+				.find('button[aria-label="Actions"]')
+				.click()
+			cy.get('button:contains("Clone board")')
+				.click()
+
+			cy.get('.checkbox-content__text:contains("Clone cards")')
+				.click()
+
+			cy.get('.modal-container button:contains("Clone")')
+				.click()
+
+			cy.get('.app-navigation__list .app-navigation-entry:contains("' + boardName + '")')
+				.should('be.visible')
+
+			cy.get('.app-navigation__list .app-navigation-entry:contains("' + boardName + ' (copy)")')
+				.should('be.visible')
+
+			cy.get('.board-title h2').contains(boardName + ' (copy)')
+
+			cy.get('h3[aria-label="TestList"]')
+				.should('be.visible')
+
+			cy.get('.card:contains("Hello world")')
+				.should('be.visible')
+		})
 	})
 })

--- a/docs/API.md
+++ b/docs/API.md
@@ -423,6 +423,25 @@ A 403 response might be returned if the users ability to create new boards has b
 
 ##### 200 Success
 
+### POST /boards/{boardId}/clone - Clone a board
+
+Creates a copy of the board.
+
+#### Request body
+
+| Parameter | Type   | Description                                          |
+| --------- | ------ | ---------------------------------------------------- |
+| withCards  | Bool   | Setting if the cards should be copied (Default: false) |
+| withAssignments  | Bool   | Setting if the card assignments should be cloned (Default: false) |
+| withLabels  | Bool   | Setting if the card labels should be cloned (Default: false) |
+| withDueDate  | Bool   | Setting if the card due dates should be cloned (Default: false) |
+| moveCardsToLeftStack  | Bool   | Setting if all cards should be moved to the most left column (useful for To-Do / Doing / Done boards) (Default: false) |
+| restoreArchivedCards  | Bool   | Setting if the archived cards should be unarchived (Default: false) |
+
+#### Response
+
+##### 200 Success
+
 ### DELETE /boards/{boardId}/acl/{aclId} - Delete an acl rule
 
 #### Response

--- a/lib/Controller/BoardApiController.php
+++ b/lib/Controller/BoardApiController.php
@@ -164,4 +164,13 @@ class BoardApiController extends ApiController {
 		$acl = $this->boardService->deleteAcl($aclId);
 		return new DataResponse($acl, HTTP::STATUS_OK);
 	}
+
+	/**
+	 * @NoAdminRequired
+	 */
+	public function clone(int $boardId, bool $withCards = false, bool $withAssignments = false, bool $withLabels = false, bool $withDueDate = false, bool $moveCardsToLeftStack = false, bool $restoreArchivedCards = false): DataResponse {
+		return new DataResponse(
+			$this->boardService->clone($boardId, $this->userId, $withCards, $withAssignments, $withLabels, $withDueDate, $moveCardsToLeftStack, $restoreArchivedCards)
+		);
+	}
 }

--- a/lib/Controller/BoardController.php
+++ b/lib/Controller/BoardController.php
@@ -135,11 +135,11 @@ class BoardController extends ApiController {
 
 	/**
 	 * @NoAdminRequired
-	 * @param $boardId
-	 * @return Board
 	 */
-	public function clone($boardId) {
-		return $this->boardService->clone($boardId, $this->userId);
+	public function clone(int $boardId, bool $withCards = false, bool $withAssignments = false, bool $withLabels = false, bool $withDueDate = false, bool $moveCardsToLeftStack = false, bool $restoreArchivedCards = false): DataResponse {
+		return new DataResponse(
+			$this->boardService->clone($boardId, $this->userId, $withCards, $withAssignments, $withLabels, $withDueDate, $moveCardsToLeftStack, $restoreArchivedCards)
+		);
 	}
 
 	/**

--- a/lib/Db/Label.php
+++ b/lib/Db/Label.php
@@ -7,6 +7,9 @@
 
 namespace OCA\Deck\Db;
 
+/**
+ * @method getTitle(): string
+ */
 class Label extends RelationalEntity {
 	protected $title;
 	protected $color;

--- a/lib/Service/AssignmentService.php
+++ b/lib/Service/AssignmentService.php
@@ -88,8 +88,6 @@ class AssignmentService {
 		$this->changeHelper = $changeHelper;
 		$this->activityManager = $activityManager;
 		$this->eventDispatcher = $eventDispatcher;
-
-		$this->assignmentServiceValidator->check(compact('userId'));
 		$this->currentUser = $userId;
 	}
 

--- a/lib/Service/BoardService.php
+++ b/lib/Service/BoardService.php
@@ -16,6 +16,7 @@ use OCA\Deck\Db\AclMapper;
 use OCA\Deck\Db\AssignmentMapper;
 use OCA\Deck\Db\Board;
 use OCA\Deck\Db\BoardMapper;
+use OCA\Deck\Db\Card;
 use OCA\Deck\Db\CardMapper;
 use OCA\Deck\Db\ChangeHelper;
 use OCA\Deck\Db\IPermissionMapper;
@@ -29,6 +30,7 @@ use OCA\Deck\Event\AclCreatedEvent;
 use OCA\Deck\Event\AclDeletedEvent;
 use OCA\Deck\Event\AclUpdatedEvent;
 use OCA\Deck\Event\BoardUpdatedEvent;
+use OCA\Deck\Event\CardCreatedEvent;
 use OCA\Deck\NoPermissionException;
 use OCA\Deck\Notification\NotificationHelper;
 use OCA\Deck\Validators\BoardServiceValidator;
@@ -38,80 +40,37 @@ use OCP\DB\Exception as DbException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IDBConnection;
-use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
-use OCP\IUserManager;
 use OCP\Server;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
 class BoardService {
-	private BoardMapper $boardMapper;
-	private StackMapper $stackMapper;
-	private LabelMapper $labelMapper;
-	private AclMapper $aclMapper;
-	private IConfig $config;
-	private IL10N $l10n;
-	private PermissionService $permissionService;
-	private NotificationHelper $notificationHelper;
-	private AssignmentMapper $assignedUsersMapper;
-	private IUserManager $userManager;
-	private IGroupManager $groupManager;
-	private ?string $userId;
-	private ActivityManager $activityManager;
-	private IEventDispatcher $eventDispatcher;
-	private ChangeHelper $changeHelper;
-	private CardMapper $cardMapper;
 	private ?array $boardsCacheFull = null;
 	private ?array $boardsCachePartial = null;
-	private IURLGenerator $urlGenerator;
-	private IDBConnection $connection;
-	private BoardServiceValidator $boardServiceValidator;
-	private SessionMapper $sessionMapper;
 
 	public function __construct(
-		BoardMapper $boardMapper,
-		StackMapper $stackMapper,
-		CardMapper $cardMapper,
-		IConfig $config,
-		IL10N $l10n,
-		LabelMapper $labelMapper,
-		AclMapper $aclMapper,
-		PermissionService $permissionService,
-		NotificationHelper $notificationHelper,
-		AssignmentMapper $assignedUsersMapper,
-		IUserManager $userManager,
-		IGroupManager $groupManager,
-		ActivityManager $activityManager,
-		IEventDispatcher $eventDispatcher,
-		ChangeHelper $changeHelper,
-		IURLGenerator $urlGenerator,
-		IDBConnection $connection,
-		BoardServiceValidator $boardServiceValidator,
-		SessionMapper $sessionMapper,
-		?string $userId,
+		private BoardMapper $boardMapper,
+		private StackMapper $stackMapper,
+		private CardMapper $cardMapper,
+		private IConfig $config,
+		private IL10N $l10n,
+		private LabelMapper $labelMapper,
+		private AclMapper $aclMapper,
+		private PermissionService $permissionService,
+		private AssignmentService $assignmentService,
+		private NotificationHelper $notificationHelper,
+		private AssignmentMapper $assignedUsersMapper,
+		private ActivityManager $activityManager,
+		private IEventDispatcher $eventDispatcher,
+		private ChangeHelper $changeHelper,
+		private IURLGenerator $urlGenerator,
+		private IDBConnection $connection,
+		private BoardServiceValidator $boardServiceValidator,
+		private SessionMapper $sessionMapper,
+		private ?string $userId,
 	) {
-		$this->boardMapper = $boardMapper;
-		$this->stackMapper = $stackMapper;
-		$this->cardMapper = $cardMapper;
-		$this->labelMapper = $labelMapper;
-		$this->config = $config;
-		$this->aclMapper = $aclMapper;
-		$this->l10n = $l10n;
-		$this->permissionService = $permissionService;
-		$this->notificationHelper = $notificationHelper;
-		$this->assignedUsersMapper = $assignedUsersMapper;
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
-		$this->activityManager = $activityManager;
-		$this->eventDispatcher = $eventDispatcher;
-		$this->changeHelper = $changeHelper;
-		$this->userId = $userId;
-		$this->urlGenerator = $urlGenerator;
-		$this->connection = $connection;
-		$this->boardServiceValidator = $boardServiceValidator;
-		$this->sessionMapper = $sessionMapper;
 	}
 
 	/**
@@ -150,7 +109,7 @@ class BoardService {
 
 	/**
 	 * @throws DoesNotExistException
-	 * @throws \OCA\Deck\NoPermissionException
+	 * @throws NoPermissionException
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 * @throws BadRequestException
 	 */
@@ -177,7 +136,7 @@ class BoardService {
 	 * @param $id
 	 * @return bool
 	 * @throws DoesNotExistException
-	 * @throws \OCA\Deck\NoPermissionException
+	 * @throws NoPermissionException
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 * @throws BadRequestException
 	 */
@@ -204,7 +163,7 @@ class BoardService {
 	 * @param $id
 	 * @return bool
 	 * @throws DoesNotExistException
-	 * @throws \OCA\Deck\NoPermissionException
+	 * @throws NoPermissionException
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 * @throws BadRequestException
 	 */
@@ -281,7 +240,7 @@ class BoardService {
 	 * @param $id
 	 * @return Board
 	 * @throws DoesNotExistException
-	 * @throws \OCA\Deck\NoPermissionException
+	 * @throws NoPermissionException
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 * @throws BadRequestException
 	 */
@@ -305,7 +264,7 @@ class BoardService {
 	 * @param $id
 	 * @return \OCP\AppFramework\Db\Entity
 	 * @throws DoesNotExistException
-	 * @throws \OCA\Deck\NoPermissionException
+	 * @throws NoPermissionException
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 */
 	public function deleteUndo($id) {
@@ -325,7 +284,7 @@ class BoardService {
 	 * @param $id
 	 * @return \OCP\AppFramework\Db\Entity
 	 * @throws DoesNotExistException
-	 * @throws \OCA\Deck\NoPermissionException
+	 * @throws NoPermissionException
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 * @throws BadRequestException
 	 */
@@ -346,7 +305,7 @@ class BoardService {
 	 * @param $archived
 	 * @return \OCP\AppFramework\Db\Entity
 	 * @throws DoesNotExistException
-	 * @throws \OCA\Deck\NoPermissionException
+	 * @throws NoPermissionException
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 * @throws BadRequestException
 	 */
@@ -411,7 +370,7 @@ class BoardService {
 	 * @param $manage
 	 * @return \OCP\AppFramework\Db\Entity
 	 * @throws BadRequestException
-	 * @throws \OCA\Deck\NoPermissionException
+	 * @throws NoPermissionException
 	 */
 	public function addAcl($boardId, $type, $participant, $edit, $share, $manage) {
 		$this->boardServiceValidator->check(compact('boardId', 'type', 'participant', 'edit', 'share', 'manage'));
@@ -455,7 +414,7 @@ class BoardService {
 	 * @param $manage
 	 * @return \OCP\AppFramework\Db\Entity
 	 * @throws DoesNotExistException
-	 * @throws \OCA\Deck\NoPermissionException
+	 * @throws NoPermissionException
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 * @throws BadRequestException
 	 */
@@ -519,15 +478,16 @@ class BoardService {
 	}
 
 	/**
-	 * @param $id
-	 * @param $userId
-	 * @return Board
-	 * @throws DoesNotExistException
-	 * @throws \OCA\Deck\NoPermissionException
-	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 * @throws BadRequestException
+	 * @throws DbException
+	 * @throws DoesNotExistException
+	 * @throws MultipleObjectsReturnedException
+	 * @throws NoPermissionException
 	 */
-	public function clone($id, $userId) {
+	public function clone(
+		int $id, string $userId,
+		bool $withCards = false, bool $withAssignments = false, bool $withLabels = false, bool $withDueDate = false, bool $moveCardsToLeftStack = false, bool $restoreArchivedCards = false,
+	): Board {
 		$this->boardServiceValidator->check(compact('id', 'userId'));
 
 		if (!$this->permissionService->canCreate()) {
@@ -550,6 +510,16 @@ class BoardService {
 		]);
 		$this->boardMapper->insert($newBoard);
 
+		foreach ($this->aclMapper->findAll($board->getId()) as $acl) {
+			$this->addAcl($newBoard->getId(),
+				$acl->getType(),
+				$acl->getParticipant(),
+				$acl->getPermissionEdit(),
+				$acl->getPermissionShare(),
+				$acl->getPermissionManage());
+		}
+
+
 		$labels = $this->labelMapper->findAll($id);
 		foreach ($labels as $label) {
 			$newLabel = new Label();
@@ -570,6 +540,10 @@ class BoardService {
 			}
 			$newStack->setBoardId($newBoard->getId());
 			$this->stackMapper->insert($newStack);
+		}
+
+		if ($withCards) {
+			$this->cloneCards($board, $newBoard, $withAssignments, $withLabels, $withDueDate, $moveCardsToLeftStack, $restoreArchivedCards);
 		}
 
 		return $this->find($newBoard->getId());
@@ -619,7 +593,7 @@ class BoardService {
 	 * @param $id
 	 * @return Board
 	 * @throws DoesNotExistException
-	 * @throws \OCA\Deck\NoPermissionException
+	 * @throws NoPermissionException
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 * @throws BadRequestException
 	 */
@@ -673,6 +647,83 @@ class BoardService {
 		}
 
 		return $boards;
+	}
+
+	private function cloneCards(Board $board, Board $newBoard, bool $withAssignments = false, bool $withLabels = false, bool $withDueDate = false, bool $moveCardsToLeftStack = false, bool $restoreArchivedCards = false): void {
+		$stacks = $this->stackMapper->findAll($board->getId());
+		$newStacks = $this->stackMapper->findAll($newBoard->getId());
+
+		$stackSorter = function (Stack $a, Stack $b) {
+			return $a->getOrder() - $b->getOrder();
+		};
+		usort($stacks, $stackSorter);
+		usort($newStacks, $stackSorter);
+
+		$i = 0;
+		foreach ($stacks as $stack) {
+			$cards = $this->cardMapper->findAll($stack->getId());
+			$archivedCards = $this->cardMapper->findAllArchived($stack->getId());
+
+			/** @var Card[] $cards */
+			$cards = array_merge($cards, $archivedCards);
+
+			foreach ($cards as $card) {
+				$targetStackId = $moveCardsToLeftStack ? $newStacks[0]->getId() : $newStacks[$i]->getId();
+
+				// Create a cloned card.
+				// Done with setters as only fields set via setters get written to db
+				$newCard = new Card();
+				$newCard->setTitle($card->getTitle());
+				$newCard->setDescription($card->getDescription());
+				$newCard->setStackId($targetStackId);
+				$newCard->setType($card->getType());
+				$newCard->setOwner($card->getOwner());
+				$newCard->setOrder($card->getOrder());
+				$newCard->setDuedate($withDueDate ? $card->getDuedate() : null);
+				$newCard->setArchived($restoreArchivedCards ? false : $card->getArchived());
+				$newCard->setStackId($targetStackId);
+
+				// Persist the cloned card.
+				$newCard = $this->cardMapper->insert($newCard);
+
+
+				// Copy labels.
+				if ($withLabels) {
+					$labels = $this->labelMapper->findAssignedLabelsForCard($card->getId());
+					$newLabels = $this->labelMapper->findAll($newBoard->getId());
+					$newLabelTitles = [];
+					foreach ($newLabels as $label) {
+						$newLabelTitles[$label->getTitle()] = $label;
+					}
+
+					foreach ($labels as $label) {
+						$newLabelId = $newLabelTitles[$label->getTitle()]?->getId() ?? null;
+						if ($newLabelId) {
+							$this->cardMapper->assignLabel($newCard->getId(), $newLabelId);
+						}
+					}
+				}
+
+
+				// Copy assignments.
+				if ($withAssignments) {
+					$assignments = $this->assignedUsersMapper->findAll($card->getId());
+
+					foreach ($assignments as $assignment) {
+						$this->assignmentService->assignUser($newCard->getId(), $assignment->getParticipant(), $assignment->getType());
+					}
+				}
+
+				// Known limitation: Currently we do not copy attachments or comments
+
+				// Copied from CardService because CardService cannot be injected due to cyclic dependencies.
+				$this->activityManager->triggerEvent(ActivityManager::DECK_OBJECT_CARD, $card, ActivityManager::SUBJECT_CARD_CREATE);
+				$this->changeHelper->cardChanged($card->getId(), false);
+				$this->eventDispatcher->dispatchTyped(new CardCreatedEvent($card));
+			}
+
+			$i++;
+		}
 	}
 
 	private function enrichWithStacks($board, $since = -1) {

--- a/src/components/navigation/BoardCloneModal.vue
+++ b/src/components/navigation/BoardCloneModal.vue
@@ -1,0 +1,124 @@
+<!--
+  - SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<NcDialog :name="t('deck', 'Clone {boardTitle}', {boardTitle: boardTitle})" :show="true" @close="close(false)">
+		<div class="modal__content">
+			<NcCheckboxRadioSwitch :checked.sync="withCards">
+				{{ t('deck', 'Clone cards') }}
+			</NcCheckboxRadioSwitch>
+			<NcCheckboxRadioSwitch v-if="withCards" :checked.sync="withAssignments">
+				{{ t('deck', 'Clone assignments') }}
+			</NcCheckboxRadioSwitch>
+			<NcCheckboxRadioSwitch v-if="withCards" :checked.sync="withLabels">
+				{{ t('deck', 'Clone labels') }}
+			</NcCheckboxRadioSwitch>
+			<NcCheckboxRadioSwitch v-if="withCards" :checked.sync="withDueDate">
+				{{ t('deck', 'Clone due dates') }}
+			</NcCheckboxRadioSwitch>
+			<div v-if="withCards" class="accordion" :class="{ 'is-open': accordionOpen }">
+				<div class="accordion__toggle" @click="accordionOpen = !accordionOpen">
+					<span class="accordion__toggle__icon">
+						‣
+					</span>
+					{{ t('deck', 'Advanced options') }}
+				</div>
+				<div v-if="accordionOpen" class="accordion__content">
+					<NcCheckboxRadioSwitch v-if="withCards" :checked.sync="moveCardsToLeftStack">
+						{{ t('deck', 'Move all cards to the first list') }}
+					</NcCheckboxRadioSwitch>
+					<NcCheckboxRadioSwitch v-if="withCards" :checked.sync="restoreArchivedCards">
+						{{ t('deck', 'Restore archived cards') }}
+					</NcCheckboxRadioSwitch>
+				</div>
+			</div>
+		</div>
+
+		<template #actions>
+			<NcButton @click="cancel">
+				{{ t('deck', 'Cancel') }}
+			</NcButton>
+			<NcButton type="primary" @click="save">
+				{{ t('deck', 'Clone') }}
+			</NcButton>
+		</template>
+	</NcDialog>
+</template>
+
+<script>
+import { NcButton, NcCheckboxRadioSwitch, NcDialog } from '@nextcloud/vue'
+
+export default {
+	name: 'BoardCloneModal',
+	components: {
+		NcDialog,
+		NcCheckboxRadioSwitch,
+		NcButton,
+	},
+	props: {
+		boardTitle: {
+			type: String,
+			default: 'Board',
+		},
+	},
+	data() {
+		return {
+			withCards: false,
+			withAssignments: true,
+			withLabels: true,
+			withDueDate: true,
+			moveCardsToLeftStack: false,
+			restoreArchivedCards: false,
+			accordionOpen: false,
+		}
+	},
+	methods: {
+		close(data) {
+			this.$emit('close', data)
+		},
+		save() {
+			const data = {
+				withCards: this.withCards,
+				withAssignments: this.withAssignments,
+				withLabels: this.withLabels,
+				withDueDate: this.withDueDate,
+				moveCardsToLeftStack: this.moveCardsToLeftStack,
+				restoreArchivedCards: this.restoreArchivedCards,
+			}
+			this.close(data)
+		},
+		cancel() {
+			this.close(false)
+		},
+	},
+}
+</script>
+
+<style scoped>
+.modal__content {
+	margin: 20px;
+}
+
+.modal__title {
+	text-align: center;
+}
+
+.modal__buttons {
+	text-align: end;
+	margin-top: .5em;
+}
+
+.accordion__toggle {
+	margin: .5em 0;
+	cursor: pointer;
+}
+
+.accordion__toggle__icon {
+	display: inline-block;
+}
+
+.accordion.is-open .accordion__toggle__icon {
+	transform: rotate(90deg);
+}
+</style>

--- a/src/services/BoardApi.js
+++ b/src/services/BoardApi.js
@@ -123,9 +123,16 @@ export class BoardApi {
 			})
 	}
 
-	async cloneBoard(board) {
+	async cloneBoard(board, withCards = false, withAssignments = false, withLabels = false, withDueDate = false, moveCardsToLeftStack = false, restoreArchivedCards = false) {
 		try {
-			const response = await axios.post(this.url(`/boards/${board.id}/clone`))
+			const response = await axios.post(this.url(`/boards/${board.id}/clone`), {
+				withCards,
+				withAssignments,
+				withLabels,
+				withDueDate,
+				moveCardsToLeftStack,
+				restoreArchivedCards,
+			})
 			return response.data
 		} catch (err) {
 			return err

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -398,9 +398,11 @@ export default new Vuex.Store({
 				return err
 			}
 		},
-		async cloneBoard({ commit }, boardData) {
+		async cloneBoard({ commit }, { boardData, settings }) {
+			const { withCards, withAssignments, withLabels, withDueDate, moveCardsToLeftStack, restoreArchivedCards } = settings
+
 			try {
-				const newBoard = await apiClient.cloneBoard(boardData)
+				const newBoard = await apiClient.cloneBoard(boardData, withCards, withAssignments, withLabels, withDueDate, moveCardsToLeftStack, restoreArchivedCards)
 				commit('cloneBoard', newBoard)
 				return newBoard
 			} catch (err) {

--- a/tests/unit/Service/BoardServiceTest.php
+++ b/tests/unit/Service/BoardServiceTest.php
@@ -46,10 +46,8 @@ use OCA\Deck\Validators\BoardServiceValidator;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IDBConnection;
-use OCP\IGroupManager;
 use OCP\IURLGenerator;
 use OCP\IUser;
-use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -73,14 +71,12 @@ class BoardServiceTest extends TestCase {
 	private $cardMapper;
 	/** @var PermissionService */
 	private $permissionService;
+	/** @var AssignmentService */
+	private $assignmentService;
 	/** @var NotificationHelper */
 	private $notificationHelper;
 	/** @var AssignmentMapper */
 	private $assignedUsersMapper;
-	/** @var IUserManager */
-	private $userManager;
-	/** @var IUserManager */
-	private $groupManager;
 	/** @var ActivityManager */
 	private $activityManager;
 	/** @var ChangeHelper */
@@ -103,14 +99,13 @@ class BoardServiceTest extends TestCase {
 		$this->aclMapper = $this->createMock(AclMapper::class);
 		$this->boardMapper = $this->createMock(BoardMapper::class);
 		$this->stackMapper = $this->createMock(StackMapper::class);
-		$this->config = $this->createMock(IConfig::class);
 		$this->cardMapper = $this->createMock(CardMapper::class);
+		$this->config = $this->createMock(IConfig::class);
 		$this->labelMapper = $this->createMock(LabelMapper::class);
 		$this->permissionService = $this->createMock(PermissionService::class);
+		$this->assignmentService = $this->createMock(AssignmentService::class);
 		$this->notificationHelper = $this->createMock(NotificationHelper::class);
 		$this->assignedUsersMapper = $this->createMock(AssignmentMapper::class);
-		$this->userManager = $this->createMock(IUserManager::class);
-		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->activityManager = $this->createMock(ActivityManager::class);
 		$this->changeHelper = $this->createMock(ChangeHelper::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
@@ -128,10 +123,9 @@ class BoardServiceTest extends TestCase {
 			$this->labelMapper,
 			$this->aclMapper,
 			$this->permissionService,
+			$this->assignmentService,
 			$this->notificationHelper,
 			$this->assignedUsersMapper,
-			$this->userManager,
-			$this->groupManager,
 			$this->activityManager,
 			$this->eventDispatcher,
 			$this->changeHelper,
@@ -157,12 +151,6 @@ class BoardServiceTest extends TestCase {
 			->method('findAllForUser')
 			->with('admin')
 			->willReturn([$b1, $b2, $b3]);
-		$user = $this->createMock(IUser::class);
-		$this->groupManager->method('getUserGroupIds')
-			->willReturn(['a', 'b', 'c']);
-		$this->userManager->method('get')
-			->with($this->userId)
-			->willReturn($user);
 
 		$result = $this->service->findAll();
 		sort($result);


### PR DESCRIPTION
* Resolves: #2797
* Target version: master 

### Summary
| Description | Screenshot |
|---|---|
| Add the possibility to clone cards together with the board. | ![image](https://user-images.githubusercontent.com/5746121/142302553-996f5a5c-e307-4827-b5c0-c2fa8ddd7f31.png) |
| Also allow customizations when cloning. | ![image](https://user-images.githubusercontent.com/5746121/142384153-46fac416-7916-418b-a16a-cd5f6a3fbeb5.png) |
| In advanced options, cards can be moved to the first list and archived cards can be restored. | ![image](https://user-images.githubusercontent.com/5746121/142384638-ed1e10fc-ca5f-4659-8191-528e79a6dab7.png) | 


### Follow Up
- [ ] Copy attachments
- [ ] Copy comments

### TODO

- [x] Write tests (I need help here, i don't know how to do this in Nextcloud)
- [x] Maybe adjust documentation. Right now only REST api doc was updated.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required

 