### PR TITLE
Optimise queries when preparing card related notifications

### DIFF
--- a/lib/Db/Stack.php
+++ b/lib/Db/Stack.php
@@ -25,6 +25,13 @@ namespace OCA\Deck\Db;
 
 use Sabre\VObject\Component\VCalendar;
 
+/**
+ * @method int getId()
+ * @method int getBoardId()
+ * @method int getDeletedAt()
+ * @method int getLastModified()
+ * @method int getOrder()
+ */
 class Stack extends RelationalEntity {
 	protected $title;
 	protected $boardId;

--- a/lib/Db/StackMapper.php
+++ b/lib/Db/StackMapper.php
@@ -62,9 +62,10 @@ WHERE c.id = ?
 SQL;
 		try {
 			return $this->findEntity($sql, [$cardId]);
-		} catch (IMapperException $e) {
-			return null;
+		} catch (MultipleObjectsReturnedException|DoesNotExistException $e) {
 		}
+
+		return null;
 	}
 
 

--- a/lib/Db/StackMapper.php
+++ b/lib/Db/StackMapper.php
@@ -25,6 +25,7 @@ namespace OCA\Deck\Db;
 
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\Entity;
+use OCP\AppFramework\Db\IMapperException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\IDBConnection;
 
@@ -46,6 +47,24 @@ class StackMapper extends DeckMapper implements IPermissionMapper {
 		$sql = 'SELECT * FROM `*PREFIX*deck_stacks` ' .
 			'WHERE `id` = ?';
 		return $this->findEntity($sql, [$id]);
+	}
+
+	/**
+	 * @param $cardId
+	 * @return Stack|null
+	 */
+	public function findStackFromCardId($cardId): ?Stack {
+		$sql = <<<SQL
+SELECT s.* 
+FROM `*PREFIX*deck_stacks` as `s`
+INNER JOIN `*PREFIX*deck_cards` as `c` ON s.id = c.stack_id
+WHERE c.id = ?
+SQL;
+		try {
+			return $this->findEntity($sql, [$cardId]);
+		} catch (IMapperException $e) {
+			return null;
+		}
 	}
 
 

