### PR TITLE
Show cards after moving into another list

### DIFF
--- a/src/components/cards/CardMenu.vue
+++ b/src/components/cards/CardMenu.vue
@@ -135,6 +135,10 @@ export default {
 		},
 		activeBoards() {
 			return this.$store.getters.boards.filter((item) => item.deletedAt === 0 && item.archived === false)
+		},
+
+		boardId() {
+			return this.card?.boardId ? this.card.boardId : this.$route.params.id
 		}
 	},
 	methods: {
@@ -169,10 +173,9 @@ export default {
 		},
 		async moveCard() {
 			this.copiedCard = Object.assign({}, this.card)
-			const boardId = this.card?.boardId ? this.card.boardId : this.$route.params.id
 			this.copiedCard.stackId = this.selectedStack.id
 			this.$store.dispatch('moveCard', this.copiedCard)
-			if (parseInt(boardId) === parseInt(this.selectedStack.boardId)) {
+			if (parseInt(this.boardId) === parseInt(this.selectedStack.boardId)) {
 				await this.$store.commit('addNewCard', { ...this.copiedCard })
 			}
 			this.modalShow = false

--- a/src/components/cards/CardMenu.vue
+++ b/src/components/cards/CardMenu.vue
@@ -167,10 +167,14 @@ export default {
 				},
 			})
 		},
-		moveCard() {
+		async moveCard() {
 			this.copiedCard = Object.assign({}, this.card)
+			const boardId = this.card?.boardId ? this.card.boardId : this.$route.params.id
 			this.copiedCard.stackId = this.selectedStack.id
 			this.$store.dispatch('moveCard', this.copiedCard)
+			if (parseInt(boardId) === parseInt(this.selectedStack.boardId)) {
+				await this.$store.commit('addNewCard', { ...this.copiedCard })
+			}
 			this.modalShow = false
 		},
 		async loadStacksFromBoard(board) {

--- a/src/store/card.js
+++ b/src/store/card.js
@@ -264,6 +264,9 @@ export default {
 				Vue.set(state.cards[existingIndex], 'attachmentCount', state.cards[existingIndex].attachmentCount - 1)
 			}
 		},
+		addNewCard(state, card) {
+			state.cards.push(card)
+		},
 	},
 	actions: {
 		async addCard({ commit }, card) {


### PR DESCRIPTION
Signed-off-by: Luka Trovic <luka@nextcloud.com>


* Resolves: #3676
* Target version: master 

### Summary
Cards disappear after moving from one list into another.

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
