### PR TITLE
fix(docs): fix links to JSON schemas for Trello

### DIFF
--- a/docs/User_documentation_en.md
+++ b/docs/User_documentation_en.md
@@ -90,7 +90,7 @@ Steps:
 * Create the configuration file
 * Execute the import informing the import file path, data file and source as `Trello JSON`
 
-Create the configuration file respecting the [JSON Schema](https://github.com/nextcloud/deck/blob/master/lib/Service/fixtures/config-trelloJson-schema.json) for import `Trello JSON`
+Create the configuration file respecting the [JSON Schema](https://github.com/nextcloud/deck/blob/master/lib/Service/Importer/fixtures/config-trelloJson-schema.json) for import `Trello JSON`
 
 Example configuration file:
 ```json
@@ -120,7 +120,7 @@ https://api.trello.com/1/members/me/boards?key={yourKey}&token={yourToken}&field
   This ID you will use in the configuration file in the `board` property
 * Create the configuration file
 
-Create the configuration file respecting the [JSON Schema](https://github.com/nextcloud/deck/blob/master/lib/Service/fixtures/config-trelloApi-schema.json) for import `Trello JSON`
+Create the configuration file respecting the [JSON Schema](https://github.com/nextcloud/deck/blob/master/lib/Service/Importer/fixtures/config-trelloApi-schema.json) for import `Trello JSON`
 
 Example configuration file:
 ```json


### PR DESCRIPTION
Link in docs was wrong, missing dir: `Importer/`


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
