### PR TITLE
Fix CalDAV blocking and modernize circles API usage

### DIFF
--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -37,6 +37,7 @@ use OCA\Deck\Db\StackMapper;
 use OCA\Deck\Event\CardCreatedEvent;
 use OCA\Deck\Event\CardDeletedEvent;
 use OCA\Deck\Event\CardUpdatedEvent;
+use OCA\Deck\NoPermissionException;
 use OCA\Deck\Notification\NotificationHelper;
 use OCA\Deck\Db\BoardMapper;
 use OCA\Deck\Db\LabelMapper;
@@ -154,7 +155,12 @@ class CardService {
 	}
 
 	public function findCalendarEntries($boardId) {
-		$this->permissionService->checkPermission($this->boardMapper, $boardId, Acl::PERMISSION_READ);
+		try {
+			$this->permissionService->checkPermission($this->boardMapper, $boardId, Acl::PERMISSION_READ);
+		} catch (NoPermissionException $e) {
+			\OC::$server->getLogger()->error('Unable to check permission for a previously obtained board ' . $boardId, ['exception' => $e]);
+			return [];
+		}
 		$cards = $this->cardMapper->findCalendarEntries($boardId);
 		foreach ($cards as $card) {
 			$this->enrich($card);

--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -280,14 +280,14 @@ class PermissionService {
 
 			if ($this->circlesService->isCirclesEnabled() && $acl->getType() === Acl::PERMISSION_TYPE_CIRCLE) {
 				try {
-					$circle = \OCA\Circles\Api\v1\Circles::detailsCircle($acl->getParticipant(), true);
+					$circle = $this->circlesService->getCircle($acl->getParticipant());
 					if ($circle === null) {
 						$this->logger->info('No circle found for acl rule ' . $acl->getId());
 						continue;
 					}
 
 					foreach ($circle->getInheritedMembers() as $member) {
-						if ($member->getUserType() !== 1 || $member->getLevel() >= Member::LEVEL_MEMBER) {
+						if ($member->getUserType() !== 1 || $member->getLevel() < Member::LEVEL_MEMBER) {
 							// deck currently only supports user members in circles
 							continue;
 						}

--- a/lib/Service/StackService.php
+++ b/lib/Service/StackService.php
@@ -35,6 +35,7 @@ use OCA\Deck\Db\ChangeHelper;
 use OCA\Deck\Db\LabelMapper;
 use OCA\Deck\Db\Stack;
 use OCA\Deck\Db\StackMapper;
+use OCA\Deck\NoPermissionException;
 use OCA\Deck\StatusException;
 
 class StackService {
@@ -142,7 +143,12 @@ class StackService {
 	}
 
 	public function findCalendarEntries($boardId) {
-		$this->permissionService->checkPermission(null, $boardId, Acl::PERMISSION_READ);
+		try {
+			$this->permissionService->checkPermission(null, $boardId, Acl::PERMISSION_READ);
+		} catch (NoPermissionException $e) {
+			\OC::$server->getLogger()->error('Unable to check permission for a previously obtained board ' . $boardId, ['exception' => $e]);
+			return [];
+		}
 		return $this->stackMapper->findAll($boardId);
 	}
 

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.11.2@6fba5eb554f9507b72932f9c75533d8af593688d">
+<files psalm-version="4.16.1@aa7e400908833b10c0333861f86cd48c510b60eb">
   <file src="lib/Activity/ActivityManager.php">
     <TypeDoesNotContainType occurrences="1">
       <code>$message !== null</code>
@@ -124,10 +124,6 @@
       <code>$offset !== null</code>
       <code>$offset !== null</code>
     </TypeDoesNotContainType>
-    <UndefinedClass occurrences="2">
-      <code>\OCA\Circles\Api\v1\Circles</code>
-      <code>\OCA\Circles\Api\v1\Circles</code>
-    </UndefinedClass>
   </file>
   <file src="lib/Db/Card.php">
     <UndefinedClass occurrences="2">
@@ -136,7 +132,6 @@
     </UndefinedClass>
   </file>
   <file src="lib/Db/CardMapper.php">
-    <InvalidArgument occurrences="1"/>
     <InvalidScalarArgument occurrences="1">
       <code>$entity-&gt;getId()</code>
     </InvalidScalarArgument>
@@ -224,9 +219,11 @@
   </file>
   <file src="lib/Service/CirclesService.php">
     <UndefinedClass occurrences="1">
-      <code>\OCA\Circles\Api\v1\Circles</code>
+      <code>?Circle</code>
     </UndefinedClass>
-    <UndefinedDocblockClass occurrences="1">
+    <UndefinedDocblockClass occurrences="3">
+      <code>$circlesManager</code>
+      <code>$circlesManager</code>
       <code>$circlesManager</code>
     </UndefinedDocblockClass>
   </file>
@@ -272,44 +269,22 @@
     </RedundantCondition>
   </file>
   <file src="lib/Service/FilesAppService.php">
-    <MissingDependency occurrences="4">
+    <MissingDependency occurrences="3">
       <code>$this-&gt;rootFolder</code>
       <code>$this-&gt;rootFolder</code>
       <code>IRootFolder</code>
-      <code>ShareNotFound</code>
     </MissingDependency>
   </file>
   <file src="lib/Service/PermissionService.php">
     <UndefinedClass occurrences="2">
+      <code>$circle</code>
       <code>Member</code>
-      <code>\OCA\Circles\Api\v1\Circles</code>
     </UndefinedClass>
   </file>
   <file src="lib/Service/StackService.php">
     <UndefinedClass occurrences="1">
       <code>BadRquestException</code>
     </UndefinedClass>
-  </file>
-  <file src="lib/Sharing/DeckShareProvider.php">
-    <InvalidReturnStatement occurrences="1">
-      <code>$shares</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>getSharesInFolder</code>
-    </InvalidReturnType>
-    <InvalidThrow occurrences="1">
-      <code>throw new GenericShareException('Already shared', $this-&gt;l-&gt;t('Path is already shared with this card'), 403);</code>
-    </InvalidThrow>
-    <MissingDependency occurrences="8">
-      <code>GenericShareException</code>
-      <code>GenericShareException</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-      <code>ShareNotFound</code>
-    </MissingDependency>
   </file>
   <file src="lib/Sharing/Listener.php">
     <InvalidArgument occurrences="1">

--- a/tests/unit/Db/AclMapperTest.php
+++ b/tests/unit/Db/AclMapperTest.php
@@ -23,6 +23,7 @@
 
 namespace OCA\Deck\Db;
 
+use OCA\Deck\Service\CirclesService;
 use OCP\IGroupManager;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
@@ -56,6 +57,7 @@ class AclMapperTest extends MapperTestUtility {
 			\OC::$server->query(StackMapper::class),
 			$this->userManager,
 			$this->groupManager,
+			$this->createMock(CirclesService::class),
 			$this->createMock(LoggerInterface::class)
 		);
 

--- a/tests/unit/Db/BoardMapperTest.php
+++ b/tests/unit/Db/BoardMapperTest.php
@@ -23,6 +23,7 @@
 
 namespace OCA\Deck\Db;
 
+use OCA\Deck\Service\CirclesService;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUserManager;
@@ -63,6 +64,7 @@ class BoardMapperTest extends MapperTestUtility {
 			\OC::$server->query(StackMapper::class),
 			$this->userManager,
 			$this->groupManager,
+			$this->createMock(CirclesService::class),
 			$this->createMock(LoggerInterface::class)
 		);
 		$this->aclMapper = \OC::$server->query(AclMapper::class);


### PR DESCRIPTION
- Avoid blocking calendar access if something goes wrong while fetching deck entries
- Move any circles API usage to internal service and make use of new circles API to get the list of circles for a user

* Resolves: #3312