--- a/lib/Db/StackMapper.php
+++ b/lib/Db/StackMapper.php
@@ -25,7 +25,6 @@ namespace OCA\Deck\Db;
 
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\Entity;
-use OCP\AppFramework\Db\IMapperException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\IDBConnection;
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -101,14 +101,11 @@ class Notifier implements INotifier {
 		switch ($notification->getSubject()) {
 			case 'card-assigned':
 				$cardId = $notification->getObjectId();
-				$boardId = $this->cardMapper->findBoardId($cardId);
+				$stack = $this->stackMapper->findStackFromCardId($cardId);
+				$boardId = $stack ? $stack->getBoardId() : null;
 				if (!$boardId) {
 					throw new AlreadyProcessedException();
 				}
-
-				$card = $this->cardMapper->find($cardId);
-				$stackId = $card->getStackId();
-				$stack = $this->stackMapper->find($stackId);
 
 				$initiator = $this->userManager->get($params[2]);
 				if ($initiator !== null) {
@@ -147,14 +144,11 @@ class Notifier implements INotifier {
 				break;
 			case 'card-overdue':
 				$cardId = $notification->getObjectId();
-				$boardId = $this->cardMapper->findBoardId($cardId);
+				$stack = $this->stackMapper->findStackFromCardId($cardId);
+				$boardId = $stack ? $stack->getBoardId() : null;
 				if (!$boardId) {
 					throw new AlreadyProcessedException();
 				}
-
-				$card = $this->cardMapper->find($cardId);
-				$stackId = $card->getStackId();
-				$stack = $this->stackMapper->find($stackId);
 
 				$notification->setParsedSubject(
 					(string) $l->t('The card "%s" on "%s" has reached its due date.', $params)
@@ -182,14 +176,11 @@ class Notifier implements INotifier {
 				break;
 			case 'card-comment-mentioned':
 				$cardId = $notification->getObjectId();
-				$boardId = $this->cardMapper->findBoardId($cardId);
+				$stack = $this->stackMapper->findStackFromCardId($cardId);
+				$boardId = $stack ? $stack->getBoardId() : null;
 				if (!$boardId) {
 					throw new AlreadyProcessedException();
 				}
-
-				$card = $this->cardMapper->find($cardId);
-				$stackId = $card->getStackId();
-				$stack = $this->stackMapper->find($stackId);
 
 				$initiator = $this->userManager->get($params[2]);
 				if ($initiator !== null) {

--- a/tests/unit/Notification/NotifierTest.php
+++ b/tests/unit/Notification/NotifierTest.php
@@ -345,11 +345,11 @@ class NotifierTest extends \Test\TestCase {
 	 * @return Stack|MockObject
 	 */
 	private function buildMockStack(int $boardId = 999) {
-		$mock_stack = $this->getMockBuilder(Stack::class)
+		$mockStack = $this->getMockBuilder(Stack::class)
 			->addMethods(['getBoardId'])
 			->getMock();
 
-		$mock_stack->method('getBoardId')->willReturn($boardId);
-		return $mock_stack;
+		$mockStack->method('getBoardId')->willReturn($boardId);
+		return $mockStack;
 	}
 }

--- a/tests/unit/Notification/NotifierTest.php
+++ b/tests/unit/Notification/NotifierTest.php
@@ -25,6 +25,7 @@ namespace OCA\Deck\Notification;
 
 use OCA\Deck\Db\BoardMapper;
 use OCA\Deck\Db\CardMapper;
+use OCA\Deck\Db\Stack;
 use OCA\Deck\Db\StackMapper;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -103,9 +104,9 @@ class NotifierTest extends \Test\TestCase {
 		$notification->expects($this->once())
 			->method('getObjectId')
 			->willReturn('123');
-		$this->cardMapper->expects($this->once())
-			->method('findBoardId')
-			->willReturn(999);
+		$this->stackMapper->expects($this->once())
+			->method('findStackFromCardId')
+			->willReturn($this->buildMockStack());
 		$expectedMessage = 'The card "Card title" on "Board title" has reached its due date.';
 		$notification->expects($this->once())
 			->method('setParsedSubject')
@@ -146,9 +147,9 @@ class NotifierTest extends \Test\TestCase {
 		$notification->expects($this->once())
 			->method('getObjectId')
 			->willReturn('123');
-		$this->cardMapper->expects($this->once())
-			->method('findBoardId')
-			->willReturn(999);
+		$this->stackMapper->expects($this->once())
+			->method('findStackFromCardId')
+			->willReturn($this->buildMockStack());
 		$expectedMessage = 'admin has mentioned you in a comment on "Card title".';
 		$notification->expects($this->once())
 			->method('setParsedSubject')
@@ -183,9 +184,9 @@ class NotifierTest extends \Test\TestCase {
 
 	/** @dataProvider dataPrepareCardAssigned */
 	public function testPrepareCardAssigned($withUserFound = true) {
-		$this->cardMapper->expects($this->once())
-			->method('findBoardId')
-			->willReturn(123);
+		$this->stackMapper->expects($this->once())
+			->method('findStackFromCardId')
+			->willReturn($this->buildMockStack(123));
 
 		/** @var INotification $notification */
 		$notification = $this->createMock(INotification::class);
@@ -337,5 +338,18 @@ class NotifierTest extends \Test\TestCase {
 		$actualNotification = $this->notifier->prepare($notification, 'en_US');
 
 		$this->assertEquals($notification, $actualNotification);
+	}
+
+	/**
+	 * @param int $boardId
+	 * @return Stack|MockObject
+	 */
+	private function buildMockStack(int $boardId = 999) {
+		$mock_stack = $this->getMockBuilder(Stack::class)
+			->addMethods(['getBoardId'])
+			->getMock();
+
+		$mock_stack->method('getBoardId')->willReturn($boardId);
+		return $mock_stack;
 	}
 }


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/deck/issues/3162
* Target version: master 

### Summary
Reduces the amount of queries required to prepare card-based notifications (the ones which store the cardId in the notification object ID), from 3 calls to 1. 


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
