### PR TITLE
fix: Use passed userid when getting attachment folder

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -224,7 +224,7 @@ class ConfigService {
 	}
 
 	public function getAttachmentFolder(string $userId = null): string {
-		if ($this->getUserId() === null) {
+		if ($userId === null && $this->getUserId() === null) {
 			throw new NoPermissionException('Must be logged in get the attachment folder');
 		}
 


### PR DESCRIPTION
Fixes getting the attachment folder without a user folder. The user id is passed already in the Listener for building the deck mount points.