### PR TITLE
perf: Register notifier and resource listener lazy

### DIFF
--- a/lib/Listeners/ResourceAdditionalScriptsListener.php
+++ b/lib/Listeners/ResourceAdditionalScriptsListener.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace OCA\Deck\Listeners;
+
+use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IRequest;
+use OCP\Util;
+
+/** @template-implements IEventListener<Event|LoadAdditionalScriptsEvent> */
+class ResourceAdditionalScriptsListener implements IEventListener {
+	private IRequest $request;
+
+	public function __construct(IRequest $request) {
+		$this->request = $request;
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof LoadAdditionalScriptsEvent) {
+			return;
+		}
+
+		if (strpos($this->request->getPathInfo(), '/call/') === 0) {
+			// Talk integration has its own entrypoint which already includes collections handling
+			return;
+		}
+
+		Util::addScript('deck', 'deck-collections');
+	}
+}


### PR DESCRIPTION
Hard to measure how much it saves a bit doesn't hurt to do especially as deck is loaded with the dav app for the caldav integration

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
