### PR TITLE
fix: execute return int for export command

### DIFF
--- a/lib/Command/UserExport.php
+++ b/lib/Command/UserExport.php
@@ -79,12 +79,12 @@ class UserExport extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
-	 * @return void
+	 * @return int
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 * @throws \ReflectionException
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$userId = $input->getArgument('user-id');
 
 		$this->boardService->setUserId($userId);
@@ -109,5 +109,6 @@ class UserExport extends Command {
 			}
 		}
 		$output->writeln(json_encode($data, JSON_PRETTY_PRINT));
+		return 0;
 	}
 }


### PR DESCRIPTION
* Target version: main, stable27, stable26

### Summary

Fix `occ deck:export` command to not print error.

### TODO

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- no tests as we currently do not test `occ` commands
- Documentation is not required
