### PR TITLE
Fix: Check all circle shares for permissions

### DIFF
--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -213,7 +213,9 @@ class PermissionService {
 
 			if ($this->circlesService->isCirclesEnabled() && $acl->getType() === Acl::PERMISSION_TYPE_CIRCLE) {
 				try {
-					return $this->circlesService->isUserInCircle($acl->getParticipant(), $userId) && $acl->getPermission($permission);
+					if ($this->circlesService->isUserInCircle($acl->getParticipant(), $userId) && $acl->getPermission($permission)) {
+						return true;
+					}
 				} catch (\Exception $e) {
 					$this->logger->info('Member not found in circle that was accessed. This should not happen.');
 				}


### PR DESCRIPTION
* Target version: master 

### Summary

Fixes a bug that appears when a board is shared with multiple circles, causing calendars not to work because of a permission exception.
If a board is shared with a circle, the \OCA\Deck\Service\PermissionService::userCan method would only return the permissions for the first circle and not evaluate other permissions like groups or other circles. This is fixed by only returning true if the permissions are actually present and continuing the check when they are not.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
