### PR TITLE
minor style fixes

### DIFF
--- a/src/components/card/AttachmentList.vue
+++ b/src/components/card/AttachmentList.vue
@@ -173,7 +173,7 @@ export default {
 			}
 		},
 		attachmentPreview() {
-			return (attachment) => (attachment.extendedData.fileid ? generateUrl(`/core/preview?fileId=${attachment.extendedData.fileid}&x=64&y=64&a=true`) : null)
+			return (attachment) => (attachment.extendedData.fileid ? generateUrl(`/core/preview?fileId=${attachment.extendedData.fileid}&x=64&y=64`) : null)
 		},
 		attachmentUrl() {
 			return (attachment) => generateUrl(`/apps/deck/cards/${attachment.cardId}/attachment/${attachment.id}`)

--- a/src/components/card/Description.vue
+++ b/src/components/card/Description.vue
@@ -298,7 +298,7 @@ export default {
 	}
 
 	&:deep(input) {
-		min-height: auto;
+		height: auto;
 	}
 
 	&:deep(a) {


### PR DESCRIPTION
* Resolves: #4162
* Target version: master 

### Summary
- changes in nextcloud core style inputs.scss broke the input[type=checkbox] style
=> changed checkbox height from fixed `36px` to `auto`
- somehow the behavior of the core preview provider changed:
	- param `a` that seems to be `crop` (according to [IPreview.php](https://github.com/nextcloud/server/blob/master/lib/public/IPreview.php#L90)) is negated (-> see [core/Controller/PreviewController.php#L144](https://github.com/nextcloud/server/blob/master/core/Controller/PreviewController.php#L144))
	- preview images are upscaled to the next power of 2
=> removed param `a` to receive cropped images

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or **is not required**
