### PR TITLE
Align Duedate-delete icon properly - fixes nextcloud/deck#3791

### DIFF
--- a/src/components/card/CardSidebarTabDetails.vue
+++ b/src/components/card/CardSidebarTabDetails.vue
@@ -388,9 +388,11 @@ export default {
 
 	.section-details {
 		flex-grow: 1;
+		display: flex;
+		flex-wrap: wrap;
 
 		button.action-item--single {
-			margin-top: -6px;
+			margin-top: -3px;
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: ben <ben@ro.tt>


* Resolves: #3791
* Target version: master 

### Summary
Fix the misaligned Icon.

<img width="373" alt="Bildschirmfoto 2022-05-12 um 10 30 38" src="https://user-images.githubusercontent.com/22852640/168027508-af3e184e-faa4-4282-895e-20c0b631aa2a.png">

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
