### PR TITLE
Fix unnecessary folder creation icon

### DIFF
--- a/src/components/card/AttachmentList.vue
+++ b/src/components/card/AttachmentList.vue
@@ -119,7 +119,6 @@ const picker = getFilePickerBuilder(t('deck', 'File to share'))
 	.setMultiSelect(false)
 	.setModal(true)
 	.setType(1)
-	.allowDirectories()
 	.build()
 
 export default {


### PR DESCRIPTION
* Resolves:   https://github.com/nextcloud/server/issues/34640#issue-1412006557
* Target version: master 
* Before
* ![Screenshot 2022-10-17 at 18-39-37 Personal - Deck - Nextcloud](https://user-images.githubusercontent.com/73851419/196385163-bf62cc5a-f8a5-4370-b4cd-5b4093e573fc.png)
* After
* ![Screenshot 2022-10-18 at 10-46-17 Personal - Deck - Nextcloud](https://user-images.githubusercontent.com/73851419/196385135-be2dda67-2e69-428d-ac42-68fbb8872c72.png)
Signed-off-by: Dennis Eisermann [73851419+DJE98@users.noreply.github.com](mailto:73851419+DJE98@users.noreply.github.com)
