### PR TITLE
Fix tests running against 25 with adjusted ISimpleFile methods

### DIFF
--- a/tests/unit/Service/FileServiceTest.php
+++ b/tests/unit/Service/FileServiceTest.php
@@ -98,6 +98,7 @@ class FileServiceTest extends TestCase {
 		$attachment = new Attachment();
 		$attachment->setId(1);
 		$attachment->setCardId(123);
+		$attachment->setData('Filename.md');
 		return $attachment;
 	}
 


### PR DESCRIPTION
Bring master back to passing tests after https://github.com/nextcloud/server/pull/32981 it doesn't expect to be called with null which it was without the additional context data.