### PR TITLE
Fix(occ): set user id for permission sevice from board service

### DIFF
--- a/lib/Service/BoardService.php
+++ b/lib/Service/BoardService.php
@@ -138,6 +138,7 @@ class BoardService {
 	 */
 	public function setUserId(string $userId): void {
 		$this->userId = $userId;
+		$this->permissionService->setUserId($userId);
 	}
 
 	/**


### PR DESCRIPTION
### Summary

Fixes #4010.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- No tests, as we currently do not test `occ` commands
- Documentation is not required
