### PR TITLE
Remove updated nightly information

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ make build
 
 Please make sure you have installed the following dependencies: `make, which, tar, npm, curl, composer`
 
-### Install the nightly builds
-
-Instead of setting everything up manually, you can just [download the nightly build](https://github.com/nextcloud/deck/releases/tag/nightly) instead. These builds are updated every 24 hours, and are pre-configured with all the needed dependencies.
-
 ## Performance limitations
 
 Deck is not yet ready for intensive usage.


### PR DESCRIPTION
Signed-off-by: xaver <shithub@xwissen.info>

* Resolves: -
* Target version: main

### Summary
Remove updated information about nightly branch. Last update was in 2021 and can't be used as early adaptor build.

### TODO
-

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
