### PR TITLE
fix: crash when leaving out system parameter

### DIFF
--- a/lib/Service/Importer/BoardImportService.php
+++ b/lib/Service/Importer/BoardImportService.php
@@ -143,11 +143,13 @@ class BoardImportService {
 	}
 
 	/**
-	 * @param mixed $system
+	 * @param ?string $system
 	 * @return self
 	 */
 	public function setSystem($system): self {
-		$this->system = $system;
+		if ($system) {
+			$this->system = $system;
+		}
 		return $this;
 	}
 


### PR DESCRIPTION
### Summary

The `--system` parameter can be supplied via command line or selected afterwards.

However if none was provided the command would crash with `TypeError: Cannot assign null to property $system`.

Handle that gracefully and make the type spec more precise for the setSystem function.

* Target version: main


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- no tests as we're not testing `occ` commands yet.
- no documentation as this is a bug fix.
