### PR TITLE
Fetch full board data after cloning

### DIFF
--- a/lib/Service/BoardService.php
+++ b/lib/Service/BoardService.php
@@ -677,7 +677,7 @@ class BoardService {
 			$this->stackMapper->insert($newStack);
 		}
 
-		return $newBoard;
+		return $this->find($newBoard->getId());
 	}
 
 	public function transferBoardOwnership(int $boardId, string $newOwner, bool $changeContent = false): Board {


### PR DESCRIPTION
Steps to reproduce:
- Create a board and share it with some users
- Clone the board
- Go to the board list

Before:
See a ? in the avatar list

After:
See the proper avatars of the recipients in the board list for the newly cloned boards by reusing the logic that aggregates the board details.