### PR TITLE
Add a11y label for sidebar button

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -203,8 +203,11 @@
 					</ActionButton>
 				</Actions>
 				<!-- FIXME: ActionRouter currently doesn't work as an inline action -->
-				<Actions :title="t('deck', 'Details')">
-					<ActionButton icon="icon-menu-sidebar" @click="toggleDetailsView" />
+				<Actions>
+					<ActionButton icon="icon-menu-sidebar"
+						:aria-label="t('deck', 'Open details')"
+						:title="t('deck', 'Details')"
+						@click="toggleDetailsView" />
 				</Actions>
 			</div>
 		</div>


### PR DESCRIPTION
* Resolves: #3822
* Target version: master 

### Summary
Adds an aria label and a title to the sidebar button.

### TODO

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
