### PR TITLE
fix(notification): Prevent null in parameters

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -239,8 +239,8 @@ class Notifier implements INotifier {
 						],
 						'user' => [
 							'type' => 'user',
-							'id' => $params[1],
-							'name' => $dn,
+							'id' => $params[1] ?? '',
+							'name' => $dn ?? '',
 						]
 					]
 				);


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

In our instance we have a notification record like this:
```
|         1236905 | deck               | m…a | 1688536306 | board                 | 371        | board-shared        | ["A…s",null]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |                     | []                      |                                                                                 | []      |                                                                                     |
```

The null here is then breaking when trying to send the notification email:
```json
{
  "reqId": "mdWuqhrBH4ueDGB9oH5R",
  "level": 3,
  "time": "2023-07-14T05:40:02+00:00",
  "remoteAddr": "",
  "user": "--",
  "app": "notifications",
  "method": "",
  "url": "--",
  "message": "An error occurred while preparing a notification (deck|board-shared|board|371) for sending",
  "userAgent": "--",
  "version": "27.0.1.0",
  "exception": {
    "Exception": "TypeError",
    "Message": "htmlspecialchars(): Argument #1 ($string) must be of type string, null given",
    "Code": 0,
    "Trace": [
      {
        "file": "…/apps/notifications/lib/MailNotifications.php",
        "line": 386,
        "function": "htmlspecialchars",
        "args": [
          null
        ]
      },
      {
        "file": "…/apps/notifications/lib/MailNotifications.php",
        "line": 347,
        "function": "replaceRichParameters",
        "class": "OCA\\Notifications\\MailNotifications",
        "type": "->",
        "args": [
          [
            [
              "deck-board",
              "371",
              "A…s",
              "https://…/index.php/apps/deck/#/board/371"
            ],
            [
              "user",
              null,
              null
            ]
          ],
          "{user} has shared {deck-board} with you."
        ]
      },
```

I don't know where the bug actually was created, maybe by ownership transfer or a share via CLI or something. But by defaulting to empty string the email at least sends

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
