### PR TITLE
Fix issue with duedate format

### DIFF
--- a/lib/Db/Card.php
+++ b/lib/Db/Card.php
@@ -108,7 +108,7 @@ class Card extends RelationalEntity {
 		$this->addType('archived', 'boolean');
 		$this->addType('notified', 'boolean');
 		$this->addType('deletedAt', 'integer');
-		$this->addType('duedate', 'string');
+		$this->addType('duedate', 'datetime');
 		$this->addRelation('labels');
 		$this->addRelation('assignedUsers');
 		$this->addRelation('attachments');
@@ -126,20 +126,6 @@ class Card extends RelationalEntity {
 		$this->databaseType = $type;
 	}
 
-	public function getDueDateTime(): ?DateTime {
-		return $this->duedate ? new DateTime($this->duedate) : null;
-	}
-
-	public function getDuedate($isoFormat = false): ?string {
-		$dt = $this->getDueDateTime();
-		$format = 'c';
-		if (!$isoFormat && $this->databaseType === 'mysql') {
-			$format = 'Y-m-d H:i:s';
-		}
-
-		return $dt ? $dt->format($format) : null;
-	}
-
 	public function getCalendarObject(): VCalendar {
 		$calendar = new VCalendar();
 		$event = $calendar->createComponent('VTODO');
@@ -148,7 +134,7 @@ class Card extends RelationalEntity {
 			$creationDate = new DateTime();
 			$creationDate->setTimestamp($this->createdAt);
 			$event->DTSTAMP = $creationDate;
-			$event->DUE = new DateTime($this->getDuedate(true), new DateTimeZone('UTC'));
+			$event->DUE = new DateTime($this->getDuedate()->format('c'), new DateTimeZone('UTC'));
 		}
 		$event->add('RELATED-TO', 'deck-stack-' . $this->getStackId());
 

--- a/lib/Db/RelationalEntity.php
+++ b/lib/Db/RelationalEntity.php
@@ -72,6 +72,9 @@ class RelationalEntity extends Entity implements \JsonSerializable {
 				$propertyReflection = $reflection->getProperty($property);
 				if (!$propertyReflection->isPrivate() && !in_array($property, $this->_resolvedProperties, true)) {
 					$json[$property] = $this->getter($property);
+					if ($json[$property] instanceof \DateTimeInterface) {
+						$json[$property] = $json[$property]->format('c');
+					}
 				}
 			}
 		}

--- a/lib/Model/CardDetails.php
+++ b/lib/Model/CardDetails.php
@@ -54,7 +54,7 @@ class CardDetails extends Card {
 		$today = new DateTime();
 		$today->setTime(0, 0);
 
-		$match_date = $this->card->getDueDateTime();
+		$match_date = $this->card->getDuedate();
 		if (!$match_date) {
 			return Card::DUEDATE_FUTURE;
 		}

--- a/lib/Notification/NotificationHelper.php
+++ b/lib/Notification/NotificationHelper.php
@@ -129,7 +129,7 @@ class NotificationHelper {
 					->setSubject('card-overdue', [
 						$card->getTitle(), $board->getTitle()
 					])
-					->setDateTime(new DateTime($card->getDuedate()));
+					->setDateTime($card->getDuedate());
 				$this->notificationManager->notify($notification);
 			}
 		}
@@ -242,7 +242,7 @@ class NotificationHelper {
 		}
 		return $this->boards[$boardId];
 	}
-	
+
 	private function generateBoardShared(Board $board, string $userId): INotification {
 		$notification = $this->notificationManager->createNotification();
 		$notification

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -337,7 +337,7 @@ class CardService {
 		$card->setType($type);
 		$card->setOrder($order);
 		$card->setOwner($owner);
-		$card->setDuedate(new \DateTime($duedate));
+		$card->setDuedate($duedate ? new \DateTime($duedate) : null);
 		$resetDuedateNotification = false;
 		if (
 			$card->getDuedate() === null ||

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -337,11 +337,11 @@ class CardService {
 		$card->setType($type);
 		$card->setOrder($order);
 		$card->setOwner($owner);
-		$card->setDuedate($duedate);
+		$card->setDuedate(new \DateTime($duedate));
 		$resetDuedateNotification = false;
 		if (
 			$card->getDuedate() === null ||
-			(new \DateTime($card->getDuedate())) != (new \DateTime($changes->getBefore()->getDuedate() ?? ''))
+			($card->getDuedate()) != ($changes->getBefore()->getDuedate())
 		) {
 			$card->setNotified(false);
 			$resetDuedateNotification = true;

--- a/tests/unit/Db/CardTest.php
+++ b/tests/unit/Db/CardTest.php
@@ -117,14 +117,6 @@ class CardTest extends TestCase {
 		], (new CardDetails($card))->jsonSerialize());
 	}
 
-	public function testMysqlDateFallback() {
-		$date = new DateTime();
-		$card = new Card();
-		$card->setDuedate($date->format('c'));
-		$card->setDatabaseType('mysql');
-		$this->assertEquals($date->format('Y-m-d H:i:s'), $card->getDuedate(false));
-	}
-
 	public function testJsonSerializeAsignedUsers() {
 		$card = $this->createCard();
 		$card->setAssignedUsers([ 'user1' ]);

--- a/tests/unit/Service/CardServiceTest.php
+++ b/tests/unit/Service/CardServiceTest.php
@@ -221,7 +221,7 @@ class CardServiceTest extends TestCase {
 		$this->assertEquals('text', $actual->getType());
 		$this->assertEquals(999, $actual->getOrder());
 		$this->assertEquals('foo', $actual->getDescription());
-		$this->assertEquals('2017-01-01T00:00:00+00:00', $actual->getDuedate());
+		$this->assertEquals(new \DateTime('2017-01-01T00:00:00+00:00'), $actual->getDuedate());
 	}
 
 	public function testUpdateArchived() {


### PR DESCRIPTION
With this change new items work again.

However the actual problem is that entries in the database have the wrong datetime format already. So at least the timezone is forgotten for every entry.
Also I didn't find the motivation to test all kind of migrations with and without duedate, with past and future, in case there is something related that would need handling.

Fix #4112 