### PR TITLE
Fix Card menu not displaying when description is not set

### DIFF
--- a/src/components/cards/CardBadges.vue
+++ b/src/components/cards/CardBadges.vue
@@ -36,7 +36,7 @@
 			<span>{{ checkListCheckedCount }}/{{ checkListCount }}</span>
 		</div>
 
-		<TextIcon v-else-if="card.description.trim() && checkListCount == 0" :size="16" decorative />
+		<TextIcon v-else-if="card.description && card.description.trim() && checkListCount == 0" :size="16" decorative />
 
 		<div v-if="card.attachmentCount > 0" class="icon-badge">
 			<AttachmentIcon :size="16" />


### PR DESCRIPTION
* Resolves: internal issue
* Target version: master 

### Summary
Cards with no description set will not display a card menu due to an error in the rendering function. This PR fixes this.

### TODO
 - / -

### Checklist

- [X] Code is properly formatted
- [X] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [X] Documentation (manuals or wiki) has been updated or is not required
