### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -254,12 +254,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "e1882fc96e3676e7628eaa82f1f8294c0d778db2"
+                "reference": "13aca78b1a060e2e2274e660b6954597e13a7035"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e1882fc96e3676e7628eaa82f1f8294c0d778db2",
-                "reference": "e1882fc96e3676e7628eaa82f1f8294c0d778db2",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/13aca78b1a060e2e2274e660b6954597e13a7035",
+                "reference": "13aca78b1a060e2e2274e660b6954597e13a7035",
                 "shasum": ""
             },
             "require": {
@@ -291,7 +291,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2023-07-22T00:39:08+00:00"
+            "time": "2023-07-29T00:34:58+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency