### PR TITLE
Fix text selection in dark mode and modal view

### DIFF
--- a/src/components/card/CardSidebar.vue
+++ b/src/components/card/CardSidebar.vue
@@ -225,6 +225,8 @@ export default {
 		padding: 0 14px;
 		max-height: 100%;
 		overflow: initial;
+		user-select: text;
+		-webkit-user-select: text;
 
 		&::v-deep {
 			.app-sidebar-header {

--- a/src/components/card/Description.vue
+++ b/src/components/card/Description.vue
@@ -323,6 +323,12 @@ h5 {
 	border-left: 1px solid var(--color-main-text);
 }
 
+.CodeMirror-selected,
+.CodeMirror-line::selection, .CodeMirror-line>span::selection, .CodeMirror-line>span>span::selection {
+	background: var(--color-primary-element) !important;
+	color: var(--color-primary-text) !important;
+}
+
 .editor-preview,
 .editor-statusbar {
 	display: none;


### PR DESCRIPTION
* Resolves: #3711
* Target version: master 

### Summary

- Ensure that text in the modal is selectable (as it is blocked by the modal components touch handling)
- Fix selection background color in dark mode

