### PR TITLE
Add app config to toggle the default calendar setting as an admin

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -102,7 +102,8 @@ class ConfigService {
 			return false;
 		}
 
-		$defaultState = (bool)$this->config->getUserValue($this->getUserId(), Application::APP_ID, 'calendar', true);
+		$appConfigState = $this->config->getAppValue(Application::APP_ID, 'calendar', 'yes') === 'yes';
+		$defaultState = (bool)$this->config->getUserValue($this->getUserId(), Application::APP_ID, 'calendar', $appConfigState);
 		if ($boardId === null) {
 			return $defaultState;
 		}


### PR DESCRIPTION
Allow to change the default setting if calendar integration should be enabled through occ:

```
occ config:app:set deck calendar --value="no"
```