### PR TITLE
fix: export doesn't handle lists with no cards

### DIFF
--- a/src/services/BoardApi.js
+++ b/src/services/BoardApi.js
@@ -163,7 +163,7 @@ export class BoardApi {
 					let CSV = row + '\r\n'
 
 					response.data.stacks.forEach(stack => {
-						stack.cards.forEach(card => {
+						stack?.cards?.forEach(card => {
 							row = ''
 							Object.keys(fields).forEach(field => {
 								if (field === 'createdAt' || field === 'lastModified') {


### PR DESCRIPTION
* Resolves: #4902 
* Target version: main

### Summary

If statement prevents the script from crashing in case there's a stack without any cards.
I would love if someone took a look at it, I'm not a programmer by trade. 
I don't know if this requires tests, or even how to write them at this point.

One thing this still doesn't handle is exporting information about the empty stack even existing.
On import it cannot be recreated.
Probably something for a different PR though.

If needed, I'll update.

### TODO

- [x] ...

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
