### PR TITLE
doc: mention QOwnNotes integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Deck is a kanban style organization tool aimed at personal planning and project 
 - [trello-to-deck](https://github.com/maxammann/trello-to-deck) - Migrates cards from Trello
 - [mail2deck](https://github.com/newroco/mail2deck) - Provides an "email in" solution
 - [A-deck](https://github.com/leoossa/A-deck) - Chrome Extension that allows to create new card in selected stack based on current tab
+- [QOwnNotes](https://github.com/pbek/QOwnNotes) - Quickly creates cards and links to them in Markdown notes
 
 ## Installation/Update
 


### PR DESCRIPTION
* Mentions the Deck integration in QOwnNotes since 23.6.0 and the following releases (see https://www.qownnotes.org/changelog.html#_23-6-0)
* Target version: main

### Checklist

- [x] Documentation (manuals or wiki) has been updated or is not required
