### PR TITLE
feat: #3268 CTRL/CMD + ENTER to Save Changes on Card Description

### DIFF
--- a/src/components/card/Description.vue
+++ b/src/components/card/Description.vue
@@ -60,6 +60,7 @@
 			ref="markdownEditor"
 			v-model="description"
 			:configs="mdeConfig"
+			@initialized="addKeyListeners"
 			@update:modelValue="updateDescription"
 			@blur="saveDescription" />
 
@@ -175,34 +176,32 @@ export default {
 		},
 	},
 	methods: {
+		addKeyListeners() {
+			this.$refs.markdownEditor.easymde.codemirror.on('keydown', (a, b) => {
+
+				if (this.keyExitState === 0 && (b.key === 'Meta' || b.key === 'Alt')) {
+					this.keyExitState = 1
+				}
+				if (this.keyExitState === 1 && b.key === 'Enter') {
+					this.keyExitState = 0
+					this.$refs.markdownEditor.easymde.codemirror.off('keydown', undefined)
+					this.$refs.markdownEditor.easymde.codemirror.off('keyup', undefined)
+					this.hideEditor()
+				}
+			})
+			this.$refs.markdownEditor.easymde.codemirror.on('keyup', (a, b) => {
+				if (b.key === 'Meta' || b.key === 'Control') {
+					this.keyExitState = 0
+				}
+
+			})
+		},
 		showEditor() {
 			if (!this.canEdit) {
 				return
 			}
 			this.descriptionEditing = true
 			this.description = this.card.description
-
-			// Has to start after the Editor is fully loaded. This shouldn't take longer than 1/4 second
-			setTimeout(() => {
-				this.$refs.markdownEditor.easymde.codemirror.on('keydown', (a, b) => {
-
-					if (this.keyExitState === 0 && (b.key === 'Meta' || b.key === 'Alt')) {
-						this.keyExitState = 1
-					}
-					if (this.keyExitState === 1 && b.key === 'Enter') {
-						this.keyExitState = 0
-						this.$refs.markdownEditor.easymde.codemirror.off('keydown', undefined)
-						this.$refs.markdownEditor.easymde.codemirror.off('keyup', undefined)
-						this.hideEditor()
-					}
-				})
-				this.$refs.markdownEditor.easymde.codemirror.on('keyup', (a, b) => {
-					if (b.key === 'Meta' || b.key === 'Control') {
-						this.keyExitState = 0
-					}
-
-				})
-			}, 250)
 
 		},
 		hideEditor() {

--- a/src/components/card/Description.vue
+++ b/src/components/card/Description.vue
@@ -115,6 +115,7 @@ export default {
 	},
 	data() {
 		return {
+			keyExitState: 0,
 			description: '',
 			markdownIt: null,
 			descriptionEditing: false,
@@ -180,8 +181,33 @@ export default {
 			}
 			this.descriptionEditing = true
 			this.description = this.card.description
+
+			// Has to start after the Editor is fully loaded. This shouldn't take longer than 1/4 second
+			setTimeout(() => {
+				this.$refs.markdownEditor.easymde.codemirror.on('keydown', (a, b) => {
+
+					if (this.keyExitState === 0 && (b.key === 'Meta' || b.key === 'Alt')) {
+						this.keyExitState = 1
+					}
+					if (this.keyExitState === 1 && b.key === 'Enter') {
+						this.keyExitState = 0
+						this.$refs.markdownEditor.easymde.codemirror.off('keydown', undefined)
+						this.$refs.markdownEditor.easymde.codemirror.off('keyup', undefined)
+						this.hideEditor()
+					}
+				})
+				this.$refs.markdownEditor.easymde.codemirror.on('keyup', (a, b) => {
+					if (b.key === 'Meta' || b.key === 'Control') {
+						this.keyExitState = 0
+					}
+
+				})
+			}, 250)
+
 		},
 		hideEditor() {
+			this.$refs.markdownEditor.easymde.codemirror.off('keydown', undefined)
+			this.$refs.markdownEditor.easymde.codemirror.off('keyup', undefined)
 			this.descriptionEditing = false
 		},
 		showAttachmentModal() {


### PR DESCRIPTION
CTRL/CMD + ENTER to Save Changes on Card Description
fixes nextcloud/deck#3268

Signed-off-by: ben <ben@ro.tt>


* Resolves: #3268
* Target version: master 

### Summary
Allows saving and leaving the Card Description Editor via `CTRL`/`CMD` + `ENTER`. It's the same shortcut as with Twitter, Trello, Github and lot's of other Webapps

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
 Haven't found any documentation of Keyboard Shortcuts, if there is any place to add this shortcut just let me know :)
