### PR TITLE
Fix entity creation for stack from card id

### DIFF
--- a/lib/Db/StackMapper.php
+++ b/lib/Db/StackMapper.php
@@ -61,7 +61,7 @@ class StackMapper extends DeckMapper implements IPermissionMapper {
 	 */
 	public function findStackFromCardId($cardId): ?Stack {
 		$qb = $this->db->getQueryBuilder();
-		$qb->select('*')
+		$qb->select('s.*')
 			->from($this->getTableName(), 's')
 			->innerJoin('s', 'deck_cards', 'c', 's.id = c.stack_id')
 			->where($qb->expr()->eq('c.id', $qb->createNamedParameter($cardId, IQueryBuilder::PARAM_INT)));


### PR DESCRIPTION
Fixes an error found in the logs when the cronjob tries to get the stack by card id where the query result columns are not limited to the stacks table:

```
{
  "reqId": "bzutolSWPJJkHgu1ph3V",
  "level": 3,
  "time": "2022-05-05T06:20:02+00:00",
  "remoteAddr": "",
  "user": "--",
  "app": "notifications",
  "method": "",
  "url": "--",
  "message": "description is not a valid attribute",
  "userAgent": "--",
  "version": "25.0.0.1",
  "exception": {
    "Exception": "BadFunctionCallException",
    "Message": "description is not a valid attribute",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/html/lib/public/AppFramework/Db/Entity.php",
        "line": 162,
        "function": "setter",
        "class": "OCP\\AppFramework\\Db\\Entity",
        "type": "->",
        "args": [
          "description",
          [
            "dfgdfgdfg\n\n\nhfgh\nfg\nh\nfgh\nf\ngh\nfg\nh\nfg\nhfg\nhfg\nh\nfgh\nfgh\nfg\nh"
          ]
        ]
      },
      {
        "file": "/var/www/html/apps-extra/deck/lib/Db/RelationalEntity.php",
        "line": 144,
        "function": "__call",
        "class": "OCP\\AppFramework\\Db\\Entity",
        "type": "->",
        "args": [
          "setDescription",
          [
            "dfgdfgdfg\n\n\nhfgh\nfg\nh\nfgh\nf\ngh\nfg\nh\nfg\nhfg\nhfg\nh\nfgh\nfgh\nfg\nh"
          ]
        ]
      },
      {
        "file": "/var/www/html/lib/public/AppFramework/Db/Entity.php",
        "line": 73,
        "function": "__call",
        "class": "OCA\\Deck\\Db\\RelationalEntity",
        "type": "->",
        "args": [
          "setDescription",
          [
            "dfgdfgdfg\n\n\nhfgh\nfg\nh\nfgh\nf\ngh\nfg\nh\nfg\nhfg\nhfg\nh\nfgh\nfgh\nfg\nh"
          ]
        ]
      },
      {
        "file": "/var/www/html/lib/public/AppFramework/Db/QBMapper.php",
        "line": 322,
        "function": "fromRow",
        "class": "OCP\\AppFramework\\Db\\Entity",
        "type": "::",
        "args": [
          {
            "id": "1",
            "title": "sdfsdf",
            "board_id": "3",
            "order": "999",
            "deleted_at": "0",
            "0": "And 11 more entries, set log level to debug to see all entries"
          }
        ]
      },
      {
        "file": "/var/www/html/lib/public/AppFramework/Db/QBMapper.php",
        "line": 363,
        "function": "mapRowToEntity",
        "class": "OCP\\AppFramework\\Db\\QBMapper",
        "type": "->",
        "args": [
          {
            "id": "1",
            "title": "sdfsdf",
            "board_id": "3",
            "order": "999",
            "deleted_at": "0",
            "0": "And 11 more entries, set log level to debug to see all entries"
          }
        ]
      },
      {
        "file": "/var/www/html/apps-extra/deck/lib/Db/StackMapper.php",
        "line": 70,
        "function": "findEntity",
        "class": "OCP\\AppFramework\\Db\\QBMapper",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\DB\\QueryBuilder\\QueryBuilder"
          }
        ]
      },
      {
        "file": "/var/www/html/apps-extra/deck/lib/Notification/Notifier.php",
        "line": 147,
        "function": "findStackFromCardId",
        "class": "OCA\\Deck\\Db\\StackMapper",
        "type": "->",
        "args": [
          "1"
        ]
      },
      {
        "file": "/var/www/html/lib/private/Notification/Manager.php",
        "line": 376,
        "function": "prepare",
        "class": "OCA\\Deck\\Notification\\Notifier",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\Notification\\Notification"
          },
          "en_GB"
        ]
      },
      {
        "file": "/var/www/html/apps/notifications/lib/MailNotifications.php",
        "line": 196,
        "function": "prepare",
        "class": "OC\\Notification\\Manager",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\Notification\\Notification"
          },
          "en_GB"
        ]
      },
      {
        "file": "/var/www/html/apps/notifications/lib/MailNotifications.php",
        "line": 166,
        "function": "sendEmailToUser",
        "class": "OCA\\Notifications\\MailNotifications",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Notifications\\Model\\Settings",
            "id": 1
          },
          {
            "1327": {
              "__class__": "OC\\Notification\\Notification"
            }
          },
          "en_GB",
          "Europe/Berlin"
        ]
      },
      {
        "file": "/var/www/html/apps/notifications/lib/BackgroundJob/SendNotificationMails.php",
        "line": 49,
        "function": "sendEmails",
        "class": "OCA\\Notifications\\MailNotifications",
        "type": "->",
        "args": [
          500,
          1651731602
        ]
      },
      {
        "file": "/var/www/html/lib/public/BackgroundJob/Job.php",
        "line": 79,
        "function": "run",
        "class": "OCA\\Notifications\\BackgroundJob\\SendNotificationMails",
        "type": "->",
        "args": [
          null
        ]
      },
      {
        "file": "/var/www/html/lib/public/BackgroundJob/TimedJob.php",
        "line": 95,
        "function": "execute",
        "class": "OCP\\BackgroundJob\\Job",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\BackgroundJob\\JobList"
          },
          {
            "__class__": "OC\\Log"
          }
        ]
      },
      {
        "file": "/var/www/html/cron.php",
        "line": 151,
        "function": "execute",
        "class": "OCP\\BackgroundJob\\TimedJob",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\BackgroundJob\\JobList"
          },
          {
            "__class__": "OC\\Log"
          }
        ]
      }
    ],
    "File": "/var/www/html/lib/public/AppFramework/Db/Entity.php",
    "Line": 133,
    "CustomMessage": "description is not a valid attribute"
  }
}
```