### PR TITLE
Properly check for the stack AND setting board permissions

### DIFF
--- a/lib/Service/StackService.php
+++ b/lib/Service/StackService.php
@@ -290,10 +290,13 @@ class StackService {
 			throw new BadRequestException('order must be a number');
 		}
 
-		$this->permissionService->checkPermission($this->stackMapper, $boardId, Acl::PERMISSION_MANAGE);
-		if ($this->boardService->isArchived($this->stackMapper, $boardId)) {
+		$this->permissionService->checkPermission($this->stackMapper, $id, Acl::PERMISSION_MANAGE);
+		$this->permissionService->checkPermission($this->boardMapper, $boardId, Acl::PERMISSION_MANAGE);
+
+		if ($this->boardService->isArchived($this->stackMapper, $id)) {
 			throw new StatusException('Operation not allowed. This board is archived.');
 		}
+
 		$stack = $this->stackMapper->find($id);
 		$changes = new ChangeSet($stack);
 		$stack->setTitle($title);

--- a/tests/unit/Service/StackServiceTest.php
+++ b/tests/unit/Service/StackServiceTest.php
@@ -195,7 +195,7 @@ class StackServiceTest extends TestCase {
 	}
 
 	public function testUpdate() {
-		$this->permissionService->expects($this->once())->method('checkPermission');
+		$this->permissionService->expects($this->exactly(2))->method('checkPermission');
 		$stack = new Stack();
 		$this->stackMapper->expects($this->once())->method('find')->willReturn($stack);
 		$this->stackMapper->expects($this->once())->method('update')->willReturn($stack);


### PR DESCRIPTION
Fixes a regression from https://github.com/nextcloud/deck/pull/3541 where the the boardId was taken to check for stack permissions. To properly check this we need to extend the permission checks to validate if the board provided in the boardId is also accessible by the user.

Steps to reproduce:
- Rename a list

Before:
403

After:
works again 

Fixes https://github.com/nextcloud/deck/issues/3633