### PR TITLE
Fix cron jobs

### DIFF
--- a/lib/Cron/CardDescriptionActivity.php
+++ b/lib/Cron/CardDescriptionActivity.php
@@ -24,6 +24,7 @@
 
 namespace OCA\Deck\Cron;
 
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\Job;
 use OCA\Deck\Activity\ActivityManager;
 use OCA\Deck\Db\CardMapper;
@@ -35,7 +36,8 @@ class CardDescriptionActivity extends Job {
 	/** @var CardMapper */
 	private $cardMapper;
 
-	public function __construct(ActivityManager $activityManager, CardMapper $cardMapper) {
+	public function __construct(ITimeFactory $time, ActivityManager $activityManager, CardMapper $cardMapper) {
+		parent::__construct($time);
 		$this->activityManager = $activityManager;
 		$this->cardMapper = $cardMapper;
 	}

--- a/lib/Cron/DeleteCron.php
+++ b/lib/Cron/DeleteCron.php
@@ -24,6 +24,7 @@
 
 namespace OCA\Deck\Cron;
 
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCA\Deck\Db\AttachmentMapper;
 use OCA\Deck\Db\BoardMapper;
@@ -40,7 +41,8 @@ class DeleteCron extends TimedJob {
 	/** @var AttachmentMapper */
 	private $attachmentMapper;
 
-	public function __construct(BoardMapper $boardMapper, AttachmentService $attachmentService, AttachmentMapper $attachmentMapper) {
+	public function __construct(ITimeFactory $time, BoardMapper $boardMapper, AttachmentService $attachmentService, AttachmentMapper $attachmentMapper) {
+		parent::__construct($time);
 		$this->boardMapper = $boardMapper;
 		$this->attachmentService = $attachmentService;
 		$this->attachmentMapper = $attachmentMapper;

--- a/lib/Cron/ScheduledNotifications.php
+++ b/lib/Cron/ScheduledNotifications.php
@@ -23,6 +23,7 @@
 
 namespace OCA\Deck\Cron;
 
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\Job;
 use OCA\Deck\Db\Card;
 use OCA\Deck\Db\CardMapper;
@@ -40,10 +41,12 @@ class ScheduledNotifications extends Job {
 	protected $logger;
 
 	public function __construct(
+		ITimeFactory $time,
 		CardMapper $cardMapper,
 		NotificationHelper $notificationHelper,
 		ILogger $logger
 	) {
+		parent::__construct($time);
 		$this->cardMapper = $cardMapper;
 		$this->notificationHelper = $notificationHelper;
 		$this->logger = $logger;

--- a/tests/unit/Cron/DeleteCronTest.php
+++ b/tests/unit/Cron/DeleteCronTest.php
@@ -30,24 +30,30 @@ use OCA\Deck\Db\BoardMapper;
 use OCA\Deck\InvalidAttachmentType;
 use OCA\Deck\Service\AttachmentService;
 use OCA\Deck\Service\IAttachmentService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
 
-class DeleteCronTest extends \Test\TestCase {
+class DeleteCronTest extends TestCase {
 
-	/** @var BoardMapper|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var ITimeFactory|MockObject */
+	private $timeFactory;
+	/** @var BoardMapper|MockObject */
 	protected $boardMapper;
-	/** @var AttachmentService|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var AttachmentService|MockObject */
 	private $attachmentService;
-	/** @var AttachmentMapper|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var AttachmentMapper|MockObject */
 	private $attachmentMapper;
 	/** @var DeleteCron */
 	protected $deleteCron;
 
 	public function setUp(): void {
 		parent::setUp();
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->boardMapper = $this->createMock(BoardMapper::class);
 		$this->attachmentService = $this->createMock(AttachmentService::class);
 		$this->attachmentMapper = $this->createMock(AttachmentMapper::class);
-		$this->deleteCron = new DeleteCron($this->boardMapper, $this->attachmentService, $this->attachmentMapper);
+		$this->deleteCron = new DeleteCron($this->timeFactory, $this->boardMapper, $this->attachmentService, $this->attachmentMapper);
 	}
 
 	protected function getBoard($id) {

--- a/tests/unit/Cron/ScheduledNoificationsTest.php
+++ b/tests/unit/Cron/ScheduledNoificationsTest.php
@@ -26,28 +26,34 @@ namespace OCA\Deck\Cron;
 use OCA\Deck\Db\Card;
 use OCA\Deck\Db\CardMapper;
 use OCA\Deck\Notification\NotificationHelper;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\ILogger;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
 
-class ScheduledNoificationsTest extends \Test\TestCase {
+class ScheduledNoificationsTest extends TestCase {
 
-	/** @var CardMapper|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var ITimeFactory|MockObject */
+	protected $timeFactory;
+	/** @var CardMapper|MockObject */
 	protected $cardMapper;
-	/** @var NotificationHelper|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var NotificationHelper|MockObject */
 	protected $notificationHelper;
-	/** @var ILogger|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var ILogger|MockObject */
 	protected $logger;
 	/** @var ScheduledNotifications */
 	protected $scheduledNotifications;
 
 	public function setUp(): void {
 		parent::setUp();
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->cardMapper = $this->createMock(CardMapper::class);
 		$this->notificationHelper = $this->createMock(NotificationHelper::class);
 		$this->logger = $this->createMock(ILogger::class);
-		$this->scheduledNotifications = new ScheduledNotifications($this->cardMapper, $this->notificationHelper, $this->logger);
+		$this->scheduledNotifications = new ScheduledNotifications($this->timeFactory, $this->cardMapper, $this->notificationHelper, $this->logger);
 	}
 
-	public function testDeleteCron() {
+	public function testScheduledCron() {
 		$c1 = new Card();
 		$c2 = new Card();
 		$cards = [$c1, $c2];


### PR DESCRIPTION
Regression from e42ffa4ca2c6d92bce0e34142d91b4d1ef9f8507

```
Error: Call to a member function getTime() on null in /home/nickv/Nextcloud/24/server/lib/public/BackgroundJob/Job.php:77
Stack trace:
#0 /home/nickv/Nextcloud/24/server/cron.php(151): OCP\BackgroundJob\Job->execute(Object(OC\BackgroundJob\JobList), Object(OC\Log))
#1 {main}
/home/nickv/Nextcloud/24/server
```

Not sure why CI passes