### PR TITLE
Fix overview card listing

### DIFF
--- a/lib/Db/Board.php
+++ b/lib/Db/Board.php
@@ -74,18 +74,14 @@ class Board extends RelationalEntity {
 	 * @param Label[] $labels
 	 */
 	public function setLabels($labels) {
-		foreach ($labels as $l) {
-			$this->labels[] = $l;
-		}
+		$this->labels = $labels;
 	}
 
 	/**
 	 * @param Acl[] $acl
 	 */
 	public function setAcl($acl) {
-		foreach ($acl as $a) {
-			$this->acl[] = $a;
-		}
+		$this->acl = $acl;
 	}
 
 	public function getETag() {

--- a/tests/unit/Db/BoardMapperTest.php
+++ b/tests/unit/Db/BoardMapperTest.php
@@ -161,6 +161,7 @@ class BoardMapperTest extends MapperTestUtility {
 		$actual = $this->boardMapper->find($this->boards[0]->getId(), true, false);
 		/** @var Board $expected */
 		$expected = $this->boards[0];
+		$expected->setLabels([]);
 		$this->assertEquals($expected->getLabels(), $actual->getLabels());
 	}
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/deck/issues/3451

Make sure that the setter behaves as expected when setting an empty array for boards without acl rules in https://github.com/nextcloud/deck/blob/901b8f25060157835157b882859f117200165e8b/lib/Db/BoardMapper.php#L104

Otherwise the new default value of null would make the board object behave as if the acls have not been obtained yet. 