### PR TITLE
fix: Always return sorted index array to make sure a json array is the result

### DIFF
--- a/lib/Db/BoardMapper.php
+++ b/lib/Db/BoardMapper.php
@@ -156,7 +156,7 @@ class BoardMapper extends QBMapper implements IPermissionMapper {
 			$userBoards = $this->findAllByUser($userId, null, null, $since, $includeArchived, $before, $term);
 			$groupBoards = $this->findAllByGroups($userId, $groups, null, null, $since, $includeArchived, $before, $term);
 			$circleBoards = $this->findAllByCircles($userId, null, null, $since, $includeArchived, $before, $term);
-			$allBoards = array_unique(array_merge($userBoards, $groupBoards, $circleBoards));
+			$allBoards = array_values(array_unique(array_merge($userBoards, $groupBoards, $circleBoards)));
 
 			// Could be moved outside
 			$acls = $this->aclMapper->findIn(array_map(function ($board) {


### PR DESCRIPTION
This has been lost in https://github.com/nextcloud/deck/pull/4452/files#diff-4975b048acd756b9fe8e6d63b016021d70ade5c1f79a5797ebe4dc6f2e87d34fL182 but the place was not that obvious. We need to use the array_values of the array_unique result to make sure that indexes are still properly in line and the later conversion to JSON results in an array not an object.
