### PR TITLE
Tag creation from card view

### DIFF
--- a/src/components/card/CardSidebarTabDetails.vue
+++ b/src/components/card/CardSidebarTabDetails.vue
@@ -36,7 +36,8 @@
 					label="title"
 					track-by="id"
 					@select="addLabelToCard"
-					@remove="removeLabelFromCard">
+					@remove="removeLabelFromCard"
+					@tag="addLabelToBoardAndCard">
 					<template #option="scope">
 						<div :style="{ backgroundColor: '#' + scope.option.color, color: textColor(scope.option.color)}" class="tag">
 							{{ scope.option.title }}
@@ -340,6 +341,17 @@ export default {
 				labelId: newLabel.id,
 			}
 			this.$store.dispatch('addLabel', data)
+		},
+
+		addLabelToBoardAndCard(name) {
+			const newLabel = {
+				title: name,
+				color: this.randomColor(),
+			}
+			this.$store.dispatch('addLabelToCurrentBoardAndCard', {
+				card: this.copiedCard,
+				newLabel,
+			})
 		},
 
 		removeLabelFromCard(removedLabel) {

--- a/src/mixins/color.js
+++ b/src/mixins/color.js
@@ -91,6 +91,8 @@ export default {
 			return false
 
 		},
-
+		randomColor() {
+			return Math.floor(Math.random() * (0xffffff + 1)).toString(16).padStart(6, '0')
+		},
 	},
 }

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -465,6 +465,18 @@ export default new Vuex.Store({
 					commit('addLabelToCurrentBoard', newLabel)
 				})
 		},
+		addLabelToCurrentBoardAndCard({ dispatch, commit }, { newLabel, card }) {
+			newLabel.boardId = this.state.currentBoard.id
+			apiClient.createLabel(newLabel)
+				.then((newLabel) => {
+					commit('addLabelToCurrentBoard', newLabel)
+					dispatch('addLabel', {
+						card,
+						labelId: newLabel.id,
+					})
+					card.labels.push(newLabel)
+				})
+		},
 
 		// acl actions
 		async addAclToCurrentBoard({ dispatch, commit }, newAcl) {


### PR DESCRIPTION
* Resolves: #1472 
* Target version: master 

### Summary
Implement addLabelToBoardAndCard to also create labels from the CardSidebar. When a label is searched in the label picker for a card and it isn't found, create a new label with a random color and add it to the current card. Tested locally.

### TODO
- [ ] Does this need extra Tests/Documentation?
- [ ] Currently, the placeholder to create the new label is just empty. Maybe we should display a "+" or some text like "Create new label".

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
