### PR TITLE
fix: Adapt regex for trello token to new length and format

### DIFF
--- a/lib/Service/Importer/fixtures/config-trelloApi-schema.json
+++ b/lib/Service/Importer/fixtures/config-trelloApi-schema.json
@@ -10,7 +10,7 @@
                 },
                 "token": {
                     "type": "string",
-                    "pattern": "^[0-9a-fA-F]{64}$"
+                    "pattern": "^[0-9a-fA-FT]{64,76}$"
                 }
             }
         },


### PR DESCRIPTION
Fix https://github.com/nextcloud/deck/issues/4520