### PR TITLE
cy: fix login submit selector for current server

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,7 +29,7 @@ Cypress.Commands.add("login", (user, password, route = "/apps/deck/") => {
 		cy.visit(route);
 		cy.get("input[name=user]").type(user);
 		cy.get("input[name=password]").type(password);
-		cy.get(".submit-wrapper input[type=submit]").click();
+		cy.get("form[name=login] [type=submit]").click();
 		cy.url().should("include", route);
 	});
 	// in case the session already existed but we are on a different route...


### PR DESCRIPTION
Made the selector flexible enough to still work with the old.


* Resolves: failing CI runs such as https://github.com/nextcloud/deck/runs/7701521315?check_suite_focus=true
* Target version: master 
