### PR TITLE
CardApiController: Fix order of optional parameters

### DIFF
--- a/lib/Controller/CardApiController.php
+++ b/lib/Controller/CardApiController.php
@@ -94,7 +94,7 @@ class CardApiController extends ApiController {
 	 *
 	 * Update a card
 	 */
-	public function update($title, $type, $order = 0, $description = '', $owner, $duedate = null, $archived = null) {
+	public function update($title, $type, $owner, $description = '', $order = 0, $duedate = null, $archived = null) {
 		$card = $this->cardService->update($this->request->getParam('cardId'), $title, $this->request->getParam('stackId'), $type, $owner, $description, $order, $duedate, 0, $archived);
 		return new DataResponse($card, HTTP::STATUS_OK);
 	}


### PR DESCRIPTION
Signed-off-by: Simon Spannagel <simonspa@kth.se>


* Follow-up from https://github.com/nextcloud/deck/pull/3364
* Target version: master 

### Summary

This fixes the logged error

```
{"reqId":"KPFJVKJ3cHDPY5qOA5Ec","level":3,"time":"2022-01-07T00:14:07+01:00","remoteAddr":"<ip>","user":"<user>","app":"PHP","method":"GET","url":"/index.php/apps/deck/api/v1.1/boards/13/stacks/58/cards/92?","message":"Required parameter $owner follows optional parameter $order at /var/www/nextcloud/apps/deck/lib/Controller/CardApiController.php#97","userAgent":"Mozilla/5.0 (Android) Nextcloud-android/3.18.1","version":"22.2.3.0","id":"61d8159819147"}
```

appearing when updating cards from the Deck Android app.


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
