### PR TITLE
fix(cards): Fix card sizing by limiting too wide style rules

### DIFF
--- a/src/components/board/Board.vue
+++ b/src/components/board/Board.vue
@@ -57,7 +57,10 @@
 					@drag-start="draggingStack = true"
 					@drag-end="draggingStack = false"
 					@drop="onDropStack">
-					<Draggable v-for="stack in stacksByBoard" :key="stack.id" data-click-closes-sidebar="true">
+					<Draggable v-for="stack in stacksByBoard"
+						:key="stack.id"
+						data-click-closes-sidebar="true"
+						class="stack-draggable-wrapper">
 						<Stack :stack="stack" :dragging="draggingStack" data-click-closes-sidebar="true" />
 					</Draggable>
 				</Container>
@@ -223,7 +226,7 @@ export default {
 		align-items: stretch;
 		height: 100%;
 
-		&:deep(.smooth-dnd-draggable-wrapper) {
+		&:deep(.stack-draggable-wrapper.smooth-dnd-draggable-wrapper) {
 			display: flex;
 			height: auto;
 


### PR DESCRIPTION
* Resolves: #4511
* Target version: main

### Summary

Flex layout and other styles should only affect the stack drag containers, not the child cards

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
