### PR TITLE
Fix deleteAcl

### DIFF
--- a/lib/Reference/CardReferenceProvider.php
+++ b/lib/Reference/CardReferenceProvider.php
@@ -81,7 +81,7 @@ class CardReferenceProvider implements IReferenceProvider {
 				$card = $this->sanitizeSerializedCard($card);
 				$board = $this->sanitizeSerializedBoard($board);
 				$stack = $this->sanitizeSerializedStack($stack);
-
+				/** @var IReference $reference */
 				$reference = new Reference($referenceText);
 				$reference->setRichObject(Application::APP_ID . '-card', [
 					'id' => $boardId . '/' . $cardId,

--- a/tests/unit/Service/BoardServiceTest.php
+++ b/tests/unit/Service/BoardServiceTest.php
@@ -427,6 +427,6 @@ class BoardServiceTest extends TestCase {
 			->method('delete')
 			->with($acl)
 			->willReturn($acl);
-		$this->assertTrue($this->service->deleteAcl(123));
+		$this->assertEquals($acl, $this->service->deleteAcl(123));
 	}
 }

--- a/tests/unit/controller/BoardControllerTest.php
+++ b/tests/unit/controller/BoardControllerTest.php
@@ -164,10 +164,14 @@ class BoardControllerTest extends \Test\TestCase {
 	}
 
 	public function testDeleteAcl() {
+		$acl = $this->getMockBuilder(Acl::class)
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->boardService->expects($this->once())
 			->method('deleteAcl')
 			->with(1)
-			->willReturn(true);
-		$this->assertEquals(true, $this->controller->deleteAcl(1));
+			->willReturn($acl);
+		$this->assertEquals($acl, $this->controller->deleteAcl(1));
 	}
 }


### PR DESCRIPTION
* Target version: master 

### Summary
Fixes an issue where front-end expects an `Acl` object to be returned in `DELETE` request. Deleting a share would result in a permanently closed sidebar.

This bug was introduced with https://github.com/nextcloud/deck/pull/3720 so there is no need to back-port the fix.