### PR TITLE
Move DeleteCron to be time insensitive

### DIFF
--- a/lib/Cron/CardDescriptionActivity.php
+++ b/lib/Cron/CardDescriptionActivity.php
@@ -24,7 +24,7 @@
 
 namespace OCA\Deck\Cron;
 
-use OC\BackgroundJob\Job;
+use OCP\BackgroundJob\Job;
 use OCA\Deck\Activity\ActivityManager;
 use OCA\Deck\Db\CardMapper;
 

--- a/lib/Cron/DeleteCron.php
+++ b/lib/Cron/DeleteCron.php
@@ -24,13 +24,14 @@
 
 namespace OCA\Deck\Cron;
 
-use OC\BackgroundJob\Job;
+use OCP\BackgroundJob\TimedJob;
 use OCA\Deck\Db\AttachmentMapper;
 use OCA\Deck\Db\BoardMapper;
 use OCA\Deck\InvalidAttachmentType;
 use OCA\Deck\Service\AttachmentService;
+use OCP\BackgroundJob\IJob;
 
-class DeleteCron extends Job {
+class DeleteCron extends TimedJob {
 
 	/** @var BoardMapper */
 	private $boardMapper;
@@ -43,6 +44,9 @@ class DeleteCron extends Job {
 		$this->boardMapper = $boardMapper;
 		$this->attachmentService = $attachmentService;
 		$this->attachmentMapper = $attachmentMapper;
+
+		$this->setInterval(60 * 60 * 24);
+		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
 	}
 
 	/**

--- a/lib/Cron/ScheduledNotifications.php
+++ b/lib/Cron/ScheduledNotifications.php
@@ -23,7 +23,7 @@
 
 namespace OCA\Deck\Cron;
 
-use OC\BackgroundJob\Job;
+use OCP\BackgroundJob\Job;
 use OCA\Deck\Db\Card;
 use OCA\Deck\Db\CardMapper;
 use OCA\Deck\Notification\NotificationHelper;


### PR DESCRIPTION
- Mark the DeleteCron background job, which cleans up items which were marked as deleted to be time insensitive (contributes to https://github.com/nextcloud/office/issues/14)
- Use public namespace job class in all jobs