### PR TITLE
[stable23] Use explicit cast to make use of index

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -39,6 +39,7 @@
 				<referencedClass name="OC\*" />
 				<referencedClass name="OC" />
 				<referencedClass name="OC\Security\CSP\ContentSecurityPolicyNonceManager" />
+				<referencedClass name="Doctrine\DBAL\Platforms\MySQLPlatform" />
 			</errorLevel>
 		</UndefinedClass>
 		<UndefinedDocblockClass>
@@ -48,6 +49,8 @@
 				<referencedClass name="Doctrine\DBAL\Schema\SchemaException" />
 				<referencedClass name="Doctrine\DBAL\Driver\Statement" />
 				<referencedClass name="Doctrine\DBAL\Schema\Table" />
+				<referencedClass name="Doctrine\DBAL\Platforms\AbstractPlatform" />
+				<referencedClass name="Doctrine\DBAL\Platforms\MySQLPlatform" />
 				<referencedClass name="OC\Security\CSP\ContentSecurityPolicyNonceManager" />
 			</errorLevel>
 		</UndefinedDocblockClass>


### PR DESCRIPTION
This ensures that indexes of oc_share are being used on MySQL when fetching the shares of a user during mountpoint setup, where otherwise a full table scan would happen.

@nickvergessen I'm wondering if there is a specific reason that the MySQLExpressionBuilder does not implement any actual casting when using castColumn(). Is that something that we should rather do in the server then maybe?

### EXPLAIN before
```
+------+-------------+-------+--------+----------------------------------------+----------------------------+---------+-------------------------+------+-------------------------------------------------+
| id   | select_type | table | type   | possible_keys                          | key                        | key_len | ref                     | rows | Extra                                           |
+------+-------------+-------+--------+----------------------------------------+----------------------------+---------+-------------------------+------+-------------------------------------------------+
|    1 | SIMPLE      | db    | const  | PRIMARY                                | PRIMARY                    | 4       | const                   | 1    | Using index; Using temporary; Using filesort    |
|    1 | SIMPLE      | ds    | ref    | PRIMARY,deck_stacks_board_id_index     | deck_stacks_board_id_index | 8       | const                   | 1    | Using index                                     |
|    1 | SIMPLE      | dc    | ref    | PRIMARY,deck_cards_stack_id_index      | deck_cards_stack_id_index  | 8       | nextcloud.ds.id         | 1    | Using where; Using index                        |
|    1 | SIMPLE      | s     | ALL    | item_share_type_index,share_with_index | NULL                       | NULL    | NULL                    | 1290 | Using where; Using join buffer (flat, BNL join) |
|    1 | SIMPLE      | f     | eq_ref | PRIMARY,fs_id_storage_size             | PRIMARY                    | 8       | nextcloud.s.file_source | 1    | Using where                                     |
|    1 | SIMPLE      | st    | eq_ref | PRIMARY                                | PRIMARY                    | 8       | nextcloud.f.storage     | 1    | Using where                                     |
+------+-------------+-------+--------+----------------------------------------+----------------------------+---------+-------------------------+------+-------------------------------------------------+
```

### EXPLAIN after

```
+------+-------------+-------+--------+----------------------------------------+----------------------------+---------+-------------------------+------+----------------------------------------------+
| id   | select_type | table | type   | possible_keys                          | key                        | key_len | ref                     | rows | Extra                                        |
+------+-------------+-------+--------+----------------------------------------+----------------------------+---------+-------------------------+------+----------------------------------------------+
|    1 | SIMPLE      | db    | const  | PRIMARY                                | PRIMARY                    | 4       | const                   | 1    | Using index; Using temporary; Using filesort |
|    1 | SIMPLE      | ds    | ref    | PRIMARY,deck_stacks_board_id_index     | deck_stacks_board_id_index | 8       | const                   | 1    | Using index                                  |
|    1 | SIMPLE      | dc    | ref    | deck_cards_stack_id_index              | deck_cards_stack_id_index  | 8       | nextcloud.ds.id         | 1    | Using where; Using index                     |
|    1 | SIMPLE      | s     | ref    | item_share_type_index,share_with_index | share_with_index           | 1023    | func                    | 36   | Using index condition; Using where           |
|    1 | SIMPLE      | f     | eq_ref | PRIMARY,fs_id_storage_size             | PRIMARY                    | 8       | nextcloud.s.file_source | 1    | Using where                                  |
|    1 | SIMPLE      | st    | eq_ref | PRIMARY                                | PRIMARY                    | 8       | nextcloud.f.storage     | 1    | Using where                                  |
+------+-------------+-------+--------+----------------------------------------+----------------------------+---------+-------------------------+------+----------------------------------------------+
```
