### PR TITLE
[stable26] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1257,12 +1257,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "0dbe7e45ba027b4393cb92845251b4cec1b39355"
+                "reference": "6f0ffec5ace13e71f50d0735c0258fc37f4ca562"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/0dbe7e45ba027b4393cb92845251b4cec1b39355",
-                "reference": "0dbe7e45ba027b4393cb92845251b4cec1b39355",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6f0ffec5ace13e71f50d0735c0258fc37f4ca562",
+                "reference": "6f0ffec5ace13e71f50d0735c0258fc37f4ca562",
                 "shasum": ""
             },
             "require": {
@@ -1292,7 +1292,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable26"
             },
-            "time": "2023-07-11T00:39:09+00:00"
+            "time": "2023-07-17T09:26:46+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency