### PR TITLE
Replace "Timeline" wording with "Activity" in order to be consistent with equivalent contexts throughout Nextcloud

### DIFF
--- a/src/components/board/BoardSidebar.vue
+++ b/src/components/board/BoardSidebar.vue
@@ -56,7 +56,7 @@
 		<NcAppSidebarTab v-if="hasActivity"
 			id="activity"
 			:order="3"
-			:name="t('deck', 'Timeline')">
+			:name="t('deck', 'Activity')">
 			<template #icon>
 				<ActivityIcon :size="20" />
 			</template>

--- a/src/components/card/CardSidebar.vue
+++ b/src/components/card/CardSidebar.vue
@@ -78,7 +78,7 @@
 		<NcAppSidebarTab v-if="hasActivity"
 			id="timeline"
 			:order="3"
-			:name="t('deck', 'Timeline')">
+			:name="t('deck', 'Activity')">
 			<template #icon>
 				<ActivityIcon :size="20" />
 			</template>


### PR DESCRIPTION
Replace "Timeline" with "Activity" in order to be consistent with other similar UI/UX contexts in Nextcloud (e.g. Files). Also, if you check the app description, the notion is "Activity" and not "Timeline" (description is relevant and is consistent with the "Activity" context).

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
