### PR TITLE
tests(integration): Add integration tests for due dates

### DIFF
--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -39,6 +39,7 @@ use OCA\Deck\Db\StackMapper;
 use OCA\Deck\Event\CardCreatedEvent;
 use OCA\Deck\Event\CardDeletedEvent;
 use OCA\Deck\Event\CardUpdatedEvent;
+use OCA\Deck\Model\CardDetails;
 use OCA\Deck\NoPermissionException;
 use OCA\Deck\Notification\NotificationHelper;
 use OCA\Deck\Db\BoardMapper;
@@ -155,7 +156,12 @@ class CardService {
 			$card->setAssignedUsers($cardAssignedUsers);
 		}
 
-		return $cards;
+		return array_map(
+			function (Card $card): CardDetails {
+				return new CardDetails($card);
+			},
+			$cards
+		);
 	}
 	public function fetchDeleted($boardId) {
 		$this->cardServiceValidator->check(compact('boardId'));

--- a/lib/Service/StackService.php
+++ b/lib/Service/StackService.php
@@ -99,15 +99,7 @@ class StackService {
 			return;
 		}
 
-		$this->cardService->enrichCards($cards);
-		$cards = array_map(
-			function (Card $card): CardDetails {
-				return new CardDetails($card);
-			},
-			$cards
-		);
-
-		$stack->setCards($cards);
+		$stack->setCards($this->cardService->enrichCards($cards));
 	}
 
 	private function enrichStacksWithCards($stacks, $since = -1) {

--- a/tests/integration/features/bootstrap/BoardContext.php
+++ b/tests/integration/features/bootstrap/BoardContext.php
@@ -220,6 +220,17 @@ class BoardContext implements Context {
 	}
 
 	/**
+	 * @Given /^get the card details$/
+	 */
+	public function getCard() {
+		$this->requestContext->sendJSONrequest('GET', '/index.php/apps/deck/cards/' . $this->card['id'], array_merge(
+			$this->card
+		));
+		$this->requestContext->getResponse()->getBody()->seek(0);
+		$this->card = json_decode((string)$this->getResponse()->getBody(), true);
+	}
+
+	/**
 	 * @Given /^set the card duedate to "([^"]*)"$/
 	 */
 	public function setTheCardDuedateTo($arg1) {

--- a/tests/integration/features/decks.feature
+++ b/tests/integration/features/decks.feature
@@ -32,3 +32,29 @@ Feature: decks
     And creates a board named "MyBoard" with color "000000"
     And create a stack named "ToDo"
     When create a card named "This is a very ong name that exceeds the maximum length of a deck board created which is longer than 255 characters This is a very ong name that exceeds the maximum length of a deck board created which is longer than 255 characters This is a very ong name that exceeds the maximum length of a deck board created which is longer than 255 characters"
+
+	Scenario: Setting a duedate on a card
+		Given acting as user "user0"
+		And creates a board named "MyBoard" with color "000000"
+		And create a stack named "ToDo"
+		And create a card named "Overdue task"
+		When get the card details
+		And the response should be a JSON array with the following mandatory values
+			|key|value|
+			|title|Overdue task|
+			|duedate||
+			|overdue|0|
+		And set the card attribute "duedate" to "2020-12-12 13:37:00"
+		When get the card details
+		And the response should be a JSON array with the following mandatory values
+			|key|value|
+			|title|Overdue task|
+			|duedate|2020-12-12T13:37:00+00:00|
+			|overdue|3|
+		And set the card attribute "duedate" to ""
+		When get the card details
+		And the response should be a JSON array with the following mandatory values
+			|key|value|
+			|title|Overdue task|
+			|duedate||
+			|overdue|0|

--- a/tests/unit/Service/CardServiceTest.php
+++ b/tests/unit/Service/CardServiceTest.php
@@ -34,6 +34,7 @@ use OCA\Deck\Db\Stack;
 use OCA\Deck\Db\StackMapper;
 use OCA\Deck\Db\BoardMapper;
 use OCA\Deck\Db\LabelMapper;
+use OCA\Deck\Model\CardDetails;
 use OCA\Deck\Notification\NotificationHelper;
 use OCA\Deck\StatusException;
 use OCA\Deck\Validators\CardServiceValidator;
@@ -188,7 +189,10 @@ class CardServiceTest extends TestCase {
 		$cardExpected->setRelatedBoard($boardMock);
 		$cardExpected->setRelatedStack($stackMock);
 		$cardExpected->setLabels([]);
-		$this->assertEquals($cardExpected, $this->cardService->find(123));
+		$expected = new CardDetails($cardExpected);
+
+		$actual = $this->cardService->find(123);
+		$this->assertEquals($expected->jsonSerialize(), $actual->jsonSerialize());
 	}
 
 	public function testCreate() {

--- a/tests/unit/Service/Importer/Systems/TrelloJsonServiceTest.php
+++ b/tests/unit/Service/Importer/Systems/TrelloJsonServiceTest.php
@@ -76,7 +76,7 @@ class TrelloJsonServiceTest extends \Test\TestCase {
 	}
 
 	public function testValidateUsersWithNotStringNextcloud() {
-		$this->expectErrorMessage('User on setting uidRelation is invalid');
+		$this->expectExceptionMessage('User on setting uidRelation is invalid');
 		$importService = $this->createMock(BoardImportService::class);
 		$importService
 			->method('getConfig')
@@ -92,7 +92,7 @@ class TrelloJsonServiceTest extends \Test\TestCase {
 	}
 
 	public function testValidateUsersWithNotFoundUser() {
-		$this->expectErrorMessage('User on setting uidRelation not found: nextcloud_user');
+		$this->expectExceptionMessage('User on setting uidRelation not found: nextcloud_user');
 		$importService = $this->createMock(BoardImportService::class);
 		$importService
 			->method('getConfig')
@@ -124,7 +124,7 @@ class TrelloJsonServiceTest extends \Test\TestCase {
 	}
 
 	public function testGetBoardWithNoName() {
-		$this->expectErrorMessage('Invalid name of board');
+		$this->expectExceptionMessage('Invalid name of board');
 		$importService = $this->createMock(BoardImportService::class);
 		$this->service->setImportService($importService);
 		$this->service->getBoard();

--- a/tests/unit/Service/StackServiceTest.php
+++ b/tests/unit/Service/StackServiceTest.php
@@ -33,6 +33,7 @@ use OCA\Deck\Db\Label;
 use OCA\Deck\Db\LabelMapper;
 use OCA\Deck\Db\Stack;
 use OCA\Deck\Db\StackMapper;
+use OCA\Deck\Model\CardDetails;
 use OCA\Deck\Validators\StackServiceValidator;
 use OCP\EventDispatcher\IEventDispatcher;
 use Psr\Log\LoggerInterface;
@@ -121,6 +122,9 @@ class StackServiceTest extends TestCase {
 							foreach ($cards as $card) {
 								$card->setLabels($this->getLabels()[$card->getId()]);
 							}
+							return array_map(function ($card) {
+								return new CardDetails($card);
+							}, $cards);
 						}
 					)
 				);


### PR DESCRIPTION
Adding tests for #4488 

- [ ] See if we can also assert the stack list which had the problem
  - https://github.com/nextcloud/deck/pull/4494/files#diff-645bd4c13431fab6226e80be9d48d7fd8d1a46096c8acc59a0e83a7b5baabcc9R181 would be useful for checking this
- [x] Adapt phpunit tests for introduced CardDetails