### PR TITLE
Avoid using dropped Test\AppFramework\Db\MapperTestUtility

### DIFF
--- a/tests/unit/Db/AclMapperTest.php
+++ b/tests/unit/Db/AclMapperTest.php
@@ -29,12 +29,12 @@ use OCP\IGroupManager;
 use OCP\IUserManager;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
-use Test\AppFramework\Db\MapperTestUtility;
+use Test\TestCase;
 
 /**
  * @group DB
  */
-class AclMapperTest extends MapperTestUtility {
+class AclMapperTest extends TestCase {
 	private $dbConnection;
 	private $aclMapper;
 	private $boardMapper;

--- a/tests/unit/Db/AttachmentMapperTest.php
+++ b/tests/unit/Db/AttachmentMapperTest.php
@@ -27,12 +27,12 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IDBConnection;
 use OCP\IUserManager;
 use OCP\Server;
-use Test\AppFramework\Db\MapperTestUtility;
+use Test\TestCase;
 
 /**
  * @group DB
  */
-class AttachmentMapperTest extends MapperTestUtility {
+class AttachmentMapperTest extends TestCase {
 
 	/** @var IDBConnection */
 	private $dbConnection;

--- a/tests/unit/Db/BoardMapperTest.php
+++ b/tests/unit/Db/BoardMapperTest.php
@@ -29,12 +29,12 @@ use OCP\IGroupManager;
 use OCP\IUserManager;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
-use Test\AppFramework\Db\MapperTestUtility;
+use Test\TestCase;
 
 /**
  * @group DB
  */
-class BoardMapperTest extends MapperTestUtility {
+class BoardMapperTest extends TestCase {
 
 	/** @var IDBConnection */
 	private $dbConnection;


### PR DESCRIPTION
Remove no longer present test helper that was not used anyways