### PR TITLE
enh/import from deck

### DIFF
--- a/docs/export-import.md
+++ b/docs/export-import.md
@@ -1,0 +1,98 @@
+## Export
+
+Deck currently supports exporting all boards a user owns in a single JSON file. The format is based on the database schema that deck uses. It can be used to re-import boards on the same or other instances.
+
+The export currently has some kown limitations in terms of specific data not included:
+- Activity information
+- File attachments to deck cards
+- Comments
+-
+```
+occ deck:export > my-file.json
+```
+
+## Import boards
+
+Importing can be done using the API or the `occ` `deck:import` command.
+
+It is possible to import from the following sources:
+
+### Deck JSON
+
+A json file that has been obtained from the above described `occ deck:export [userid]` command can be imported.
+
+```
+occ deck:import my-file.json
+```
+
+In case you are importing from a different instance you may use an additional config file to provide custom user id mapping in case users have different identifiers.
+
+```
+{
+    "owner": "admin",
+    "uidRelation": {
+        "johndoe": "test-user-1"
+    }
+}
+```
+
+#### Trello JSON
+
+Limitations:
+* Comments with more than 1000 characters are placed as attached files to the card.
+
+Steps:
+* Create the data file
+	* Access Trello
+	* go to the board you want to export
+	* Follow the steps in [Trello documentation](https://help.trello.com/article/747-exporting-data-from-trello-1) and export as JSON
+* Create the configuration file
+* Execute the import informing the import file path, data file and source as `Trello JSON`
+
+Create the configuration file respecting the [JSON Schema](https://github.com/nextcloud/deck/blob/main/lib/Service/Importer/fixtures/config-trelloJson-schema.json) for import `Trello JSON`
+
+Example configuration file:
+```json
+{
+    "owner": "admin",
+    "color": "0800fd",
+    "uidRelation": {
+        "johndoe": "johndoe"
+    }
+}
+```
+
+**Limitations**:
+
+Importing from a JSON file imports up to 1000 actions. To find out how many actions the board to be imported has, identify how many actions the JSON has.
+
+#### Trello API
+
+Import using API is recommended for boards with more than 1000 actions.
+
+Trello makes it possible to attach links to a card. Deck does not have this feature. Attachments and attachment links are added in a markdown table at the end of the description for every imported card that has attachments in Trello.
+
+* Get the API Key and API Token [here](https://developer.atlassian.com/cloud/trello/guides/rest-api/api-introduction/#authentication-and-authorization)
+* Get the ID of the board you want to import by making a request to:
+  https://api.trello.com/1/members/me/boards?key={yourKey}&token={yourToken}&fields=id,name
+
+  This ID you will use in the configuration file in the `board` property
+* Create the configuration file
+
+Create the configuration file respecting the [JSON Schema](https://github.com/nextcloud/deck/blob/main/lib/Service/Importer/fixtures/config-trelloApi-schema.json) for import `Trello JSON`
+
+Example configuration file:
+```json
+{
+    "owner": "admin",
+    "color": "0800fd",
+    "api": {
+        "key": "0cc175b9c0f1b6a831c399e269772661",
+        "token": "92eb5ffee6ae2fec3ad71c777531578f4a8a08f09d37b73795649038408b5f33"
+    },
+    "board": "8277e0910d750195b4487976",
+    "uidRelation": {
+        "johndoe": "johndoe"
+    }
+}
+```

--- a/lib/Command/BoardImport.php
+++ b/lib/Command/BoardImport.php
@@ -30,12 +30,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class BoardImport extends Command {
-	private BoardImportCommandService $boardImportCommandService;
-
 	public function __construct(
-		BoardImportCommandService $boardImportCommandService
+		private BoardImportCommandService $boardImportCommandService
 	) {
-		$this->boardImportCommandService = $boardImportCommandService;
 		parent::__construct();
 	}
 

--- a/lib/Command/BoardImport.php
+++ b/lib/Command/BoardImport.php
@@ -25,6 +25,7 @@ namespace OCA\Deck\Command;
 
 use OCA\Deck\Service\Importer\BoardImportCommandService;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -41,7 +42,9 @@ class BoardImport extends Command {
 	 */
 	protected function configure() {
 		$allowedSystems = $this->boardImportCommandService->getAllowedImportSystems();
-		$names = array_column($allowedSystems, 'name');
+		$names = array_map(function ($name) {
+			return '"' . $name . '"';
+		}, array_column($allowedSystems, 'internalName'));
 		$this
 			->setName('deck:import')
 			->setDescription('Import data')
@@ -50,7 +53,7 @@ class BoardImport extends Command {
 				null,
 				InputOption::VALUE_REQUIRED,
 				'Source system for import. Available options: ' . implode(', ', $names) . '.',
-				null
+				'DeckJson',
 			)
 			->addOption(
 				'config',
@@ -65,6 +68,11 @@ class BoardImport extends Command {
 				InputOption::VALUE_OPTIONAL,
 				'Data file to import.',
 				'data.json'
+			)
+			->addArgument(
+				'file',
+				InputArgument::OPTIONAL,
+				'File to import',
 			)
 		;
 	}

--- a/lib/Command/UserExport.php
+++ b/lib/Command/UserExport.php
@@ -96,7 +96,7 @@ class UserExport extends Command {
 			$data[$board->getId()] = (array)$fullBoard->jsonSerialize();
 			$stacks = $this->stackMapper->findAll($board->getId());
 			foreach ($stacks as $stack) {
-				$data[$board->getId()]['stacks'][] = (array)$stack->jsonSerialize();
+				$data[$board->getId()]['stacks'][$stack->getId()] = (array)$stack->jsonSerialize();
 				$cards = $this->cardMapper->findAllByStack($stack->getId());
 				foreach ($cards as $card) {
 					$fullCard = $this->cardMapper->find($card->getId());

--- a/lib/Command/UserExport.php
+++ b/lib/Command/UserExport.php
@@ -29,39 +29,23 @@ use OCA\Deck\Db\CardMapper;
 use OCA\Deck\Db\StackMapper;
 use OCA\Deck\Model\CardDetails;
 use OCA\Deck\Service\BoardService;
-use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\MultipleObjectsReturnedException;
-use OCP\IGroupManager;
-use OCP\IUserManager;
+use OCP\App\IAppManager;
+use OCP\DB\Exception;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class UserExport extends Command {
-	protected $boardService;
-	protected $cardMapper;
-	private $userManager;
-	private $groupManager;
-	private $assignedUsersMapper;
-
-	public function __construct(BoardMapper $boardMapper,
-		BoardService $boardService,
-		StackMapper $stackMapper,
-		CardMapper $cardMapper,
-		AssignmentMapper $assignedUsersMapper,
-		IUserManager $userManager,
-		IGroupManager $groupManager) {
+	public function __construct(
+		private IAppManager $appManager,
+		private BoardMapper $boardMapper,
+		private BoardService $boardService,
+		private StackMapper $stackMapper,
+		private CardMapper $cardMapper,
+		private AssignmentMapper $assignedUsersMapper,
+	) {
 		parent::__construct();
-
-		$this->cardMapper = $cardMapper;
-		$this->boardService = $boardService;
-		$this->stackMapper = $stackMapper;
-		$this->assignedUsersMapper = $assignedUsersMapper;
-		$this->boardMapper = $boardMapper;
-
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
 	}
 
 	protected function configure() {
@@ -73,19 +57,16 @@ class UserExport extends Command {
 				InputArgument::REQUIRED,
 				'User ID of the user'
 			)
+			->addOption('legacy-format', 'l')
 		;
 	}
 
 	/**
-	 * @param InputInterface $input
-	 * @param OutputInterface $output
-	 * @return int
-	 * @throws DoesNotExistException
-	 * @throws MultipleObjectsReturnedException
-	 * @throws \ReflectionException
+	 * @throws Exception
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$userId = $input->getArgument('user-id');
+		$legacyFormat = $input->getOption('legacy-format');
 
 		$this->boardService->setUserId($userId);
 		$boards = $this->boardService->findAll();
@@ -93,10 +74,10 @@ class UserExport extends Command {
 		$data = [];
 		foreach ($boards as $board) {
 			$fullBoard = $this->boardMapper->find($board->getId(), true, true);
-			$data[$board->getId()] = (array)$fullBoard->jsonSerialize();
+			$data[$board->getId()] = $fullBoard->jsonSerialize();
 			$stacks = $this->stackMapper->findAll($board->getId());
 			foreach ($stacks as $stack) {
-				$data[$board->getId()]['stacks'][$stack->getId()] = (array)$stack->jsonSerialize();
+				$data[$board->getId()]['stacks'][$stack->getId()] = $stack->jsonSerialize();
 				$cards = $this->cardMapper->findAllByStack($stack->getId());
 				foreach ($cards as $card) {
 					$fullCard = $this->cardMapper->find($card->getId());
@@ -108,7 +89,12 @@ class UserExport extends Command {
 				}
 			}
 		}
-		$output->writeln(json_encode($data, JSON_PRETTY_PRINT));
+		$output->writeln(json_encode(
+			$legacyFormat ? $data : [
+				'version' => $this->appManager->getAppVersion('deck'),
+				'boards' => $data
+			],
+			JSON_PRETTY_PRINT));
 		return 0;
 	}
 }

--- a/lib/Command/UserExport.php
+++ b/lib/Command/UserExport.php
@@ -69,7 +69,7 @@ class UserExport extends Command {
 		$legacyFormat = $input->getOption('legacy-format');
 
 		$this->boardService->setUserId($userId);
-		$boards = $this->boardService->findAll();
+		$boards = $this->boardService->findAll(fullDetails: true);
 
 		$data = [];
 		foreach ($boards as $board) {

--- a/lib/Command/UserExport.php
+++ b/lib/Command/UserExport.php
@@ -69,7 +69,7 @@ class UserExport extends Command {
 		$legacyFormat = $input->getOption('legacy-format');
 
 		$this->boardService->setUserId($userId);
-		$boards = $this->boardService->findAll(fullDetails: true);
+		$boards = $this->boardService->findAll(fullDetails: false);
 
 		$data = [];
 		foreach ($boards as $board) {

--- a/lib/Db/Assignment.php
+++ b/lib/Db/Assignment.php
@@ -41,4 +41,17 @@ class Assignment extends RelationalEntity implements JsonSerializable {
 		$this->addType('type', 'integer');
 		$this->addResolvable('participant');
 	}
+
+	public function getTypeString(): string {
+		switch ($this->getType()) {
+			case self::TYPE_USER:
+				return 'user';
+			case self::TYPE_GROUP:
+				return 'group';
+			case self::TYPE_CIRCLE:
+				return 'circle';
+		}
+
+		return 'unknown';
+	}
 }

--- a/lib/Db/BoardMapper.php
+++ b/lib/Db/BoardMapper.php
@@ -532,12 +532,12 @@ class BoardMapper extends QBMapper implements IPermissionMapper {
 		if ($boardId) {
 			unset($this->boardCache[$boardId]);
 		} else {
-			$this->boardCache = null;
+			$this->boardCache = new CappedMemoryCache();
 		}
 		if ($userId) {
 			unset($this->userBoardCache[$userId]);
 		} else {
-			$this->userBoardCache = null;
+			$this->userBoardCache = new CappedMemoryCache();
 		}
 	}
 }

--- a/lib/Db/LabelMapper.php
+++ b/lib/Db/LabelMapper.php
@@ -115,7 +115,9 @@ class LabelMapper extends DeckMapper implements IPermissionMapper {
 	}
 
 	public function insert(Entity $entity): Entity {
-		$entity->setLastModified(time());
+		if (!in_array('lastModified', $entity->getUpdatedFields())) {
+			$entity->setLastModified(time());
+		}
 		return parent::insert($entity);
 	}
 

--- a/lib/Db/RelationalEntity.php
+++ b/lib/Db/RelationalEntity.php
@@ -138,7 +138,7 @@ class RelationalEntity extends Entity implements \JsonSerializable {
 
 		$attr = lcfirst(substr($methodName, 3));
 		if (array_key_exists($attr, $this->_resolvedProperties) && str_starts_with($methodName, 'set')) {
-			if (!is_scalar($args[0])) {
+			if ($args[0] !== null && !is_scalar($args[0])) {
 				$args[0] = $args[0]['primaryKey'];
 			}
 			parent::setter($attr, $args);

--- a/lib/Service/Importer/ABoardImportService.php
+++ b/lib/Service/Importer/ABoardImportService.php
@@ -61,6 +61,10 @@ abstract class ABoardImportService {
 	 */
 	abstract public function bootstrap(): void;
 
+	public function getBoards(): array {
+		return [$this->getImportService()->getData()];
+	}
+
 	abstract public function getBoard(): ?Board;
 
 	/**
@@ -132,5 +136,14 @@ abstract class ABoardImportService {
 
 	public function needValidateData(): bool {
 		return $this->needValidateData;
+	}
+
+	public function reset(): void {
+		// FIXME: Would be cleaner if we could just get a new instance per board
+		// but currently https://github.com/nextcloud/deck/blob/7d820aa3f9fc69ada8188549b9a2fbb9093ffb95/lib/Service/Importer/BoardImportService.php#L194 returns a singleton
+		$this->labels = [];
+		$this->stacks = [];
+		$this->acls = [];
+		$this->cards = [];
 	}
 }

--- a/lib/Service/Importer/BoardImportCommandService.php
+++ b/lib/Service/Importer/BoardImportCommandService.php
@@ -184,7 +184,7 @@ class BoardImportCommandService extends BoardImportService {
 		foreach ($boards as $board) {
 			$this->reset();
 			$this->setData($board);
-			$this->getOutput()->writeln('Importing board...');
+			$this->getOutput()->writeln('Importing board "' . $this->getBoard()->getTitle() . '".');
 			$this->importBoard();
 			$this->getOutput()->writeln('Assign users to board...');
 			$this->importAcl();

--- a/lib/Service/Importer/BoardImportCommandService.php
+++ b/lib/Service/Importer/BoardImportCommandService.php
@@ -95,7 +95,7 @@ class BoardImportCommandService extends BoardImportService {
 			$helper = $this->getCommand()->getHelper('question');
 			$question = new Question(
 				"<info>You can get more info on https://deck.readthedocs.io/en/latest/User_documentation_en/#6-import-boards</info>\n" .
-				'Please inform a valid config json file: ',
+				'Please provide a valid config json file: ',
 				'config.json'
 			);
 			$question->setValidator(function (string $answer) {
@@ -130,7 +130,7 @@ class BoardImportCommandService extends BoardImportService {
 		$allowedSystems = $this->getAllowedImportSystems();
 		$names = array_column($allowedSystems, 'name');
 		$question = new ChoiceQuestion(
-			'Please inform a source system',
+			'Please select a source system',
 			$names,
 			0
 		);

--- a/lib/Service/Importer/BoardImportCommandService.php
+++ b/lib/Service/Importer/BoardImportCommandService.php
@@ -179,21 +179,28 @@ class BoardImportCommandService extends BoardImportService {
 	public function import(): void {
 		$this->getOutput()->writeln('Starting import...');
 		$this->bootstrap();
-		$this->getOutput()->writeln('Importing board...');
-		$this->importBoard();
-		$this->getOutput()->writeln('Assign users to board...');
-		$this->importAcl();
-		$this->getOutput()->writeln('Importing labels...');
-		$this->importLabels();
-		$this->getOutput()->writeln('Importing stacks...');
-		$this->importStacks();
-		$this->getOutput()->writeln('Importing cards...');
-		$this->importCards();
-		$this->getOutput()->writeln('Assign cards to labels...');
-		$this->assignCardsToLabels();
-		$this->getOutput()->writeln('Importing comments...');
-		$this->importComments();
-		$this->getOutput()->writeln('Importing participants...');
-		$this->importCardAssignments();
+		$boards = $this->getImportSystem()->getBoards();
+
+		foreach ($boards as $board) {
+			$this->reset();
+			$this->setData($board);
+			$this->getOutput()->writeln('Importing board...');
+			$this->importBoard();
+			$this->getOutput()->writeln('Assign users to board...');
+			$this->importAcl();
+			$this->getOutput()->writeln('Importing labels...');
+			$this->importLabels();
+			$this->getOutput()->writeln('Importing stacks...');
+			$this->importStacks();
+			$this->getOutput()->writeln('Importing cards...');
+			$this->importCards();
+			$this->getOutput()->writeln('Assign cards to labels...');
+			$this->assignCardsToLabels();
+			$this->getOutput()->writeln('Importing comments...');
+			$this->importComments();
+			$this->getOutput()->writeln('Importing participants...');
+			$this->importCardAssignments();
+			$this->getOutput()->writeln('<info>Finished board import of "' . $this->getBoard()->getTitle() . '"</info>');
+		}
 	}
 }

--- a/lib/Service/Importer/BoardImportCommandService.php
+++ b/lib/Service/Importer/BoardImportCommandService.php
@@ -76,7 +76,6 @@ class BoardImportCommandService extends BoardImportService {
 	}
 
 	protected function validateConfig(): void {
-		// FIXME: Make config optional for deck plain importer (but use a call on the importer insterad)
 		try {
 			$config = $this->getInput()->getOption('config');
 			if (!$config) {

--- a/lib/Service/Importer/BoardImportService.php
+++ b/lib/Service/Importer/BoardImportService.php
@@ -84,6 +84,8 @@ class BoardImportService {
 	) {
 		$this->board = new Board();
 		$this->disableCommentsEvents();
+
+		$this->config = new \stdClass();
 	}
 
 	private function disableCommentsEvents(): void {
@@ -152,6 +154,11 @@ class BoardImportService {
 	public function getAllowedImportSystems(): array {
 		if (!$this->allowedSystems) {
 			$this->addAllowedImportSystem([
+				'name' => DeckJsonService::$name,
+				'class' => DeckJsonService::class,
+				'internalName' => 'DeckJson'
+			]);
+			$this->addAllowedImportSystem([
 				'name' => TrelloApiService::$name,
 				'class' => TrelloApiService::class,
 				'internalName' => 'TrelloApi'
@@ -160,11 +167,6 @@ class BoardImportService {
 				'name' => TrelloJsonService::$name,
 				'class' => TrelloJsonService::class,
 				'internalName' => 'TrelloJson'
-			]);
-			$this->addAllowedImportSystem([
-				'name' => DeckJsonService::$name,
-				'class' => DeckJsonService::class,
-				'internalName' => 'DeckJson'
 			]);
 		}
 		$this->eventDispatcher->dispatchTyped(new BoardImportGetAllowedEvent($this));

--- a/lib/Service/Importer/BoardImportService.php
+++ b/lib/Service/Importer/BoardImportService.php
@@ -49,6 +49,7 @@ use OCP\Comments\NotFoundException as CommentNotFoundException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUserManager;
 use OCP\Server;
+use Psr\Log\LoggerInterface;
 
 class BoardImportService {
 	private string $system = '';
@@ -70,6 +71,11 @@ class BoardImportService {
 	private $data;
 	private Board $board;
 
+	/** @var callable[] */
+	private array $errorCollectors = [];
+	/** @var callable[] */
+	private array $outputCollectors = [];
+
 	public function __construct(
 		private IUserManager $userManager,
 		private BoardMapper $boardMapper,
@@ -80,12 +86,35 @@ class BoardImportService {
 		private AttachmentMapper $attachmentMapper,
 		private CardMapper $cardMapper,
 		private ICommentsManager $commentsManager,
-		private IEventDispatcher $eventDispatcher
+		private IEventDispatcher $eventDispatcher,
+		private LoggerInterface $logger
 	) {
 		$this->board = new Board();
 		$this->disableCommentsEvents();
 
 		$this->config = new \stdClass();
+	}
+
+	public function registerErrorCollector(callable $errorCollector): void {
+		$this->errorCollectors[] = $errorCollector;
+	}
+
+	public function registerOutputCollector(callable $outputCollector): void {
+		$this->outputCollectors[] = $outputCollector;
+	}
+
+	private function addError(string $message, $exception): void {
+		$message .= ' (on board ' . $this->getBoard()->getTitle() . ')';
+		foreach ($this->errorCollectors as $errorCollector) {
+			$errorCollector($message, $exception);
+		}
+		$this->logger->error($message, ['exception' => $exception]);
+	}
+
+	private function addOutput(string $message): void {
+		foreach ($this->outputCollectors as $outputCollector) {
+			$outputCollector($message);
+		}
 	}
 
 	private function disableCommentsEvents(): void {
@@ -117,6 +146,7 @@ class BoardImportService {
 				$this->importComments();
 				$this->importCardAssignments();
 			} catch (\Throwable $th) {
+				$this->logger->error('Failed to import board', ['exception' => $th]);
 				throw new BadRequestException($th->getMessage());
 			}
 		}
@@ -195,6 +225,10 @@ class BoardImportService {
 
 	public function importBoard(): void {
 		$board = $this->getImportSystem()->getBoard();
+		if (!$this->userManager->userExists($board->getOwner())) {
+			throw new \Exception('Target owner ' . $board->getOwner() . ' not found. Please provide a mapping through the import config.');
+		}
+
 		if ($board) {
 			$this->boardMapper->insert($board);
 			$this->board = $board;
@@ -211,8 +245,13 @@ class BoardImportService {
 	public function importAcl(): void {
 		$aclList = $this->getImportSystem()->getAclList();
 		foreach ($aclList as $code => $acl) {
-			$this->aclMapper->insert($acl);
-			$this->getImportSystem()->updateAcl($code, $acl);
+			try {
+				$this->aclMapper->insert($acl);
+				$this->getImportSystem()->updateAcl($code, $acl);
+			} catch (\Exception $e) {
+				$this->addError('Failed to import acl rule for ' . $acl->getParticipant(), $e);
+
+			}
 		}
 		$this->getBoard()->setAcl($aclList);
 	}
@@ -220,8 +259,12 @@ class BoardImportService {
 	public function importLabels(): void {
 		$labels = $this->getImportSystem()->getLabels();
 		foreach ($labels as $code => $label) {
-			$this->labelMapper->insert($label);
-			$this->getImportSystem()->updateLabel($code, $label);
+			try {
+				$this->labelMapper->insert($label);
+				$this->getImportSystem()->updateLabel($code, $label);
+			} catch (\Exception $e) {
+				$this->addError('Failed to import label ' . $label->getTitle(), $e);
+			}
 		}
 		$this->getBoard()->setLabels($labels);
 	}
@@ -229,8 +272,12 @@ class BoardImportService {
 	public function importStacks(): void {
 		$stacks = $this->getImportSystem()->getStacks();
 		foreach ($stacks as $code => $stack) {
-			$this->stackMapper->insert($stack);
-			$this->getImportSystem()->updateStack($code, $stack);
+			try {
+				$this->stackMapper->insert($stack);
+				$this->getImportSystem()->updateStack($code, $stack);
+			} catch (\Exception $e) {
+				$this->addError('Failed to import list ' . $stack->getTitle(), $e);
+			}
 		}
 		$this->getBoard()->setStacks(array_values($stacks));
 	}
@@ -238,22 +285,26 @@ class BoardImportService {
 	public function importCards(): void {
 		$cards = $this->getImportSystem()->getCards();
 		foreach ($cards as $code => $card) {
-			$createdAt = $card->getCreatedAt();
-			$lastModified = $card->getLastModified();
-			$this->cardMapper->insert($card);
-			$updateDate = false;
-			if ($createdAt && $createdAt !== $card->getCreatedAt()) {
-				$card->setCreatedAt($createdAt);
-				$updateDate = true;
+			try {
+				$createdAt = $card->getCreatedAt();
+				$lastModified = $card->getLastModified();
+				$this->cardMapper->insert($card);
+				$updateDate = false;
+				if ($createdAt && $createdAt !== $card->getCreatedAt()) {
+					$card->setCreatedAt($createdAt);
+					$updateDate = true;
+				}
+				if ($lastModified && $lastModified !== $card->getLastModified()) {
+					$card->setLastModified($lastModified);
+					$updateDate = true;
+				}
+				if ($updateDate) {
+					$this->cardMapper->update($card, false);
+				}
+				$this->getImportSystem()->updateCard($code, $card);
+			} catch (\Exception $e) {
+				$this->addError('Failed to import card ' . $card->getTitle(), $e);
 			}
-			if ($lastModified && $lastModified !== $card->getLastModified()) {
-				$card->setLastModified($lastModified);
-				$updateDate = true;
-			}
-			if ($updateDate) {
-				$this->cardMapper->update($card, false);
-			}
-			$this->getImportSystem()->updateCard($code, $card);
 		}
 	}
 
@@ -274,11 +325,15 @@ class BoardImportService {
 		$data = $this->getImportSystem()->getCardLabelAssignment();
 		foreach ($data as $cardId => $assignemnt) {
 			foreach ($assignemnt as $assignmentId => $labelId) {
-				$this->assignCardToLabel(
-					$cardId,
-					$labelId
-				);
-				$this->getImportSystem()->updateCardLabelsAssignment($cardId, $assignmentId, $labelId);
+				try {
+					$this->assignCardToLabel(
+						$cardId,
+						$labelId
+					);
+					$this->getImportSystem()->updateCardLabelsAssignment($cardId, $assignmentId, $labelId);
+				} catch (\Exception $e) {
+					$this->addError('Failed to assign label ' . $labelId . ' to ' . $cardId, $e);
+				}
 			}
 		}
 	}
@@ -320,9 +375,14 @@ class BoardImportService {
 	public function importCardAssignments(): void {
 		$allAssignments = $this->getImportSystem()->getCardAssignments();
 		foreach ($allAssignments as $cardId => $assignments) {
-			foreach ($assignments as $assignmentId => $assignment) {
-				$this->assignmentMapper->insert($assignment);
-				$this->getImportSystem()->updateCardAssignment($cardId, $assignmentId, $assignment);
+			foreach ($assignments as $assignment) {
+				try {
+					$assignment = $this->assignmentMapper->insert($assignment);
+					$this->getImportSystem()->updateCardAssignment($cardId, (string)$assignment->getId(), $assignment);
+					$this->addOutput('Assignment ' . $assignment->getParticipant() . ' added');
+				} catch (NotFoundException $e) {
+					$this->addError('No origin or mapping found for card "' . $cardId . '" and ' . $assignment->getTypeString() .' assignment "' . $assignment->getParticipant(), $e);
+				}
 			}
 		}
 	}

--- a/lib/Service/Importer/BoardImportService.php
+++ b/lib/Service/Importer/BoardImportService.php
@@ -61,7 +61,7 @@ class BoardImportService {
 	private ICommentsManager $commentsManager;
 	private IEventDispatcher $eventDispatcher;
 	private string $system = '';
-	private ?ABoardImportService $systemInstance;
+	private ?ABoardImportService $systemInstance = null;
 	private array $allowedSystems = [];
 	/**
 	 * Data object created from config JSON

--- a/lib/Service/Importer/BoardImportService.php
+++ b/lib/Service/Importer/BoardImportService.php
@@ -42,6 +42,7 @@ use OCA\Deck\NotFoundException;
 use OCA\Deck\Service\FileService;
 use OCA\Deck\Service\Importer\Systems\TrelloApiService;
 use OCA\Deck\Service\Importer\Systems\TrelloJsonService;
+use OCA\Deck\Service\Importer\Systems\DeckJsonService;
 use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException as CommentNotFoundException;
@@ -173,6 +174,11 @@ class BoardImportService {
 				'name' => TrelloJsonService::$name,
 				'class' => TrelloJsonService::class,
 				'internalName' => 'TrelloJson'
+			]);
+			$this->addAllowedImportSystem([
+				'name' => DeckJsonService::$name,
+				'class' => DeckJsonService::class,
+				'internalName' => 'DeckJson'
 			]);
 		}
 		$this->eventDispatcher->dispatchTyped(new BoardImportGetAllowedEvent($this));

--- a/lib/Service/Importer/BoardImportService.php
+++ b/lib/Service/Importer/BoardImportService.php
@@ -117,7 +117,6 @@ class BoardImportService {
 				$this->importComments();
 				$this->importCardAssignments();
 			} catch (\Throwable $th) {
-				throw $th;
 				throw new BadRequestException($th->getMessage());
 			}
 		}

--- a/lib/Service/Importer/Systems/DeckJsonService.php
+++ b/lib/Service/Importer/Systems/DeckJsonService.php
@@ -216,6 +216,8 @@ class DeckJsonService extends ABoardImportService {
 			$acl->setPermissionEdit(false);
 			$acl->setPermissionShare(false);
 			$acl->setPermissionManage(false);
+			// FIXME: Figure out a way to collect and aggregate warnings about users
+			// FIXME: Maybe have a dry run?
 			$return[] = $acl;
 		}
 		return $return;

--- a/lib/Service/Importer/Systems/DeckJsonService.php
+++ b/lib/Service/Importer/Systems/DeckJsonService.php
@@ -78,7 +78,7 @@ class DeckJsonService extends ABoardImportService {
 
 	public function mapMember($uid): ?string {
 		$ownerMap = $this->mapOwner($uid);
-		if ($ownerMap !== $uid) {
+		if ($uid === $this->getImportService()->getData()->owner && $ownerMap !== $this->getImportService()->getData()->owner) {
 			return $ownerMap;
 		}
 

--- a/lib/Service/Importer/Systems/DeckJsonService.php
+++ b/lib/Service/Importer/Systems/DeckJsonService.php
@@ -77,6 +77,11 @@ class DeckJsonService extends ABoardImportService {
 	}
 
 	public function mapMember($uid): ?string {
+		$ownerMap = $this->mapOwner($uid);
+		if ($ownerMap !== $uid) {
+			return $ownerMap;
+		}
+
 		$uidCandidate = isset($this->members[$uid]) ? $this->members[$uid]?->getUID() ?? null : null;
 		if ($uidCandidate) {
 			return $uidCandidate;
@@ -104,7 +109,7 @@ class DeckJsonService extends ABoardImportService {
 			foreach ($sourceCard->assignedUsers as $idMember) {
 				$assignment = new Assignment();
 				$assignment->setCardId($this->cards[$sourceCard->id]->getId());
-				$assignment->setParticipant($idMember->participant->uid);
+				$assignment->setParticipant($this->mapMember($idMember->participant->uid ?? $idMember->participant));
 				$assignment->setType($idMember->participant->type);
 				$assignments[$sourceCard->id][] = $assignment;
 			}

--- a/lib/Service/Importer/Systems/DeckJsonService.php
+++ b/lib/Service/Importer/Systems/DeckJsonService.php
@@ -31,8 +31,6 @@ use OCA\Deck\Db\Card;
 use OCA\Deck\Db\Label;
 use OCA\Deck\Db\Stack;
 use OCA\Deck\Service\Importer\ABoardImportService;
-use OCP\IL10N;
-use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 
@@ -44,8 +42,6 @@ class DeckJsonService extends ABoardImportService {
 
 	public function __construct(
 		private IUserManager $userManager,
-		private IURLGenerator $urlGenerator,
-		private IL10N $l10n
 	) {
 	}
 
@@ -84,6 +80,20 @@ class DeckJsonService extends ABoardImportService {
 			$user = current($user);
 			$this->members[$user->id] = $this->getImportService()->getConfig('uidRelation')->$exportUid;
 		}
+	}
+
+	public function mapMember($uid): ?string {
+
+		$uidCandidate = $this->members[$uid]?->getUID() ?? null;
+		if ($uidCandidate) {
+			return $uidCandidate;
+		}
+
+		if ($this->userManager->userExists($uid)) {
+			return $uid;
+		}
+
+		return null;
 	}
 
 	public function getCardAssignments(): array {
@@ -176,6 +186,7 @@ class DeckJsonService extends ABoardImportService {
 			$card = new Card();
 			$card->setTitle($cardSource->title);
 			$card->setLastModified($cardSource->lastModified);
+			$card->setCreatedAt($cardSource->createdAt);
 			$card->setArchived($cardSource->archived);
 			$card->setDescription($cardSource->description);
 			$card->setStackId($this->stacks[$cardSource->stackId]->getId());

--- a/lib/Service/Importer/Systems/DeckJsonService.php
+++ b/lib/Service/Importer/Systems/DeckJsonService.php
@@ -184,7 +184,6 @@ class DeckJsonService extends ABoardImportService {
 					$card->stackId = $index;
 					$this->tmpCards[] = $card;
 				}
-				// TODO: check older exports as currently there is a bug that adds lists to it with different index
 			}
 		}
 		return $return;
@@ -221,7 +220,6 @@ class DeckJsonService extends ABoardImportService {
 		$board = $this->getImportService()->getData();
 		$return = [];
 		foreach ($board->acl as $aclData) {
-			// FIXME: Figure out mapping
 			$acl = new Acl();
 			$acl->setBoardId($this->getImportService()->getBoard()->getId());
 			$acl->setType($aclData->type);
@@ -236,7 +234,6 @@ class DeckJsonService extends ABoardImportService {
 			if ($participant) {
 				$return[] = $acl;
 			}
-			// TODO: Once we have error collection we should catch non-existing users
 		}
 		return $return;
 	}

--- a/lib/Service/Importer/Systems/DeckJsonService.php
+++ b/lib/Service/Importer/Systems/DeckJsonService.php
@@ -134,7 +134,7 @@ class DeckJsonService extends ABoardImportService {
 		}
 		$importBoard = $this->getImportService()->getData();
 		$board->setTitle($importBoard->title);
-		$board->setOwner($importBoard->owner->uid);
+		$board->setOwner($importBoard->owner?->uid ?? $importBoard->owner);
 		$board->setColor($importBoard->color);
 		$board->setArchived($importBoard->archived);
 		$board->setDeletedAt($importBoard->deletedAt);

--- a/lib/Service/Importer/Systems/DeckJsonService.php
+++ b/lib/Service/Importer/Systems/DeckJsonService.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @copyright Copyright (c) 2021 Vitor Mattos <vitor@php.rio>
+ * @copyright Copyright (c) 2023 Julius Härtl <jus@bitgrid.net>
  *
- * @author Vitor Mattos <vitor@php.rio>
+ * @author Julius Härtl <jus@bitgrid.net>
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/lib/Service/Importer/Systems/DeckJsonService.php
+++ b/lib/Service/Importer/Systems/DeckJsonService.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * @copyright Copyright (c) 2021 Vitor Mattos <vitor@php.rio>
+ *
+ * @author Vitor Mattos <vitor@php.rio>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Deck\Service\Importer\Systems;
+
+use OC\Comments\Comment;
+use OCA\Deck\BadRequestException;
+use OCA\Deck\Db\Acl;
+use OCA\Deck\Db\Assignment;
+use OCA\Deck\Db\Attachment;
+use OCA\Deck\Db\Board;
+use OCA\Deck\Db\Card;
+use OCA\Deck\Db\Label;
+use OCA\Deck\Db\Stack;
+use OCA\Deck\Service\Importer\ABoardImportService;
+use OCP\Comments\IComment;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+
+class DeckJsonService extends ABoardImportService {
+	/** @var string */
+	public static $name = 'Deck JSON';
+	/** @var IUserManager */
+	private $userManager;
+	/** @var IURLGenerator */
+	private $urlGenerator;
+	/** @var IL10N */
+	private $l10n;
+	/** @var IUser[] */
+	private $members = [];
+	private array $tmpCards = [];
+
+	public function __construct(
+		IUserManager $userManager,
+		IURLGenerator $urlGenerator,
+		IL10N $l10n
+	) {
+		$this->userManager = $userManager;
+		$this->urlGenerator = $urlGenerator;
+		$this->l10n = $l10n;
+	}
+
+	public function bootstrap(): void {
+		$this->validateUsers();
+	}
+
+	public function getJsonSchemaPath(): string {
+		return implode(DIRECTORY_SEPARATOR, [
+			__DIR__,
+			'..',
+			'fixtures',
+			'config-deckJson-schema.json',
+		]);
+	}
+
+	public function validateUsers(): void {
+		if (empty($this->getImportService()->getConfig('uidRelation'))) {
+			return;
+		}
+		foreach ($this->getImportService()->getConfig('uidRelation') as $exportUid => $nextcloudUid) {
+			$user = array_filter($this->getImportService()->getData()->members, function (\stdClass $u) use ($exportUid) {
+				return $u->username === $exportUid;
+			});
+			if (!$user) {
+				throw new \LogicException('Trello user ' . $exportUid . ' not found in property "members" of json data');
+			}
+			if (!is_string($nextcloudUid) && !is_numeric($nextcloudUid)) {
+				throw new \LogicException('User on setting uidRelation is invalid');
+			}
+			$nextcloudUid = (string) $nextcloudUid;
+			$this->getImportService()->getConfig('uidRelation')->$exportUid = $this->userManager->get($nextcloudUid);
+			if (!$this->getImportService()->getConfig('uidRelation')->$exportUid) {
+				throw new \LogicException('User on setting uidRelation not found: ' . $nextcloudUid);
+			}
+			$user = current($user);
+			$this->members[$user->id] = $this->getImportService()->getConfig('uidRelation')->$exportUid;
+		}
+	}
+
+	public function getCardAssignments(): array {
+		$assignments = [];
+		foreach ($this->tmpCards as $sourceCard) {
+			foreach ($sourceCard->assignedUsers as $idMember) {
+				$assignment = new Assignment();
+				$assignment->setCardId($this->cards[$sourceCard->id]->getId());
+				$assignment->setParticipant($idMember->participant->uid);
+				$assignment->setType($idMember->participant->type);
+				$assignments[$sourceCard->id][] = $assignment;
+			}
+		}
+		return $assignments;
+	}
+
+	public function getComments(): array {
+		// Comments are not implemented in export
+		return [];
+	}
+
+	public function getCardLabelAssignment(): array {
+		$cardsLabels = [];
+		foreach ($this->tmpCards as $sourceCard) {
+			foreach ($sourceCard->labels as $label) {
+				$cardId = $this->cards[$sourceCard->id]->getId();
+				$labelId = $this->labels[$label->id]->getId();
+				$cardsLabels[$cardId][] = $labelId;
+			}
+		}
+		return $cardsLabels;
+	}
+
+	public function getBoard(): Board {
+		$board = $this->getImportService()->getBoard();
+		if (empty($this->getImportService()->getData()->title)) {
+			throw new BadRequestException('Invalid name of board');
+		}
+		$board->setTitle($this->getImportService()->getData()->title);
+		$board->setOwner($this->getImportService()->getData()->owner->uid);
+		$board->setColor($this->getImportService()->getData()->color);
+		return $board;
+	}
+
+	/**
+	 * @return Label[]
+	 */
+	public function getLabels(): array {
+		foreach ($this->getImportService()->getData()->labels as $label) {
+			$newLabel = new Label();
+			$newLabel->setTitle($label->title);
+			$newLabel->setColor($label->color);
+			$newLabel->setBoardId($this->getImportService()->getBoard()->getId());
+			$this->labels[$label->id] = $newLabel;
+		}
+		return $this->labels;
+	}
+
+	/**
+	 * @return Stack[]
+	 */
+	public function getStacks(): array {
+		$return = [];
+		foreach ($this->getImportService()->getData()->stacks as $index => $source) {
+			if ($source->title) {
+				$stack = new Stack();
+				$stack->setTitle($source->title);
+				$stack->setBoardId($this->getImportService()->getBoard()->getId());
+				$stack->setOrder($source->order);
+				$return[$source->id] = $stack;
+			}
+
+			if ($source->cards) {
+				foreach ($source->cards as $card) {
+					$card->stackId = $index;
+					$this->tmpCards[] = $card;
+				}
+				// TODO: check older exports as currently there is a bug that adds lists to it with different index
+			}
+		}
+		return $return;
+	}
+
+	/**
+	 * @return Card[]
+	 */
+	public function getCards(): array {
+		$cards = [];
+		foreach ($this->tmpCards as $cardSource) {
+			$card = new Card();
+			$card->setTitle($cardSource->title);
+			$card->setLastModified($cardSource->lastModified);
+			$card->setArchived($cardSource->archived);
+			$card->setDescription($cardSource->description);
+			$card->setStackId($this->stacks[$cardSource->stackId]->getId());
+			$card->setType('plain');
+			$card->setOrder($cardSource->order);
+			$card->setOwner($this->getBoard()->getOwner());
+			$card->setDuedate($cardSource->duedate);
+			$cards[$cardSource->id] = $card;
+		}
+		return $cards;
+	}
+
+	/**
+	 * @return Acl[]
+	 */
+	public function getAclList(): array {
+		// FIXME: To implement
+		$return = [];
+		foreach ($this->members as $member) {
+			if ($member->getUID() === $this->getImportService()->getConfig('owner')->getUID()) {
+				continue;
+			}
+			$acl = new Acl();
+			$acl->setBoardId($this->getImportService()->getBoard()->getId());
+			$acl->setType(Acl::PERMISSION_TYPE_USER);
+			$acl->setParticipant($member->getUID());
+			$acl->setPermissionEdit(false);
+			$acl->setPermissionShare(false);
+			$acl->setPermissionManage(false);
+			$return[] = $acl;
+		}
+		return $return;
+	}
+
+	private function replaceUsernames(string $text): string {
+		foreach ($this->getImportService()->getConfig('uidRelation') as $trello => $nextcloud) {
+			$text = str_replace($trello, $nextcloud->getUID(), $text);
+		}
+		return $text;
+	}
+
+	public function getBoards(): array {
+		return get_object_vars($this->getImportService()->getData());
+	}
+
+	public function reset(): void {
+		parent::reset();
+		$this->tmpCards = [];
+	}
+}

--- a/lib/Service/Importer/Systems/TrelloJsonService.php
+++ b/lib/Service/Importer/Systems/TrelloJsonService.php
@@ -397,4 +397,12 @@ class TrelloJsonService extends ABoardImportService {
 			$trelloCard->desc .= "| [{$name}]({$attachment->url}) | {$attachment->date} |\n";
 		}
 	}
+
+	public function getBoards(): array {
+		if ($this->getImportService()->getData()->boards) {
+			return $this->getImportService()->getData()->boards;
+		}
+
+		return [$this->getImportService()->getData()];
+	}
 }

--- a/lib/Service/Importer/fixtures/config-deckJson-schema.json
+++ b/lib/Service/Importer/fixtures/config-deckJson-schema.json
@@ -1,0 +1,24 @@
+{
+    "type": "object",
+    "properties": {
+        "uidRelation": {
+            "type": "object",
+            "comment": "Relationship between Trello and Nextcloud usernames",
+            "example": {
+                "johndoe": "admin"
+            }
+        },
+        "owner": {
+            "type": "string",
+            "required": true,
+            "comment": "Nextcloud owner username"
+        },
+        "color": {
+            "type": "string",
+            "required": true,
+            "pattern": "^[0-9a-fA-F]{6}$",
+            "comment": "Default color for the board. If you don't inform, the default color will be used.",
+            "default": "0800fd"
+        }
+    }
+}

--- a/lib/Service/Importer/fixtures/config-deckJson-schema.json
+++ b/lib/Service/Importer/fixtures/config-deckJson-schema.json
@@ -12,13 +12,6 @@
             "type": "string",
             "required": true,
             "comment": "Nextcloud owner username"
-        },
-        "color": {
-            "type": "string",
-            "required": true,
-            "pattern": "^[0-9a-fA-F]{6}$",
-            "comment": "Default color for the board. If you don't inform, the default color will be used.",
-            "default": "0800fd"
         }
     }
 }

--- a/tests/data/config-deckJson.json
+++ b/tests/data/config-deckJson.json
@@ -1,0 +1,7 @@
+{
+    "owner": "admin",
+    "color": "0800fd",
+    "uidRelation": {
+        "johndoe": "test-user-1"
+    }
+}

--- a/tests/data/deck.json
+++ b/tests/data/deck.json
@@ -1,0 +1,748 @@
+{
+    "version": "1.11.0-dev",
+    "boards": {
+        "188": {
+            "id": 188,
+            "title": "My test board",
+            "owner": {
+                "primaryKey": "admin",
+                "uid": "admin",
+                "displayname": "admin",
+                "type": 0
+            },
+            "color": "e0ed31",
+            "archived": false,
+            "labels": [
+                {
+                    "id": 239,
+                    "title": "L2",
+                    "color": "31CC7C",
+                    "boardId": 188,
+                    "cardId": null,
+                    "lastModified": 1689667435,
+                    "ETag": "63b77251cca5a56fe74a97e4baeab59c"
+                },
+                {
+                    "id": 240,
+                    "title": "L4",
+                    "color": "317CCC",
+                    "boardId": 188,
+                    "cardId": null,
+                    "lastModified": 1689667442,
+                    "ETag": "15dcabeb47583ce5398faaeb65f7a4b6"
+                },
+                {
+                    "id": 241,
+                    "title": "L1",
+                    "color": "FF7A66",
+                    "boardId": 188,
+                    "cardId": null,
+                    "lastModified": 1689667432,
+                    "ETag": "7d58be91f19ebc4f94b352db8c76c056"
+                },
+                {
+                    "id": 242,
+                    "title": "L3",
+                    "color": "F1DB50",
+                    "boardId": 188,
+                    "cardId": null,
+                    "lastModified": 1689667440,
+                    "ETag": "160253b9d33ae0a7a3af90e7d418ba60"
+                }
+            ],
+            "acl": [],
+            "permissions": {
+                "PERMISSION_READ": true,
+                "PERMISSION_EDIT": true,
+                "PERMISSION_MANAGE": true,
+                "PERMISSION_SHARE": true
+            },
+            "users": [],
+            "shared": 0,
+            "stacks": {
+                "64": {
+                    "id": 64,
+                    "title": "A",
+                    "boardId": 188,
+                    "deletedAt": 0,
+                    "lastModified": 1689667779,
+                    "order": 999,
+                    "ETag": "ddfd0c27e53d8db94ac5e9aaa021746e",
+                    "cards": [
+                        {
+                            "id": 114,
+                            "title": "1",
+                            "description": "",
+                            "stackId": 64,
+                            "type": "plain",
+                            "lastModified": 1689667779,
+                            "lastEditor": null,
+                            "createdAt": 1689667569,
+                            "labels": [
+                                {
+                                    "id": 239,
+                                    "title": "L2",
+                                    "color": "31CC7C",
+                                    "boardId": 188,
+                                    "cardId": 114,
+                                    "lastModified": 1689667435,
+                                    "ETag": "63b77251cca5a56fe74a97e4baeab59c"
+                                }
+                            ],
+                            "assignedUsers": [],
+                            "attachments": null,
+                            "attachmentCount": null,
+                            "owner": {
+                                "primaryKey": "admin",
+                                "uid": "admin",
+                                "displayname": "admin",
+                                "type": 0
+                            },
+                            "order": 999,
+                            "archived": false,
+                            "duedate": "2050-07-24T22:00:00+00:00",
+                            "deletedAt": 0,
+                            "commentsUnread": 0,
+                            "commentsCount": 0,
+                            "ETag": "ddfd0c27e53d8db94ac5e9aaa021746e",
+                            "overdue": 0,
+                            "boardId": 188,
+                            "board": {
+                                "id": 188,
+                                "title": "My test board"
+                            }
+                        },
+                        {
+                            "id": 115,
+                            "title": "2",
+                            "description": "",
+                            "stackId": 64,
+                            "type": "plain",
+                            "lastModified": 1689667752,
+                            "lastEditor": null,
+                            "createdAt": 1689667572,
+                            "labels": [],
+                            "assignedUsers": [],
+                            "attachments": null,
+                            "attachmentCount": null,
+                            "owner": {
+                                "primaryKey": "admin",
+                                "uid": "admin",
+                                "displayname": "admin",
+                                "type": 0
+                            },
+                            "order": 999,
+                            "archived": false,
+                            "duedate": "2023-07-17T02:00:00+00:00",
+                            "deletedAt": 0,
+                            "commentsUnread": 0,
+                            "commentsCount": 0,
+                            "ETag": "9a8ed495f7d83f8310ae6291d6dc4624",
+                            "overdue": 3,
+                            "boardId": 188,
+                            "board": {
+                                "id": 188,
+                                "title": "My test board"
+                            }
+                        },
+                        {
+                            "id": 116,
+                            "title": "3",
+                            "description": "",
+                            "stackId": 64,
+                            "type": "plain",
+                            "lastModified": 1689667760,
+                            "lastEditor": "admin",
+                            "createdAt": 1689667576,
+                            "labels": [],
+                            "assignedUsers": [
+                                {
+                                    "id": 5,
+                                    "participant": {
+                                        "primaryKey": "admin",
+                                        "uid": "admin",
+                                        "displayname": "admin",
+                                        "type": 0
+                                    },
+                                    "cardId": 116,
+                                    "type": 0
+                                }
+                            ],
+                            "attachments": null,
+                            "attachmentCount": null,
+                            "owner": {
+                                "primaryKey": "admin",
+                                "uid": "admin",
+                                "displayname": "admin",
+                                "type": 0
+                            },
+                            "order": 999,
+                            "archived": false,
+                            "duedate": null,
+                            "deletedAt": 0,
+                            "commentsUnread": 0,
+                            "commentsCount": 0,
+                            "ETag": "f908c4359e9ca0703f50da2bbe967594",
+                            "overdue": 0,
+                            "boardId": 188,
+                            "board": {
+                                "id": 188,
+                                "title": "My test board"
+                            }
+                        }
+                    ]
+                },
+                "65": {
+                    "id": 65,
+                    "title": "B",
+                    "boardId": 188,
+                    "deletedAt": 0,
+                    "lastModified": 1689667796,
+                    "order": 999,
+                    "ETag": "b97a2b19e1cafc8f95e3f4db71097214",
+                    "cards": [
+                        {
+                            "id": 117,
+                            "title": "4",
+                            "description": "",
+                            "stackId": 65,
+                            "type": "plain",
+                            "lastModified": 1689667767,
+                            "lastEditor": "admin",
+                            "createdAt": 1689667578,
+                            "labels": [
+                                {
+                                    "id": 239,
+                                    "title": "L2",
+                                    "color": "31CC7C",
+                                    "boardId": 188,
+                                    "cardId": 117,
+                                    "lastModified": 1689667435,
+                                    "ETag": "63b77251cca5a56fe74a97e4baeab59c"
+                                },
+                                {
+                                    "id": 240,
+                                    "title": "L4",
+                                    "color": "317CCC",
+                                    "boardId": 188,
+                                    "cardId": 117,
+                                    "lastModified": 1689667442,
+                                    "ETag": "15dcabeb47583ce5398faaeb65f7a4b6"
+                                },
+                                {
+                                    "id": 241,
+                                    "title": "L1",
+                                    "color": "FF7A66",
+                                    "boardId": 188,
+                                    "cardId": 117,
+                                    "lastModified": 1689667432,
+                                    "ETag": "7d58be91f19ebc4f94b352db8c76c056"
+                                }
+                            ],
+                            "assignedUsers": [],
+                            "attachments": null,
+                            "attachmentCount": null,
+                            "owner": {
+                                "primaryKey": "admin",
+                                "uid": "admin",
+                                "displayname": "admin",
+                                "type": 0
+                            },
+                            "order": 999,
+                            "archived": false,
+                            "duedate": null,
+                            "deletedAt": 0,
+                            "commentsUnread": 0,
+                            "commentsCount": 0,
+                            "ETag": "6b20cc46fa5d2e5f65251526b50cc130",
+                            "overdue": 0,
+                            "boardId": 188,
+                            "board": {
+                                "id": 188,
+                                "title": "My test board"
+                            }
+                        },
+                        {
+                            "id": 118,
+                            "title": "5",
+                            "description": "",
+                            "stackId": 65,
+                            "type": "plain",
+                            "lastModified": 1689667773,
+                            "lastEditor": "admin",
+                            "createdAt": 1689667581,
+                            "labels": [
+                                {
+                                    "id": 239,
+                                    "title": "L2",
+                                    "color": "31CC7C",
+                                    "boardId": 188,
+                                    "cardId": 118,
+                                    "lastModified": 1689667435,
+                                    "ETag": "63b77251cca5a56fe74a97e4baeab59c"
+                                }
+                            ],
+                            "assignedUsers": [],
+                            "attachments": null,
+                            "attachmentCount": null,
+                            "owner": {
+                                "primaryKey": "admin",
+                                "uid": "admin",
+                                "displayname": "admin",
+                                "type": 0
+                            },
+                            "order": 999,
+                            "archived": false,
+                            "duedate": null,
+                            "deletedAt": 0,
+                            "commentsUnread": 0,
+                            "commentsCount": 0,
+                            "ETag": "488145982535a91d9ab47db647ecf539",
+                            "overdue": 0,
+                            "boardId": 188,
+                            "board": {
+                                "id": 188,
+                                "title": "My test board"
+                            }
+                        },
+                        {
+                            "id": 119,
+                            "title": "6",
+                            "description": "# Test description\n\nHello world",
+                            "stackId": 65,
+                            "type": "plain",
+                            "lastModified": 1689667796,
+                            "lastEditor": null,
+                            "createdAt": 1689667583,
+                            "labels": [],
+                            "assignedUsers": [
+                                {
+                                    "id": 6,
+                                    "participant": {
+                                        "primaryKey": "admin",
+                                        "uid": "admin",
+                                        "displayname": "admin",
+                                        "type": 0
+                                    },
+                                    "cardId": 119,
+                                    "type": 0
+                                }
+                            ],
+                            "attachments": null,
+                            "attachmentCount": null,
+                            "owner": {
+                                "primaryKey": "admin",
+                                "uid": "admin",
+                                "displayname": "admin",
+                                "type": 0
+                            },
+                            "order": 999,
+                            "archived": false,
+                            "duedate": null,
+                            "deletedAt": 0,
+                            "commentsUnread": 0,
+                            "commentsCount": 0,
+                            "ETag": "b97a2b19e1cafc8f95e3f4db71097214",
+                            "overdue": 0,
+                            "boardId": 188,
+                            "board": {
+                                "id": 188,
+                                "title": "My test board"
+                            }
+                        }
+                    ]
+                },
+                "66": {
+                    "id": 66,
+                    "title": "C",
+                    "boardId": 188,
+                    "deletedAt": 0,
+                    "lastModified": 0,
+                    "order": 999,
+                    "ETag": "cfcd208495d565ef66e7dff9f98764da"
+                }
+            },
+            "activeSessions": [],
+            "deletedAt": 0,
+            "lastModified": 1689667796,
+            "settings": [],
+            "ETag": "b97a2b19e1cafc8f95e3f4db71097214"
+        },
+        "189": {
+            "id": 189,
+            "title": "Shared board",
+            "owner": {
+                "primaryKey": "admin",
+                "uid": "admin",
+                "displayname": "admin",
+                "type": 0
+            },
+            "color": "30b6d8",
+            "archived": false,
+            "labels": [
+                {
+                    "id": 243,
+                    "title": "Finished",
+                    "color": "31CC7C",
+                    "boardId": 189,
+                    "cardId": null,
+                    "lastModified": 1689667413,
+                    "ETag": "aa71367f6a9a2fc2d47fc46163a30208"
+                },
+                {
+                    "id": 244,
+                    "title": "To review",
+                    "color": "317CCC",
+                    "boardId": 189,
+                    "cardId": null,
+                    "lastModified": 1689667413,
+                    "ETag": "aa71367f6a9a2fc2d47fc46163a30208"
+                },
+                {
+                    "id": 245,
+                    "title": "Action needed",
+                    "color": "FF7A66",
+                    "boardId": 189,
+                    "cardId": null,
+                    "lastModified": 1689667413,
+                    "ETag": "aa71367f6a9a2fc2d47fc46163a30208"
+                },
+                {
+                    "id": 246,
+                    "title": "Later",
+                    "color": "F1DB50",
+                    "boardId": 189,
+                    "cardId": null,
+                    "lastModified": 1689667413,
+                    "ETag": "aa71367f6a9a2fc2d47fc46163a30208"
+                }
+            ],
+            "acl": [
+                {
+                    "id": 4,
+                    "participant": {
+                        "primaryKey": "alice",
+                        "uid": "alice",
+                        "displayname": "alice",
+                        "type": 0
+                    },
+                    "type": 0,
+                    "boardId": 189,
+                    "permissionEdit": true,
+                    "permissionShare": false,
+                    "permissionManage": false,
+                    "owner": false
+                },
+                {
+                    "id": 5,
+                    "participant": {
+                        "primaryKey": "jane",
+                        "uid": "jane",
+                        "displayname": "jane",
+                        "type": 0
+                    },
+                    "type": 0,
+                    "boardId": 189,
+                    "permissionEdit": false,
+                    "permissionShare": true,
+                    "permissionManage": false,
+                    "owner": false
+                },
+                {
+                    "id": 6,
+                    "participant": {
+                        "primaryKey": "admin",
+                        "uid": "admin",
+                        "displayname": "admin",
+                        "type": 1
+                    },
+                    "type": 1,
+                    "boardId": 189,
+                    "permissionEdit": false,
+                    "permissionShare": false,
+                    "permissionManage": true,
+                    "owner": false
+                }
+            ],
+            "permissions": {
+                "PERMISSION_READ": true,
+                "PERMISSION_EDIT": true,
+                "PERMISSION_MANAGE": true,
+                "PERMISSION_SHARE": true
+            },
+            "users": [],
+            "shared": 0,
+            "stacks": {
+                "61": {
+                    "id": 61,
+                    "title": "ToDo",
+                    "boardId": 189,
+                    "deletedAt": 0,
+                    "lastModified": 1689667537,
+                    "order": 999,
+                    "ETag": "6c315c83f146485e6b2b6fdc24ffa617",
+                    "cards": [
+                        {
+                            "id": 107,
+                            "title": "Write tests",
+                            "description": "",
+                            "stackId": 61,
+                            "type": "plain",
+                            "lastModified": 1689667521,
+                            "lastEditor": null,
+                            "createdAt": 1689667483,
+                            "labels": [],
+                            "assignedUsers": [],
+                            "attachments": null,
+                            "attachmentCount": null,
+                            "owner": {
+                                "primaryKey": "admin",
+                                "uid": "admin",
+                                "displayname": "admin",
+                                "type": 0
+                            },
+                            "order": 0,
+                            "archived": false,
+                            "duedate": null,
+                            "deletedAt": 0,
+                            "commentsUnread": 0,
+                            "commentsCount": 0,
+                            "ETag": "f0450d41827f55580554c993304c8073",
+                            "overdue": 0,
+                            "boardId": 189,
+                            "board": {
+                                "id": 189,
+                                "title": "Shared board"
+                            }
+                        },
+                        {
+                            "id": 111,
+                            "title": "Write blog post",
+                            "description": "",
+                            "stackId": 61,
+                            "type": "plain",
+                            "lastModified": 1689667521,
+                            "lastEditor": null,
+                            "createdAt": 1689667518,
+                            "labels": [],
+                            "assignedUsers": [],
+                            "attachments": null,
+                            "attachmentCount": null,
+                            "owner": {
+                                "primaryKey": "admin",
+                                "uid": "admin",
+                                "displayname": "admin",
+                                "type": 0
+                            },
+                            "order": 1,
+                            "archived": false,
+                            "duedate": null,
+                            "deletedAt": 0,
+                            "commentsUnread": 0,
+                            "commentsCount": 0,
+                            "ETag": "f0450d41827f55580554c993304c8073",
+                            "overdue": 0,
+                            "boardId": 189,
+                            "board": {
+                                "id": 189,
+                                "title": "Shared board"
+                            }
+                        },
+                        {
+                            "id": 112,
+                            "title": "Announce feature",
+                            "description": "",
+                            "stackId": 61,
+                            "type": "plain",
+                            "lastModified": 1689667527,
+                            "lastEditor": null,
+                            "createdAt": 1689667527,
+                            "labels": [],
+                            "assignedUsers": [],
+                            "attachments": null,
+                            "attachmentCount": null,
+                            "owner": {
+                                "primaryKey": "admin",
+                                "uid": "admin",
+                                "displayname": "admin",
+                                "type": 0
+                            },
+                            "order": 999,
+                            "archived": false,
+                            "duedate": null,
+                            "deletedAt": 0,
+                            "commentsUnread": 0,
+                            "commentsCount": 0,
+                            "ETag": "1956848c45be91fefc967ee8831ea4cf",
+                            "overdue": 0,
+                            "boardId": 189,
+                            "board": {
+                                "id": 189,
+                                "title": "Shared board"
+                            }
+                        },
+                        {
+                            "id": 113,
+                            "title": "\ud83c\udf89 Party",
+                            "description": "",
+                            "stackId": 61,
+                            "type": "plain",
+                            "lastModified": 1689667537,
+                            "lastEditor": null,
+                            "createdAt": 1689667537,
+                            "labels": [],
+                            "assignedUsers": [],
+                            "attachments": null,
+                            "attachmentCount": null,
+                            "owner": {
+                                "primaryKey": "admin",
+                                "uid": "admin",
+                                "displayname": "admin",
+                                "type": 0
+                            },
+                            "order": 999,
+                            "archived": false,
+                            "duedate": null,
+                            "deletedAt": 0,
+                            "commentsUnread": 0,
+                            "commentsCount": 0,
+                            "ETag": "6c315c83f146485e6b2b6fdc24ffa617",
+                            "overdue": 0,
+                            "boardId": 189,
+                            "board": {
+                                "id": 189,
+                                "title": "Shared board"
+                            }
+                        }
+                    ]
+                },
+                "62": {
+                    "id": 62,
+                    "title": "In progress",
+                    "boardId": 189,
+                    "deletedAt": 0,
+                    "lastModified": 1689667502,
+                    "order": 999,
+                    "ETag": "1498939b8816e6041da80050dacc3ed3",
+                    "cards": [
+                        {
+                            "id": 108,
+                            "title": "Write feature",
+                            "description": "",
+                            "stackId": 62,
+                            "type": "plain",
+                            "lastModified": 1689667488,
+                            "lastEditor": null,
+                            "createdAt": 1689667488,
+                            "labels": [],
+                            "assignedUsers": [],
+                            "attachments": null,
+                            "attachmentCount": null,
+                            "owner": {
+                                "primaryKey": "admin",
+                                "uid": "admin",
+                                "displayname": "admin",
+                                "type": 0
+                            },
+                            "order": 999,
+                            "archived": false,
+                            "duedate": null,
+                            "deletedAt": 0,
+                            "commentsUnread": 0,
+                            "commentsCount": 0,
+                            "ETag": "d2a8b634cdd96ab5ef48910bbbd715b1",
+                            "overdue": 0,
+                            "boardId": 189,
+                            "board": {
+                                "id": 189,
+                                "title": "Shared board"
+                            }
+                        }
+                    ]
+                },
+                "63": {
+                    "id": 63,
+                    "title": "Done",
+                    "boardId": 189,
+                    "deletedAt": 0,
+                    "lastModified": 1689667518,
+                    "order": 999,
+                    "ETag": "09ba5a39921de760db53bcd56457eea5",
+                    "cards": [
+                        {
+                            "id": 109,
+                            "title": "Plan feature",
+                            "description": "",
+                            "stackId": 63,
+                            "type": "plain",
+                            "lastModified": 1689667506,
+                            "lastEditor": null,
+                            "createdAt": 1689667493,
+                            "labels": [],
+                            "assignedUsers": [],
+                            "attachments": null,
+                            "attachmentCount": null,
+                            "owner": {
+                                "primaryKey": "admin",
+                                "uid": "admin",
+                                "displayname": "admin",
+                                "type": 0
+                            },
+                            "order": 0,
+                            "archived": false,
+                            "duedate": null,
+                            "deletedAt": 0,
+                            "commentsUnread": 0,
+                            "commentsCount": 0,
+                            "ETag": "193163d8a8acedbfaba196b1f0d65bc8",
+                            "overdue": 0,
+                            "boardId": 189,
+                            "board": {
+                                "id": 189,
+                                "title": "Shared board"
+                            }
+                        },
+                        {
+                            "id": 110,
+                            "title": "Design feature",
+                            "description": "",
+                            "stackId": 63,
+                            "type": "plain",
+                            "lastModified": 1689667506,
+                            "lastEditor": null,
+                            "createdAt": 1689667502,
+                            "labels": [],
+                            "assignedUsers": [],
+                            "attachments": null,
+                            "attachmentCount": null,
+                            "owner": {
+                                "primaryKey": "admin",
+                                "uid": "admin",
+                                "displayname": "admin",
+                                "type": 0
+                            },
+                            "order": 1,
+                            "archived": false,
+                            "duedate": null,
+                            "deletedAt": 0,
+                            "commentsUnread": 0,
+                            "commentsCount": 0,
+                            "ETag": "193163d8a8acedbfaba196b1f0d65bc8",
+                            "overdue": 0,
+                            "boardId": 189,
+                            "board": {
+                                "id": 189,
+                                "title": "Shared board"
+                            }
+                        }
+                    ]
+                }
+            },
+            "activeSessions": [],
+            "deletedAt": 0,
+            "lastModified": 1689667537,
+            "settings": [],
+            "ETag": "6c315c83f146485e6b2b6fdc24ffa617"
+        }
+    }
+}

--- a/tests/integration/database/TransferOwnershipTest.php
+++ b/tests/integration/database/TransferOwnershipTest.php
@@ -277,7 +277,7 @@ class TransferOwnershipTest extends \Test\TestCase {
 		// Arrange separate board next to the one being transferred
 		$board = $this->boardService->create('Test 2', self::TEST_USER_1, '000000');
 		$id = $board->getId();
-		$this->boardService->addAcl($id, Acl::PERMISSION_TYPE_USER, self::TEST_USER_1, true, true, true);
+		// $this->boardService->addAcl($id, Acl::PERMISSION_TYPE_USER, self::TEST_USER_1, true, true, true);
 		$this->boardService->addAcl($id, Acl::PERMISSION_TYPE_GROUP, self::TEST_GROUP, true, true, true);
 		$this->boardService->addAcl($id, Acl::PERMISSION_TYPE_USER, self::TEST_USER_3, false, true, false);
 		$stacks[] = $this->stackService->create('Stack A', $id, 1);

--- a/tests/integration/import/ImportExportTest.php
+++ b/tests/integration/import/ImportExportTest.php
@@ -49,11 +49,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ImportExportTest extends \Test\TestCase {
 
 	private IDBConnection $connection;
-	private const TEST_USER1 = 'test-share-user1';
-	private const TEST_USER3 = 'test-share-user3';
-	private const TEST_USER2 = 'test-share-user2';
-	private const TEST_USER4 = 'test-share-user4';
-	private const TEST_GROUP1 = 'test-share-group1';
+	private const TEST_USER1 = 'test-export-user1';
+	private const TEST_USER3 = 'test-export-user3';
+	private const TEST_USER2 = 'test-export-user2';
+	private const TEST_USER4 = 'test-export-user4';
+	private const TEST_GROUP1 = 'test-export-group1';
 
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();

--- a/tests/integration/import/ImportExportTest.php
+++ b/tests/integration/import/ImportExportTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Deck\Db;
+
+use OCA\Deck\Command\BoardImport;
+use OCA\Deck\Service\Importer\BoardImportService;
+use OCA\Deck\Service\Importer\Systems\DeckJsonService;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\Server;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @group DB
+ */
+class ImportExportTest extends \Test\TestCase {
+
+	private IDBConnection $connection;
+	private const TEST_USER1 = 'test-share-user1';
+	private const TEST_USER3 = 'test-share-user3';
+	private const TEST_USER2 = 'test-share-user2';
+	private const TEST_USER4 = 'test-share-user4';
+	private const TEST_GROUP1 = 'test-share-group1';
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		$backend = new \Test\Util\User\Dummy();
+		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
+		$backend->createUser(self::TEST_USER1, self::TEST_USER1);
+		$backend->createUser(self::TEST_USER2, self::TEST_USER2);
+		$backend->createUser(self::TEST_USER3, self::TEST_USER3);
+		$backend->createUser(self::TEST_USER4, self::TEST_USER4);
+		// create group
+		$groupBackend = new \Test\Util\Group\Dummy();
+		$groupBackend->createGroup(self::TEST_GROUP1);
+		$groupBackend->createGroup('group');
+		$groupBackend->createGroup('group1');
+		$groupBackend->createGroup('group2');
+		$groupBackend->createGroup('group3');
+		$groupBackend->addToGroup(self::TEST_USER1, 'group');
+		$groupBackend->addToGroup(self::TEST_USER2, 'group');
+		$groupBackend->addToGroup(self::TEST_USER3, 'group');
+		$groupBackend->addToGroup(self::TEST_USER2, 'group1');
+		$groupBackend->addToGroup(self::TEST_USER3, 'group2');
+		$groupBackend->addToGroup(self::TEST_USER4, 'group3');
+		$groupBackend->addToGroup(self::TEST_USER2, self::TEST_GROUP1);
+		Server::get(IGroupManager::class)->addBackend($groupBackend);
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->connection = \OCP\Server::get(IDBConnection::class);
+		$this->connection->beginTransaction();
+
+	}
+
+	public function testImportOcc() {
+		$input = $this->createMock(InputInterface::class);
+		$input->expects($this->any())
+			->method('getOption')
+			->willReturnCallback(function ($arg) {
+				return match ($arg) {
+					'system' => 'DeckJson',
+					'data' => __DIR__ . '/../../data/deck.json',
+					'config' => __DIR__ . '/../../data/config-trelloJson.json',
+				};
+			});
+		$output = $this->createMock(OutputInterface::class);
+		$importer = \OCP\Server::get(BoardImport::class);
+		$application = new Application();
+		$importer->setApplication($application);
+		$importer->run($input, $output);
+
+		$this->assertDatabase();
+	}
+
+	public function testImport() {
+		$importer = \OCP\Server::get(BoardImportService::class);
+		$deckJsonService = \OCP\Server::get(DeckJsonService::class);
+		$deckJsonService->setImportService($importer);
+
+		$importer->setSystem('DeckJson');
+		$importer->setImportSystem($deckJsonService);
+		$importer->setConfigInstance(json_decode(file_get_contents(__DIR__ . '/../../data/config-trelloJson.json')));
+		$importer->setData(json_decode(file_get_contents(__DIR__ . '/../../data/deck.json')));
+		$importer->import();
+
+		$this->assertDatabase();
+	}
+
+	public function assertDatabase() {
+		$boardMapper = \OCP\Server::get(BoardMapper::class);
+		$boards = $boardMapper->findAllByOwner('admin');
+		self::assertEquals('My test board', $boards[0]->getTitle());
+		self::assertEquals('Shared board', $boards[1]->getTitle());
+		self::assertEquals(2, count($boards));
+	}
+
+	public function tearDown(): void {
+		if ($this->connection->inTransaction()) {
+			$this->connection->rollBack();
+		}
+		parent::tearDown();
+	}
+}

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -12,5 +12,8 @@
     <testsuite name="integration-app">
       <directory>./integration/app</directory>
     </testsuite>
+	  <testsuite name="integration-import">
+		  <directory>./integration/import</directory>
+	  </testsuite>
   </testsuites>
 </phpunit>

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -193,6 +193,8 @@ namespace Symfony\Component\Console\Output {
 	class OutputInterface {
 		public const VERBOSITY_VERBOSE = 1;
 		public function writeln($text, int $flat = 0) {}
+		public function isVerbose(): bool {}
+		public function isVeryVerbose(): bool {}
 	}
 }
 

--- a/tests/unit/Command/UserExportTest.php
+++ b/tests/unit/Command/UserExportTest.php
@@ -31,12 +31,14 @@ use OCA\Deck\Db\CardMapper;
 use OCA\Deck\Db\Stack;
 use OCA\Deck\Db\StackMapper;
 use OCA\Deck\Service\BoardService;
+use OCP\App\IAppManager;
 use OCP\IGroupManager;
 use OCP\IUserManager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class UserExportTest extends \Test\TestCase {
+	protected $appManager;
 	protected $boardMapper;
 	protected $boardService;
 	protected $stackMapper;
@@ -45,10 +47,11 @@ class UserExportTest extends \Test\TestCase {
 	protected $userManager;
 	protected $groupManager;
 
-	private $userExport;
+	private UserExport $userExport;
 
 	public function setUp(): void {
 		parent::setUp();
+		$this->appManager = $this->createMock(IAppManager::class);
 		$this->boardMapper = $this->createMock(BoardMapper::class);
 		$this->boardService = $this->createMock(BoardService::class);
 		$this->stackMapper = $this->createMock(StackMapper::class);
@@ -56,7 +59,7 @@ class UserExportTest extends \Test\TestCase {
 		$this->assignedUserMapper = $this->createMock(AssignmentMapper::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
-		$this->userExport = new UserExport($this->boardMapper, $this->boardService, $this->stackMapper, $this->cardMapper, $this->assignedUserMapper, $this->userManager, $this->groupManager);
+		$this->userExport = new UserExport($this->appManager, $this->boardMapper, $this->boardService, $this->stackMapper, $this->cardMapper, $this->assignedUserMapper, $this->userManager, $this->groupManager);
 	}
 
 	public function getBoard($id) {
@@ -114,5 +117,6 @@ class UserExportTest extends \Test\TestCase {
 			->method('findAll')
 			->willReturn([]);
 		$result = $this->invokePrivate($this->userExport, 'execute', [$input, $output]);
+		self::assertEquals(0, $result);
 	}
 }

--- a/tests/unit/Service/Importer/BoardImportServiceTest.php
+++ b/tests/unit/Service/Importer/BoardImportServiceTest.php
@@ -118,6 +118,9 @@ class BoardImportServiceTest extends \Test\TestCase {
 		$this->trelloJsonService
 			->method('getJsonSchemaPath')
 			->willReturn($configFile);
+		$this->trelloJsonService
+			->method('getBoards')
+			->willReturn([$data]);
 		$this->boardImportService->setImportSystem($this->trelloJsonService);
 
 		$owner = $this->createMock(IUser::class);
@@ -192,8 +195,7 @@ class BoardImportServiceTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('insert');
 
-		$actual = $this->boardImportService->import();
-
-		$this->assertNull($actual);
+		$this->boardImportService->import();
+		self::assertTrue(true);
 	}
 }

--- a/tests/unit/Service/Importer/BoardImportServiceTest.php
+++ b/tests/unit/Service/Importer/BoardImportServiceTest.php
@@ -43,6 +43,7 @@ use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 class BoardImportServiceTest extends \Test\TestCase {
 	/** @var IDBConnection|MockObject */
@@ -92,7 +93,8 @@ class BoardImportServiceTest extends \Test\TestCase {
 			$this->attachmentMapper,
 			$this->cardMapper,
 			$this->commentsManager,
-			$this->eventDispatcher
+			$this->eventDispatcher,
+			$this->createMock(LoggerInterface::class),
 		);
 
 		$this->boardImportService->setSystem('trelloJson');
@@ -145,6 +147,9 @@ class BoardImportServiceTest extends \Test\TestCase {
 	}
 
 	public function testImportSuccess() {
+		$this->userManager->method('userExists')
+			->willReturn(true);
+
 		$this->boardMapper
 			->expects($this->once())
 			->method('insert');

--- a/tests/unit/Service/Importer/Systems/DeckJsonServiceTest.php
+++ b/tests/unit/Service/Importer/Systems/DeckJsonServiceTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @copyright Copyright (c) 2021 Vitor Mattos <vitor@php.rio>
+ *
+ * @author Vitor Mattos <vitor@php.rio>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Deck\Service\Importer\Systems;
+
+use OCA\Deck\Service\Importer\BoardImportService;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Server;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * @group DB
+ */
+class DeckJsonServiceTest extends \Test\TestCase {
+	private DeckJsonService $service;
+	/** @var IURLGenerator|MockObject */
+	private $urlGenerator;
+	/** @var IUserManager|MockObject */
+	private $userManager;
+	/** @var IL10N */
+	private $l10n;
+	public function setUp(): void {
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->service = new DeckJsonService(
+			$this->userManager,
+			$this->urlGenerator,
+			$this->l10n
+		);
+	}
+
+	public function testGetBoardWithNoName() {
+		$this->expectExceptionMessage('Invalid name of board');
+		$importService = $this->createMock(BoardImportService::class);
+		$this->service->setImportService($importService);
+		$this->service->getBoard();
+	}
+
+	public function testGetBoardWithSuccess() {
+		$importService = Server::get(BoardImportService::class);
+
+		$data = json_decode(file_get_contents(__DIR__ . '/../../../../data/deck.json'));
+		$importService->setData($data);
+
+		$configInstance = json_decode(file_get_contents(__DIR__ . '/../../../../data/config-trelloJson.json'));
+		$importService->setConfigInstance($configInstance);
+
+		$owner = $this->createMock(IUser::class);
+		$owner
+			->method('getUID')
+			->willReturn('owner');
+		$importService->setConfig('owner', $owner);
+
+		$this->service->setImportService($importService);
+
+		$boards = $this->service->getBoards();
+		$importService->setData($boards[0]);
+		$actual = $this->service->getBoard();
+		$this->assertEquals('My test board', $actual->getTitle());
+		$this->assertEquals('admin', $actual->getOwner());
+		$this->assertEquals('e0ed31', $actual->getColor());
+	}
+}

--- a/tests/unit/Service/Importer/Systems/DeckJsonServiceTest.php
+++ b/tests/unit/Service/Importer/Systems/DeckJsonServiceTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @copyright Copyright (c) 2021 Vitor Mattos <vitor@php.rio>
+ * @copyright Copyright (c) 2023 Julius Härtl <jus@bitgrid.net>
  *
- * @author Vitor Mattos <vitor@php.rio>
+ * @author Julius Härtl <jus@bitgrid.net>
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/tests/unit/Service/Importer/Systems/DeckJsonServiceTest.php
+++ b/tests/unit/Service/Importer/Systems/DeckJsonServiceTest.php
@@ -65,13 +65,13 @@ class DeckJsonServiceTest extends \Test\TestCase {
 		$data = json_decode(file_get_contents(__DIR__ . '/../../../../data/deck.json'));
 		$importService->setData($data);
 
-		$configInstance = json_decode(file_get_contents(__DIR__ . '/../../../../data/config-trelloJson.json'));
+		$configInstance = json_decode(file_get_contents(__DIR__ . '/../../../../data/config-deckJson.json'));
 		$importService->setConfigInstance($configInstance);
 
 		$owner = $this->createMock(IUser::class);
 		$owner
 			->method('getUID')
-			->willReturn('owner');
+			->willReturn('admin');
 		$importService->setConfig('owner', $owner);
 
 		$this->service->setImportService($importService);


### PR DESCRIPTION
- [x] fixes https://github.com/nextcloud/deck/issues/4818
- [x] Refactor import framework to support multiple board impoards
- [x] Basic implementation of importing deck json data
  - [x] Boards
  - [x] Stacks
  - [x] Cards
  - [x] Labels
  - [x] Label assignments
  - [x] User/group/circle assignments
- [x] Tests
  - [x] Import from json
  - [x] Re-import previously exported json
- [ ] Documentation
  - [ ] Review documentation about import/export
  - [ ] limitations of import/export (attachments, comments, activity)
  - [ ] Document occ deck:import changes in changelog

## Possible follow ups
- [ ] UI for importing since the API is already there
- [ ] Properly handle import issues and not fail but collect issues and still continue with the import

## Notes
- PHP 8.0 is fine since we need it for 26

- Useful snipped for comparing the json export of a imported board
```
diff --git a/tests/integration/import/ImportExportTest.php b/tests/integration/import/ImportExportTest.php
index 00df316f..e3f75f3c 100644
--- a/tests/integration/import/ImportExportTest.php
+++ b/tests/integration/import/ImportExportTest.php
@@ -147,6 +147,8 @@ class ImportExportTest extends \Test\TestCase {
                $tmpExportFile = tempnam('/tmp', 'export');
                file_put_contents($tmpExportFile, $jsonOutput);

+               self::assertEquals(file_get_contents(__DIR__ . '/../../data/deck.json'), $jsonOutput);
+
                // cleanup test database
                $this->connection->rollBack();
                $this->connection->beginTransaction();
```