### PR TITLE
Enabled advanced fields option on tag color picker

### DIFF
--- a/src/components/board/TagsTabSidebar.vue
+++ b/src/components/board/TagsTabSidebar.vue
@@ -5,7 +5,10 @@
 				<!-- Edit Tag -->
 				<template v-if="editingLabelId === label.id">
 					<form class="label-form" @submit.prevent="updateLabel(label)">
-						<NcColorPicker class="color-picker-wrapper" :value="'#' + editingLabel.color" @input="updateColor">
+						<NcColorPicker class="color-picker-wrapper"
+							:value="'#' + editingLabel.color"
+							:advanced-fields="true"
+							@input="updateColor">
 							<div :style="{ backgroundColor: '#' + editingLabel.color }" class="color0 icon-colorpicker" />
 						</NcColorPicker>
 						<input v-model="editingLabel.title" type="text">
@@ -48,7 +51,10 @@
 			<li v-if="addLabel" class="editing">
 				<!-- New Tag -->
 				<form class="label-form" @submit.prevent="clickAddLabel">
-					<NcColorPicker class="color-picker-wrapper" :value="'#' + addLabelObj.color" @input="updateColor">
+					<NcColorPicker class="color-picker-wrapper"
+						:value="'#' + addLabelObj.color"
+						:advanced-fields="true"
+						@input="updateColor">
 						<div :style="{ backgroundColor: '#' + addLabelObj.color }" class="color0 icon-colorpicker" />
 					</NcColorPicker>
 					<input v-model="addLabelObj.title" type="text">


### PR DESCRIPTION
Signed-off-by: Fabian Dingemans <mail@fabiandingemans.nl>

* Resolves: #1911
* Target version: master 

### Summary

I have enabled the advanced fields option on the color picker for the board tag editor.
This allows users to enter a rgb, hls or hex code as color.

### TODO

None

### Checklist

- [x ] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x ] Tests (unit, integration, api and/or acceptance) are included
- [x ] Documentation (manuals or wiki) has been updated or is not required
