### PR TITLE
Inserted required property in the rename list field, to prevent the l…

### DIFF
--- a/lib/Service/StackService.php
+++ b/lib/Service/StackService.php
@@ -214,7 +214,7 @@ class StackService {
 	 * @throws BadRequestException
 	 */
 	public function create($title, $boardId, $order) {
-		if ($title === false || $title === null) {
+		if ($title === false || $title === null || mb_strlen($title) === 0) {
 			throw new BadRequestException('title must be provided');
 		}
 
@@ -291,7 +291,7 @@ class StackService {
 			throw new BadRequestException('stack id must be a number');
 		}
 
-		if ($title === false || $title === null) {
+		if ($title === false || $title === null || mb_strlen($title) === 0) {
 			throw new BadRequestException('title must be provided');
 		}
 

--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -35,7 +35,10 @@
 					{{ stack.title }}
 				</h3>
 				<form v-else @submit.prevent="finishedEdit(stack)">
-					<input v-model="copiedStack.title" v-focus type="text">
+					<input v-model="copiedStack.title"
+						v-focus
+						type="text"
+						required="required">
 					<input v-tooltip="t('deck', 'Add a new list')"
 						class="icon-confirm"
 						type="submit"


### PR DESCRIPTION
When creating a list on the Deck, there is a validation requiring the name of the list to be informed

But when renaming a list, it was possible to keep it without a name, so I put the required field validation

* Resolves: #3861
* Target version: master 

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
