### PR TITLE
fix(API): Fix board API details parameter to work as expected

### DIFF
--- a/lib/Controller/BoardApiController.php
+++ b/lib/Controller/BoardApiController.php
@@ -60,9 +60,11 @@ class BoardApiController extends ApiController {
 	 * @NoCSRFRequired
 	 *
 	 * Return all of the boards that the current user has access to.
+	 *
+	 * @param bool $details
 	 * @throws StatusException
 	 */
-	public function index($details = null) {
+	public function index(bool $details = false) {
 		$modified = $this->request->getHeader('If-Modified-Since');
 		if ($modified === null || $modified === '') {
 			$boards = $this->boardService->findAll(0, $details === true);


### PR DESCRIPTION
* Resolves: #4517 
* Target version: main

### Summary

Before `?details=true` in the URL resulted in `string "true"` and therefore did not match `$details === true` which was brought in by https://github.com/nextcloud/deck/commit/b19b7794bc773d824275f18d58263c382532790f but it matched the old `$details` logic.

Defining the parameter as `bool` (like it was done in the other touched controller methods) gives the actual boolean to the controller fixing the comparison

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
