### PR TITLE
Fix event name for updating the description

### DIFF
--- a/src/components/card/Description.vue
+++ b/src/components/card/Description.vue
@@ -57,7 +57,7 @@
 			ref="markdownEditor"
 			v-model="description"
 			:configs="mdeConfig"
-			@input="updateDescription"
+			@update:modelValue="updateDescription"
 			@blur="saveDescription" />
 
 		<Modal v-if="modalShow" :title="t('deck', 'Choose attachment')" @close="modalShow=false">


### PR DESCRIPTION
Bringing back saving the description during editing which was broken due to the renamed event from https://github.com/nextcloud/deck/pull/3337 with v1.6.0-beta1

Ref: https://github.com/NikulinIlya/vue-easymde/compare/1.4.0...v2.0.0