### PR TITLE
Improve stack drag and drop behavior

### DIFF
--- a/src/components/board/Board.vue
+++ b/src/components/board/Board.vue
@@ -120,7 +120,7 @@ export default {
 			return this.$store.getters.stacksByBoard(this.board.id)
 		},
 		dragHandleSelector() {
-			return this.canEdit ? null : '.no-drag'
+			return this.canEdit ? '.stack__title' : '.no-drag'
 		},
 		isEmpty() {
 			return this.stacksByBoard.length === 0

--- a/src/components/board/Board.vue
+++ b/src/components/board/Board.vue
@@ -53,9 +53,11 @@
 				<Container lock-axix="y"
 					orientation="horizontal"
 					:drag-handle-selector="dragHandleSelector"
+					@drag-start="draggingStack = true"
+					@drag-end="draggingStack = false"
 					@drop="onDropStack">
 					<Draggable v-for="stack in stacksByBoard" :key="stack.id">
-						<Stack :stack="stack" />
+						<Stack :stack="stack" :dragging="draggingStack" />
 					</Draggable>
 				</Container>
 			</div>
@@ -100,6 +102,7 @@ export default {
 	},
 	data() {
 		return {
+			draggingStack: false,
 			loading: true,
 			newStackTitle: '',
 		}

--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -25,7 +25,7 @@
 	<div class="stack">
 		<div v-click-outside="stopCardCreation"
 			class="stack__header"
-			:class="{'stack__header--add': showAddCard }"
+			:class="{'stack__header--add': showAddCard}"
 			tabindex="0"
 			:aria-label="stack.title">
 			<transition name="fade" mode="out-in">
@@ -390,7 +390,7 @@ export default {
 			margin: 6px;
 			padding: 4px 4px;
 
-			&:focus {
+			&:focus-visible {
 				outline: 2px solid var(--color-border-dark);
 				border-radius: 3px;
 			}

--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -171,6 +171,10 @@ export default {
 		ClickOutside,
 	},
 	props: {
+		dragging: {
+			type: Boolean,
+			default: false,
+		},
 		stack: {
 			type: Object,
 			default: undefined,
@@ -270,6 +274,10 @@ export default {
 			this.modalArchivAllCardsShow = false
 		},
 		startEditing(stack) {
+			if (this.dragging) {
+			  return
+			}
+
 			this.copiedStack = Object.assign({}, stack)
 			this.editing = true
 		},

--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -41,7 +41,10 @@
 					@keydown.enter="startEditing(stack)">
 					{{ stack.title }}
 				</h3>
-				<form v-else @submit.prevent="finishedEdit(stack)">
+				<form v-else-if="editing"
+					v-click-outside="cancelEdit"
+					@submit.prevent="finishedEdit(stack)"
+					@keyup.esc="cancelEdit">
 					<input v-model="copiedStack.title"
 						v-focus
 						type="text"
@@ -142,7 +145,7 @@
 </template>
 
 <script>
-
+import ClickOutside from 'vue-click-outside'
 import { mapGetters, mapState } from 'vuex'
 import { Container, Draggable } from 'vue-smooth-dnd'
 
@@ -164,7 +167,9 @@ export default {
 		NcModal,
 		ArchiveIcon,
 	},
-
+	directives: {
+		ClickOutside,
+	},
 	props: {
 		stack: {
 			type: Object,
@@ -272,6 +277,9 @@ export default {
 			if (this.copiedStack.title !== stack.title) {
 				this.$store.dispatch('updateStack', this.copiedStack)
 			}
+			this.editing = false
+		},
+		cancelEdit() {
 			this.editing = false
 		},
 		async clickAddCard() {


### PR DESCRIPTION
* Resolves: #2669
* Target version: master 

### Summary

This allows stacks only to be dragged by the title, minimizing accidental drag'n'drops. Also the title can not be edited accidentally while dragging the stack. (see https://github.com/nextcloud/deck/issues/2669#issuecomment-1208973459)

As a bonus, stack title edits can now aborted via <Esc> or clicking away (same as card titles).

If you want me to add some e2e tests, maybe you can provide me with some pointers? To be honest, i'm not very keen on writing drag'n'drop tests, because they often end up flacky, in my experience..

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
