### PR TITLE
Add related resources panel to board sharing tab sidebar

### DIFF
--- a/src/components/board/SharingTabSidebar.vue
+++ b/src/components/board/SharingTabSidebar.vue
@@ -61,6 +61,10 @@
 			</li>
 		</ul>
 
+		<NcRelatedResourcesPanel v-if="board.id"
+			provider-id="deck"
+			:item-id="board.id" />
+
 		<CollectionList v-if="projectsEnabled && board.id"
 			:id="`${board.id}`"
 			:name="board.title"
@@ -69,7 +73,7 @@
 </template>
 
 <script>
-import { NcAvatar, NcMultiselect, NcActions, NcActionButton, ActionCheckbox } from '@nextcloud/vue'
+import { NcAvatar, NcMultiselect, NcActions, NcActionButton, ActionCheckbox, NcRelatedResourcesPanel } from '@nextcloud/vue'
 import { CollectionList } from 'nextcloud-vue-collections'
 import { mapGetters, mapState } from 'vuex'
 import { getCurrentUser } from '@nextcloud/auth'
@@ -86,6 +90,7 @@ export default {
 		ActionCheckbox,
 		NcMultiselect,
 		CollectionList,
+		NcRelatedResourcesPanel,
 	},
 	props: {
 		board: {


### PR DESCRIPTION
### Requires

- [x] https://github.com/nextcloud/nextcloud-vue/pull/3081
- [x] Upgrade `@nextcloud/vue` >=7.0.0-beta.1