### PR TITLE
fix(references): Mute NoPermissionException as it is expected to happen for references

### DIFF
--- a/lib/Reference/BoardReferenceProvider.php
+++ b/lib/Reference/BoardReferenceProvider.php
@@ -23,6 +23,7 @@
 namespace OCA\Deck\Reference;
 
 use OCA\Deck\AppInfo\Application;
+use OCA\Deck\NoPermissionException;
 use OCA\Deck\Service\BoardService;
 use OCP\Collaboration\Reference\IReference;
 use OCP\Collaboration\Reference\IReferenceProvider;
@@ -67,7 +68,12 @@ class BoardReferenceProvider implements IReferenceProvider {
 		if ($this->matchReference($referenceText)) {
 			$boardId = $this->getBoardId($referenceText);
 			if ($boardId !== null) {
-				$board = $this->boardService->find($boardId)->jsonSerialize();
+				try {
+					$board = $this->boardService->find($boardId)->jsonSerialize();
+				} catch (NoPermissionException $e) {
+					// Skip throwing if user has no permissions
+					return null;
+				}
 				$board = $this->sanitizeSerializedBoard($board);
 				/** @var IReference $reference */
 				$reference = new Reference($referenceText);

--- a/lib/Reference/CardReferenceProvider.php
+++ b/lib/Reference/CardReferenceProvider.php
@@ -27,6 +27,7 @@ use OCA\Deck\Db\Assignment;
 use OCA\Deck\Db\Attachment;
 use OCA\Deck\Db\Label;
 use OCA\Deck\Model\CardDetails;
+use OCA\Deck\NoPermissionException;
 use OCA\Deck\Service\BoardService;
 use OCA\Deck\Service\CardService;
 use OCA\Deck\Service\StackService;
@@ -121,9 +122,15 @@ class CardReferenceProvider extends ADiscoverableReferenceProvider implements IS
 			$ids = $this->getBoardCardId($referenceText);
 			if ($ids !== null) {
 				[$boardId, $cardId] = $ids;
-				$card = $this->cardService->find((int) $cardId)->jsonSerialize();
-				$board = $this->boardService->find((int) $boardId)->jsonSerialize();
-				$stack = $this->stackService->find((int) $card['stackId'])->jsonSerialize();
+				try {
+					$card = $this->cardService->find((int) $cardId)->jsonSerialize();
+					$board = $this->boardService->find((int) $boardId)->jsonSerialize();
+					$stack = $this->stackService->find((int) $card['stackId'])->jsonSerialize();
+				} catch (NoPermissionException $e) {
+					// Skip throwing if user has no permissions
+					return null;
+				}
+
 
 				$card = $this->sanitizeSerializedCard($card);
 				$board = $this->sanitizeSerializedBoard($board);

--- a/lib/Reference/CommentReferenceProvider.php
+++ b/lib/Reference/CommentReferenceProvider.php
@@ -27,6 +27,7 @@ use OCA\Deck\Db\Assignment;
 use OCA\Deck\Db\Attachment;
 use OCA\Deck\Db\Label;
 use OCA\Deck\Model\CardDetails;
+use OCA\Deck\NoPermissionException;
 use OCA\Deck\Service\BoardService;
 use OCA\Deck\Service\CardService;
 use OCA\Deck\Service\CommentService;
@@ -85,9 +86,14 @@ class CommentReferenceProvider implements IReferenceProvider {
 			if ($ids !== null) {
 				[$boardId, $cardId, $commentId] = $ids;
 
-				$card = $this->cardService->find($cardId)->jsonSerialize();
-				$board = $this->boardService->find($boardId)->jsonSerialize();
-				$stack = $this->stackService->find((int) $card['stackId'])->jsonSerialize();
+				try {
+					$card = $this->cardService->find($cardId)->jsonSerialize();
+					$board = $this->boardService->find($boardId)->jsonSerialize();
+					$stack = $this->stackService->find((int) $card['stackId'])->jsonSerialize();
+				} catch (NoPermissionException $e) {
+					// Skip throwing if user has no permissions
+					return null;
+				}
 				$card = $this->sanitizeSerializedCard($card);
 				$board = $this->sanitizeSerializedBoard($board);
 				$stack = $this->sanitizeSerializedStack($stack);


### PR DESCRIPTION
Avoid throwing and logging permission exceptions which may be expected and should be handled by just returning no reference for deck references.