### PR TITLE
Fix z-index for deck sidebar

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -46,6 +46,6 @@ export default {
 		z-index: 100;
 	}
 	.app-deck .app-sidebar {
-		z-index: 20000 !important;
+		z-index: 1500 !important;
 	}
 </style>


### PR DESCRIPTION
The sidebar would previously render above the user menu (logout, settings, etc)

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
