### PR TITLE
Remove unused argument from transfer ownership

### DIFF
--- a/src/store/main.js
+++ b/src/store/main.js
@@ -486,9 +486,8 @@ export default new Vuex.Store({
 					dispatch('loadBoardById', acl.boardId)
 				})
 		},
-		async transferOwnership({ commit }, { boardId, owner, newOwner }) {
+		async transferOwnership({ commit }, { boardId, newOwner }) {
 			await axios.put(generateUrl(`apps/deck/boards/${boardId}/transferOwner`), {
-				owner,
 				newOwner,
 			})
 		},


### PR DESCRIPTION
The owner is not used in the controller arguments https://github.com/nextcloud/deck/blob/23f0b16a5aca738699bfaa396ff4d505f975b4cf/lib/Controller/BoardController.php#L165 as it is inherited from the board that is being transferred.