### PR TITLE
Deck card comment notification label improvement

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -58,9 +58,9 @@
     </commands>
     <activity>
         <settings>
-            <setting>OCA\Deck\Activity\Setting</setting>
+            <setting>OCA\Deck\Activity\SettingChanges</setting>
+            <setting>OCA\Deck\Activity\SettingDescription</setting>
             <setting>OCA\Deck\Activity\SettingComment</setting>
-            <setting>OCA\Deck\Activity\DescriptionSetting</setting>
         </settings>
         <filters>
             <filter>OCA\Deck\Activity\Filter</filter>

--- a/lib/Activity/SettingBase.php
+++ b/lib/Activity/SettingBase.php
@@ -23,9 +23,10 @@
 
 namespace OCA\Deck\Activity;
 
+use OCP\Activity\ActivitySettings;
 use OCP\IL10N;
 
-class Setting implements \OCP\Activity\ISetting {
+abstract class SettingBase extends ActivitySettings {
 
 	/** @var IL10N */
 	protected $l;
@@ -35,6 +36,14 @@ class Setting implements \OCP\Activity\ISetting {
 	 */
 	public function __construct(IL10N $l) {
 		$this->l = $l;
+	}
+
+	public function getGroupIdentifier() {
+		return 'deck';
+	}
+
+	public function getGroupName() {
+		return $this->l->t('Deck');
 	}
 
 	/**

--- a/lib/Activity/SettingChanges.php
+++ b/lib/Activity/SettingChanges.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
+ * @copyright Copyright (c) 2018 Julius Härtl <jus@bitgrid.net>
  *
  * @author Julius Härtl <jus@bitgrid.net>
  *
@@ -13,7 +13,7 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
@@ -23,14 +23,13 @@
 
 namespace OCA\Deck\Activity;
 
-class SettingComment extends SettingBase {
-
+class SettingChanges extends SettingBase {
 	/**
 	 * @return string Lowercase a-z and underscore only identifier
 	 * @since 11.0.0
 	 */
 	public function getIdentifier(): string {
-		return 'deck_comment';
+		return 'deck';
 	}
 
 	/**
@@ -38,7 +37,17 @@ class SettingComment extends SettingBase {
 	 * @since 11.0.0
 	 */
 	public function getName(): string {
-		return $this->l->t('A <strong>comment</strong> was created on a card');
+		return $this->l->t('A <strong>board, list or card</strong> was changed');
+	}
+
+	/**
+	 * @return int whether the filter should be rather on the top or bottom of
+	 * the admin section. The filters are arranged in ascending order of the
+	 * priority values. It is required to return a value between 0 and 100.
+	 * @since 11.0.0
+	 */
+	public function getPriority(): int {
+		return 90;
 	}
 
 	/**
@@ -46,6 +55,30 @@ class SettingComment extends SettingBase {
 	 * @since 11.0.0
 	 */
 	public function canChangeStream(): bool {
+		return true;
+	}
+
+	/**
+	 * @return bool True when the option can be changed for the stream
+	 * @since 11.0.0
+	 */
+	public function isDefaultEnabledStream(): bool {
+		return true;
+	}
+
+	/**
+	 * @return bool True when the option can be changed for the mail
+	 * @since 11.0.0
+	 */
+	public function canChangeMail(): bool {
+		return true;
+	}
+
+	/**
+	 * @return bool True when the option can be changed for the stream
+	 * @since 11.0.0
+	 */
+	public function isDefaultEnabledMail(): bool {
 		return false;
 	}
 }

--- a/lib/Activity/SettingComment.php
+++ b/lib/Activity/SettingComment.php
@@ -38,7 +38,7 @@ class SettingComment extends Setting {
 	 * @since 11.0.0
 	 */
 	public function getName(): string {
-		return $this->l->t('A <strong>comment</strong> was created on a card');
+		return $this->l->t('A <strong>comment</strong> was created on a Deck card');
 	}
 
 	/**

--- a/lib/Activity/SettingDescription.php
+++ b/lib/Activity/SettingDescription.php
@@ -23,7 +23,7 @@
 
 namespace OCA\Deck\Activity;
 
-class DescriptionSetting extends Setting {
+class SettingDescription extends SettingBase {
 
 	/**
 	 * @return string Lowercase a-z and underscore only identifier
@@ -38,6 +38,6 @@ class DescriptionSetting extends Setting {
 	 * @since 11.0.0
 	 */
 	public function getName(): string {
-		return $this->l->t('A <strong>card description</strong> inside the Deck app has been changed');
+		return $this->l->t('A <strong>card description</strong> has been changed');
 	}
 }

--- a/tests/unit/Activity/SettingTest.php
+++ b/tests/unit/Activity/SettingTest.php
@@ -30,7 +30,7 @@ class SettingTest extends TestCase {
 
 	/** @var IL10N */
 	private $l10n;
-	/** @var Setting */
+	/** @var SettingBase */
 	private $setting;
 
 	public function setUp(): void {
@@ -38,7 +38,7 @@ class SettingTest extends TestCase {
 		$this->l10n->expects($this->any())->method('t')->will($this->returnCallback(function ($s) {
 			return $s;
 		}));
-		$this->setting = new Setting($this->l10n);
+		$this->setting = new SettingChanges($this->l10n);
 	}
 
 	public function testGetIdentifier() {
@@ -46,7 +46,7 @@ class SettingTest extends TestCase {
 	}
 
 	public function testGetName() {
-		$this->assertEquals('Changes in the <strong>Deck app</strong>', $this->setting->getName());
+		$this->assertEquals('A <strong>board, list or card</strong> was changed', $this->setting->getName());
 	}
 
 	public function testGetPriority() {


### PR DESCRIPTION
### Concerning the following wording, which doesn't mention Deck, so we don't know what's the concerned app.
![2023-05-31_11-05](https://github.com/nextcloud/deck/assets/33763786/75d388cc-2ddb-482b-ad20-23d7e97b360a)


### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
