### PR TITLE
Prevent tag itself being edit button if user lacks permissions

### DIFF
--- a/src/components/board/TagsTabSidebar.vue
+++ b/src/components/board/TagsTabSidebar.vue
@@ -25,9 +25,13 @@
 					</form>
 				</template>
 				<template v-else>
-					<div class="label-title" @click="clickEdit(label)">
+					<div v-if="canManage && !isArchived" class="label-title" @click="clickEdit(label)">
 						<span :style="{ backgroundColor: `#${label.color}`, color: textColor(label.color) }">{{ label.title }}</span>
 					</div>
+					<div v-else class="label-title">
+						<span :style="{ backgroundColor: `#${label.color}`, color: textColor(label.color) }">{{ label.title }}</span>
+					</div>
+
 					<NcActions v-if="canManage && !isArchived">
 						<NcActionButton icon="icon-rename" @click="clickEdit(label)">
 							{{ t('deck', 'Edit') }}


### PR DESCRIPTION
* Resolves: #4554 <!-- related github issue -->
* Target version: main

### Summary

The tag itself is also a button for triggering edit mode. It should not be if user permissions don't permit editing. The current behavior lets the user attempt the edit (which then understandably fails - albeit without any feedback to the user since it was likely never expected to occur). This change prevents the button from being clickable to trigger edit mode unless the user has the correct permissions. Modeled after the adjacent checks that already exist which remove the edit and delete buttons for users with permissions. I believe this simply implements what was intended and the label/tag itself also being able to trigger editing was just a minor oversight.

### TODO

- [x] Get reviewed

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [na] Tests (unit, integration, api and/or acceptance) are included
- [na] Documentation (manuals or wiki) has been updated or is not required
