### PR TITLE
set last modified when the card was found. Fixes #3763

### DIFF
--- a/src/store/card.js
+++ b/src/store/card.js
@@ -249,8 +249,8 @@ export default {
 			const existingIndex = state.cards.findIndex(_card => _card.id === card.id)
 			if (existingIndex !== -1) {
 				Vue.set(state.cards[existingIndex], property, card[property])
+				Vue.set(state.cards[existingIndex], 'lastModified', Date.now() / 1000)
 			}
-			Vue.set(state.cards[existingIndex], 'lastModified', Date.now() / 1000)
 		},
 		cardIncreaseAttachmentCount(state, cardId) {
 			const existingIndex = state.cards.findIndex(_card => _card.id === cardId)


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/deck/issues/3763
* Target version: master 

### Summary
Last modified should be updated on the modified card instead of on the -1 index.

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
