### PR TITLE
allow user to toggle visibility of the calendar for a deck board

### DIFF
--- a/lib/DAV/Calendar.php
+++ b/lib/DAV/Calendar.php
@@ -188,12 +188,18 @@ class Calendar extends ExternalCalendar {
 			foreach ($properties as $key => $value) {
 				switch ($key) {
 					case '{DAV:}displayname':
+						if (!$this->backend->checkBoardPermission($this->board->getId(), Acl::PERMISSION_MANAGE)) {
+							throw new Forbidden('no permission to change the displayname');
+						}
 						if (mb_strpos($value, 'Deck: ') === 0) {
 							$value = mb_substr($value, strlen('Deck: '));
 						}
 						$this->board->setTitle($value);
 						break;
 					case '{http://apple.com/ns/ical/}calendar-color':
+						if (!$this->backend->checkBoardPermission($this->board->getId(), Acl::PERMISSION_MANAGE)) {
+							throw new Forbidden('no permission to change the calendar color');
+						}
 						$color = substr($value, 1, 6);
 						if (!preg_match('/[a-f0-9]{6}/i', $color)) {
 							throw new InvalidDataException('No valid color provided');

--- a/lib/DAV/Calendar.php
+++ b/lib/DAV/Calendar.php
@@ -59,20 +59,21 @@ class Calendar extends ExternalCalendar {
 	}
 
 	public function getACL() {
+		// the calendar should always have the read and the write-properties permissions
+		// write-properties is needed to allow the user to toggle the visibility of shared deck calendars
 		$acl = [
 			[
 				'privilege' => '{DAV:}read',
 				'principal' => $this->getOwner(),
 				'protected' => true,
-			]
-		];
-		if ($this->backend->checkBoardPermission($this->board->getId(), Acl::PERMISSION_MANAGE)) {
-			$acl[] = [
+			],
+			[
 				'privilege' => '{DAV:}write-properties',
 				'principal' => $this->getOwner(),
 				'protected' => true,
-			];
-		}
+			]
+		];
+
 		return $acl;
 	}
 


### PR DESCRIPTION
* Resolves:  https://github.com/nextcloud/deck/issues/4618

* Target version: main

### Summary

The calendar object needs to be exposed with "write-properties" in order to allow users to hide/show the corresponding calendar in the calendar app. It doesn't has any affects on the general permissions for the whole board or the individual cards. As soon as you select a calendar item you jump to the deck app where the normal deck permissions are applied.

As far as I understand it, caldav knows two kind if write permissions:

* "{DAV:}write" for editing calendar entries
* "{DAV:}write-properties" to only edit properties (like the visibility) of the calendar.

Looking at how we treat shared regular calendars, I think the solution should be fine: https://github.com/nextcloud/server/blob/master/apps/dav/lib/CalDAV/Calendar.php#L181


### TODO

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required

@juliushaertl This was a quick try to fix a issue I discovered, does it makes sense?
