### PR TITLE
Improve CalDAV integration performance

### DIFF
--- a/lib/DAV/Calendar.php
+++ b/lib/DAV/Calendar.php
@@ -52,12 +52,6 @@ class Calendar extends ExternalCalendar {
 		$this->board = $board;
 
 		$this->principalUri = $principalUri;
-
-		if ($board) {
-			$this->children = $this->backend->getChildren($board->getId());
-		} else {
-			$this->children = [];
-		}
 	}
 
 	public function getOwner() {
@@ -122,7 +116,7 @@ class Calendar extends ExternalCalendar {
 	public function getChild($name) {
 		if ($this->childExists($name)) {
 			$card = array_values(array_filter(
-				$this->children,
+				$this->getBackendChildren(),
 				function ($card) use (&$name) {
 					return $card->getCalendarPrefix() . '-' . $card->getId() . '.ics' === $name;
 				}
@@ -137,7 +131,7 @@ class Calendar extends ExternalCalendar {
 	public function getChildren() {
 		$childNames = array_map(function ($card) {
 			return $card->getCalendarPrefix() . '-' . $card->getId() . '.ics';
-		}, $this->children);
+		}, $this->getBackendChildren());
 
 		$children = [];
 
@@ -148,9 +142,23 @@ class Calendar extends ExternalCalendar {
 		return $children;
 	}
 
+	private function getBackendChildren() {
+		if ($this->children) {
+			return $this->children;
+		}
+
+		if ($this->board) {
+			$this->children = $this->backend->getChildren($this->board->getId());
+		} else {
+			$this->children = [];
+		}
+
+		return $this->children;
+	}
+
 	public function childExists($name) {
 		return count(array_filter(
-			$this->children,
+			$this->getBackendChildren(),
 			function ($card) use (&$name) {
 				return $card->getCalendarPrefix() . '-' . $card->getId() . '.ics' === $name;
 			}

--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -193,6 +193,7 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 			->from('deck_cards', 'c')
 			->join('c', 'deck_stacks', 's', 's.id = c.stack_id')
 			->where($qb->expr()->eq('s.board_id', $qb->createNamedParameter($boardId)))
+			->andWhere($qb->expr()->eq('c.archived', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)))
 			->andWhere($qb->expr()->eq('c.deleted_at', $qb->createNamedParameter('0')))
 			->orderBy('c.duedate')
 			->setMaxResults($limit)


### PR DESCRIPTION
- Avoid querying each card when getting the calendars only
- Avoid fetching archived cards for calendars

Should resolve https://github.com/nextcloud/deck/issues/3542
Fixes https://github.com/nextcloud/deck/issues/3981

- Fetching the calendar list: 1 per board, 5 per card for each board https://blackfire.io/profiles/compare/1598d59c-4404-4280-b0c7-3335d5f5a329/graph (115 queries on perftesting)
- Fetching a single deck calendar: Saves 5 requests per card + limits cards to only the needed ones (not archived) https://blackfire.io/profiles/compare/785c59a0-ef1c-4eec-96db-0158b6449d14/graph (63 on perftesting)