### PR TITLE
Fix cursor generation if no results are found

### DIFF
--- a/lib/Search/DeckProvider.php
+++ b/lib/Search/DeckProvider.php
@@ -139,6 +139,6 @@ class DeckProvider implements IProvider {
 		$cardTimestamps = array_map(function (Card $card) {
 			return $card->getLastModified();
 		}, $cards);
-		return (min($boardTimestamps) ?: '') . '|' . (min($cardTimestamps) ?: '');
+		return (count($boardTimestamps) > 0 ? min($boardTimestamps) : '') . '|' . (count($cardTimestamps) > 0 ? min($cardTimestamps) : '');
 	}
 }


### PR DESCRIPTION
Fixes #3457 

With PHP 8.0 internal functions might throw errors and for min this does not yet seem to be reflected in the docs https://www.php.net/manual/en/function.min.php

https://php.watch/versions/8.0/internal-function-exceptions