### PR TITLE
Fix confusion between stackId and boardId in StackService

### DIFF
--- a/lib/Service/StackService.php
+++ b/lib/Service/StackService.php
@@ -290,8 +290,8 @@ class StackService {
 			throw new BadRequestException('order must be a number');
 		}
 
-		$this->permissionService->checkPermission($this->stackMapper, $id, Acl::PERMISSION_MANAGE);
-		if ($this->boardService->isArchived($this->stackMapper, $id)) {
+		$this->permissionService->checkPermission($this->stackMapper, $boardId, Acl::PERMISSION_MANAGE);
+		if ($this->boardService->isArchived($this->stackMapper, $boardId)) {
 			throw new StatusException('Operation not allowed. This board is archived.');
 		}
 		$stack = $this->stackMapper->find($id);


### PR DESCRIPTION
The stack ID is used instead of the board ID to check if the current user has permissions to update a stack.