### PR TITLE
Fix consistency of a "Create card" wording with its equivalent for Notes ("New card")

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -52,7 +52,7 @@
 				<template #icon>
 					<PlusIcon :size="20" />
 				</template>
-				{{ t('deck', 'Add card') }}
+				{{ t('deck', 'New card') }}
 			</NcButton>
 			<CardCreateDialog v-if="showAddCardModal" @close="toggleAddCardModel" />
 		</div>


### PR DESCRIPTION
Create card -> New card (more relevant when compared with the equivalent button in the Notes widget)

![2023-03-15_13-21](https://user-images.githubusercontent.com/33763786/225307476-f16a67ab-b780-4651-83e7-e0ab28f5d3d2.png)


### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
