### PR TITLE
Better display of card dates (creation and change dates)

### DIFF
--- a/src/components/card/CardSidebar.vue
+++ b/src/components/card/CardSidebar.vue
@@ -147,10 +147,10 @@ export default {
 			return this.$store.getters.cardById(this.id)
 		},
 		subtitle() {
-			return '<strong>' + t('deck', 'Created') + ' :</strong> ' + this.relativeDate(this.currentCard.createdAt * 1000) + '<br><strong>' + t('deck', 'Modified') + ' :</strong> ' + this.relativeDate(this.currentCard.lastModified * 1000)
+			return t('deck', 'Modified') + ': ' + this.relativeDate(this.currentCard.lastModified * 1000) + ' ⸱ ' + t('deck', 'Created') + ': ' + this.relativeDate(this.currentCard.createdAt * 1000)
 		},
 		subtitleTooltip() {
-			return t('deck', 'Created') + ' : ' + this.formatDate(this.currentCard.createdAt) + '\n' + t('deck', 'Modified') + ' : ' + this.formatDate(this.currentCard.lastModified)
+			return t('deck', 'Modified') + ': ' + this.formatDate(this.currentCard.lastModified) + '\n' + t('deck', 'Created') + ': ' + this.formatDate(this.currentCard.createdAt)
 		},
 		cardRichObject() {
 			return {

--- a/src/components/card/CardSidebar.vue
+++ b/src/components/card/CardSidebar.vue
@@ -147,10 +147,10 @@ export default {
 			return this.$store.getters.cardById(this.id)
 		},
 		subtitle() {
-			return t('deck', 'Modified') + ': ' + this.relativeDate(this.currentCard.lastModified * 1000) + ' ' + t('deck', 'Created') + ': ' + this.relativeDate(this.currentCard.createdAt * 1000)
+			return '<strong>' + t('deck', 'Created') + ' :</strong> ' + this.relativeDate(this.currentCard.createdAt * 1000) + '<br><strong>' + t('deck', 'Modified') + ' :</strong> ' + this.relativeDate(this.currentCard.lastModified * 1000)
 		},
 		subtitleTooltip() {
-			return t('deck', 'Modified') + ': ' + this.formatDate(this.currentCard.lastModified) + '\n' + t('deck', 'Created') + ': ' + this.formatDate(this.currentCard.createdAt)
+			return t('deck', 'Created') + ' : ' + this.formatDate(this.currentCard.createdAt) + '\n' + t('deck', 'Modified') + ' : ' + this.formatDate(this.currentCard.lastModified)
 		},
 		cardRichObject() {
 			return {


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

### Before : 

![2023-04-20_10-10](https://user-images.githubusercontent.com/33763786/233302838-8ccb8598-3456-488d-98e0-ad1b35c27204.png)

### After (inverted + strong and space before ":") : 

![2023-04-20_10-09](https://user-images.githubusercontent.com/33763786/233302864-1f5c29bc-7a7e-4919-b0d6-31aea68846e3.png)

Note : 2 lines are inverted in tooltip as well ... so the "created" line is now above.

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
