### PR TITLE
Update signature of Entity::markFieldUpdated

### DIFF
--- a/lib/Db/RelationalEntity.php
+++ b/lib/Db/RelationalEntity.php
@@ -53,7 +53,7 @@ class RelationalEntity extends Entity implements \JsonSerializable {
 	 * @param string $attribute the name of the attribute
 	 * @since 7.0.0
 	 */
-	protected function markFieldUpdated($attribute) {
+	protected function markFieldUpdated(string $attribute): void {
 		if (!in_array($attribute, $this->_relations, true)) {
 			parent::markFieldUpdated($attribute);
 		}


### PR DESCRIPTION
Ref https://github.com/nextcloud/server/commit/e91457d9cd68182591038636155d415b5dee0ec4

### Summary

```
PHP Fatal error:  Declaration of OCA\Deck\Db\RelationalEntity::markFieldUpdated($attribute) must be compatible with OCP\AppFramework\Db\Entity::markFieldUpdated(string $attribute): void in /var/www/html/apps/deck/lib/Db/RelationalEntity.php on line 56
PHP Fatal error:  Declaration of OCA\Deck\Db\RelationalEntity::markFieldUpdated($attribute) must be compatible with OCP\AppFramework\Db\Entity::markFieldUpdated(string $attribute): void in /var/www/html/apps/deck/lib/Db/RelationalEntity.php on line 56
PHP Fatal error:  Declaration of OCA\Deck\Db\RelationalEntity::markFieldUpdated($attribute) must be compatible with OCP\AppFramework\Db\Entity::markFieldUpdated(string $attribute): void in /var/www/html/apps/deck/lib/Db/RelationalEntity.php on line 56
```

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
