### PR TITLE
fix: Append datetime picker to body to avoid cut off

### DIFF
--- a/src/components/card/CardSidebarTabDetails.vue
+++ b/src/components/card/CardSidebarTabDetails.vue
@@ -103,6 +103,7 @@
 					:formatter="format"
 					:disabled="saving || !canEdit"
 					:shortcuts="shortcuts"
+					:append-to-body="true"
 					confirm />
 				<NcActions v-if="canEdit">
 					<NcActionButton v-if="copiedCard.duedate" icon="icon-delete" @click="removeDue()">


### PR DESCRIPTION
Append the date picker to body to avoid cutting it off at the card details overflow container

* Resolves: https://github.com/nextcloud/deck/issues/4436
* Resolves: https://github.com/nextcloud/deck/issues/4395
* Resolves: https://github.com/nextcloud/deck/issues/4195
* Resolves: https://github.com/nextcloud/deck/issues/3586
* Resolves: https://github.com/nextcloud/deck/issues/3218
* Target version: main
