### PR TITLE
return the selector for collections

### DIFF
--- a/src/init-collections.js
+++ b/src/init-collections.js
@@ -45,7 +45,7 @@ window.addEventListener('DOMContentLoaded', () => {
 	window.OCP.Collaboration.registerType('deck', {
 		action: () => {
 			const BoardSelector = () => import('./BoardSelector')
-			buildSelector(BoardSelector)
+			return buildSelector(BoardSelector)
 		},
 		typeString: t('deck', 'Link to a board'),
 		typeIconClass: 'icon-deck',
@@ -54,7 +54,7 @@ window.addEventListener('DOMContentLoaded', () => {
 	window.OCP.Collaboration.registerType('deck-card', {
 		action: () => {
 			const CardSelector = () => import('./CardSelector')
-			buildSelector(CardSelector)
+			return buildSelector(CardSelector)
 		},
 		typeString: t('deck', 'Link to a card'),
 		typeIconClass: 'icon-deck',


### PR DESCRIPTION
I stumbled over it, when adding collections to Polls. 

* Target version: master 

### Summary
Avoids `TypeError: can't access property "then", e.action() is undefined` when adding a board or card as collection

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required

