### PR TITLE
Make links in markdown note bolder

### DIFF
--- a/src/components/card/Description.vue
+++ b/src/components/card/Description.vue
@@ -334,4 +334,15 @@ h5 {
 #app-sidebar .app-sidebar-header__desc h4 {
 	font-size: 12px !important;
 }
+
+.vue-easymde .cm-s-easymde .cm-link {
+	color: var(--color-main-text);
+}
+
+.vue-easymde .cm-s-easymde .cm-string.cm-url,
+.vue-easymde .cm-s-easymde .cm-formatting.cm-link,
+.vue-easymde .cm-s-easymde .cm-formatting.cm-url,
+.vue-easymde .cm-s-easymde .cm-formatting.cm-image {
+	color: var(--color-text-maxcontrast);
+}
 </style>


### PR DESCRIPTION
Signed-off-by: Luka Trovic <luka@nextcloud.com>


* Resolves: #3443
* Target version: master 

### Summary
Improve contrast link in Markdown note

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
