### PR TITLE
🚸 Shows error on board fetchData

### DIFF
--- a/src/components/board/Board.vue
+++ b/src/components/board/Board.vue
@@ -77,6 +77,7 @@ import Controls from '../Controls'
 import Stack from './Stack'
 import { EmptyContent } from '@nextcloud/vue'
 import GlobalSearchResults from '../search/GlobalSearchResults'
+import { showError } from '../../helpers/errors'
 
 export default {
 	name: 'Board',
@@ -139,6 +140,7 @@ export default {
 				await this.$store.dispatch('loadStacks', this.id)
 			} catch (e) {
 				console.error(e)
+				showError(e)
 			}
 			this.loading = false
 		},

--- a/src/helpers/errors.js
+++ b/src/helpers/errors.js
@@ -1,0 +1,27 @@
+import { showError as errorDialog } from '@nextcloud/dialogs'
+
+const showAxiosError = err => {
+	const response = err?.response || {}
+	const message = response?.data.message
+
+	if (message) {
+		errorDialog(message)
+		return
+	}
+
+	errorDialog(err.message)
+}
+
+const showError = err => {
+	// axios error
+	if (err.response) {
+		showAxiosError(err)
+		return
+	}
+
+	errorDialog(err.message)
+}
+
+export {
+	showError,
+}


### PR DESCRIPTION
* Related issues: 
  * #2559
  * #3634 

* Target version: master 

### Summary
In some cases `fetchData` receive errors from API, never stop the loading and no message appears to the user.

This small change allows showing the API error to the user.


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
