### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/components/ActivityEntry.vue
+++ b/src/components/ActivityEntry.vue
@@ -75,7 +75,7 @@ export default {
 			const subject = this.activity.subject_rich[0]
 			const parameters = JSON.parse(JSON.stringify(this.activity.subject_rich[1]))
 			if (parameters.after && typeof parameters.after.id === 'string' && parameters.after.id.startsWith('dt:')) {
-				const dateTime = parameters.after.id.substr(3)
+				const dateTime = parameters.after.id.slice(3)
 				parameters.after.name = moment(dateTime).format('L LTS')
 			}
 

--- a/src/init-calendar.js
+++ b/src/init-calendar.js
@@ -26,8 +26,8 @@ import { generateUrl } from '@nextcloud/router'
 subscribe('calendar:handle-todo-click', ({ calendarId, taskId }) => {
 	const deckAppPrefix = 'app-generated--deck--board-'
 	if (calendarId.startsWith(deckAppPrefix)) {
-		const board = calendarId.substr(deckAppPrefix.length)
-		const card = taskId.substr('card-'.length).replace('.ics', '')
+		const board = calendarId.slice(deckAppPrefix.length)
+		const card = taskId.slice('card-'.length).replace('.ics', '')
 		console.debug('[deck] Clicked task matches deck calendar pattern')
 		window.location = generateUrl(`apps/deck/#/board/${board}/card/${card}`)
 	}

--- a/src/init-talk.js
+++ b/src/init-talk.js
@@ -46,7 +46,7 @@ window.addEventListener('DOMContentLoaded', () => {
 		icon: 'icon-deck',
 		async callback({ message: { message, actorDisplayName }, metadata: { name: conversationName, token: conversationToken } }) {
 			const shortenedMessageCandidate = message.replace(/^(.{255}[^\s]*).*/, '$1')
-			const shortenedMessage = shortenedMessageCandidate === '' ? message.substr(0, 255) : shortenedMessageCandidate
+			const shortenedMessage = shortenedMessageCandidate === '' ? message.slice(0, 255) : shortenedMessageCandidate
 			try {
 				await buildSelector(CardCreateDialog, {
 					props: {

--- a/src/store/card.js
+++ b/src/store/card.js
@@ -92,7 +92,7 @@ export default {
 
 					const filterOutQuotes = (q) => {
 						if (q[0] === '"' && q[q.length - 1] === '"') {
-							return q.substr(1, q.length - 2)
+							return q.slice(1, -1)
 						}
 						return q
 					}
@@ -153,7 +153,7 @@ export default {
 							const comparator = query[0] + (query[1] === '=' ? '=' : '')
 							const isValidComparator = ['<', '<=', '>', '>='].indexOf(comparator) !== -1
 							const parsedCardDate = moment(card.duedate)
-							const parsedDate = moment(query.substr(isValidComparator ? comparator.length : 0))
+							const parsedDate = moment(query.slice(isValidComparator ? comparator.length : 0))
 							switch (comparator) {
 							case '<':
 								hasMatch = hasMatch && parsedCardDate.isBefore(parsedDate)


### PR DESCRIPTION
### Summary

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
