### PR TITLE
Prevent opening card and applyLabelFilter on card drag end

### DIFF
--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -99,12 +99,14 @@
 			non-drag-area-selector=".dragDisabled"
 			:drag-handle-selector="dragHandleSelector"
 			@should-accept-drop="canEdit"
+			@drag-start="draggingCard = true"
+			@drag-end="draggingCard = false"
 			@drop="($event) => onDropCard(stack.id, $event)">
 			<Draggable v-for="card in cardsByStack" :key="card.id">
 				<transition :appear="animate && !card.animated && (card.animated=true)"
 					:appear-class="'zoom-appear-class'"
 					:appear-active-class="'zoom-appear-active-class'">
-					<CardItem :id="card.id" />
+					<CardItem :id="card.id" :dragging="draggingCard" />
 				</transition>
 			</Draggable>
 		</Container>
@@ -142,6 +144,7 @@ export default {
 	data() {
 		return {
 			editing: false,
+			draggingCard: false,
 			copiedStack: '',
 			newCardTitle: '',
 			showAddCard: false,

--- a/src/components/cards/CardItem.vue
+++ b/src/components/cards/CardItem.vue
@@ -106,6 +106,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		dragging: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	data() {
 		return {
@@ -154,6 +158,9 @@ export default {
 	},
 	methods: {
 		openCard() {
+			if (this.dragging) {
+			  return
+			}
 			const boardId = this.card && this.card.boardId ? this.card.boardId : this.$route.params.id
 			this.$router.push({ name: 'card', params: { id: boardId, cardId: this.card.id } }).catch(() => {})
 		},
@@ -171,6 +178,9 @@ export default {
 			this.editing = false
 		},
 		applyLabelFilter(label) {
+			if (this.dragging) {
+				return
+			}
 			this.$nextTick(() => this.$store.dispatch('toggleFilter', { tags: [label.id] }))
 		},
 	},


### PR DESCRIPTION
refs #2594

Problem: A click event is triggered on the element we drag (when dragging a card) when it's dropped.

This issue was mentioned in vue-smooth-dnd: https://github.com/kutlugsahin/vue-smooth-dnd/issues/50 but no solution/fix was provided.

I can't find another way to solve this.

Suggested solution: Thanks to drag-start and drag-end events, we know if we are currently dragging a card or not. We pass this information to the cards. The `applyLabelFilter` and `openCard` methods of the CardItem component don't do anything when the card is being dragged.