### PR TITLE
Fix for issue #3637

### DIFF
--- a/src/css/markdown.scss
+++ b/src/css/markdown.scss
@@ -25,6 +25,10 @@ ul {
 	.task-list-item {
 		margin-left: -20px;
 		list-style-type: none;
+
+		ul {
+			padding-left: 20px;
+		}
 	}
 }
 


### PR DESCRIPTION
Added padding on nested ul, to compensate for the negative margin on the containing li

* Resolves: #3637
* Target version: master 

### Summary
Compensates for the negative margin added earlier on the li elements, when the list style was changed to none

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
