### PR TITLE
Fix attachment creator name: show display name

### DIFF
--- a/src/components/card/AttachmentList.vue
+++ b/src/components/card/AttachmentList.vue
@@ -63,7 +63,7 @@
 						<div v-if="attachment.deletedAt === 0">
 							<span class="filesize">{{ formattedFileSize(attachment.extendedData.filesize) }}</span>
 							<span class="filedate">{{ relativeDate(attachment.createdAt*1000) }}</span>
-							<span class="filedate">{{ attachment.createdBy }}</span>
+							<span class="filedate">{{ attachment.extendedData.attachmentCreator.displayName }}</span>
 						</div>
 						<div v-else>
 							<span class="attachment--info">{{ t('deck', 'Pending share') }}</span>


### PR DESCRIPTION
closes #4035 

The user id was displayed.

Not sure if it's the perfect way to implement that. I did't want to make changes to the Attachment class so the display name goes in the `extendedData` which was originally used for the file info only. Now it also holds the info about the attachment creator.

So this PR adds a `attachmentCreator` field in the `extendedData` (named like that so it can't be confused with the file creator).

We might want to backport this to stable24 to have it at least in the latest NC enterprise.