### PR TITLE
Fix sorting stacks

### DIFF
--- a/lib/Service/StackService.php
+++ b/lib/Service/StackService.php
@@ -352,6 +352,7 @@ class StackService {
 		$this->permissionService->checkPermission($this->stackMapper, $id, Acl::PERMISSION_MANAGE);
 		$stackToSort = $this->stackMapper->find($id);
 		$stacks = $this->stackMapper->findAll($stackToSort->getBoardId());
+		usort($stacks, static fn (Stack $stackA, Stack $stackB) => $stackA->getOrder() - $stackB->getOrder());
 		$result = [];
 		$i = 0;
 		foreach ($stacks as $stack) {


### PR DESCRIPTION
Currently stacks can not be reordered as wished.

The problem is `findAll` always returns sorted by `id`, not by `order`.
So when you move a second column, everything else will reset

* Create a new Deck board with stacks named 1-5
* Move stack 5 to the beginning, expected: 5,1,2,3,4
* Reload the page ✅ 
* Move stack 1 behind 3, expected: 5,2,3,1,4
* Reload the page 💥, actual: 2,3,1,4,5

Happens on c.nc.c as well