### PR TITLE
fix: Avoid too large index on postgres as indexing just the last_editor column is enough

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@
 - 🚀 Get your project organized
 
 </description>
-    <version>1.11.0-dev</version>
+    <version>1.11.0-dev.1</version>
     <licence>agpl</licence>
     <author>Julius Härtl</author>
     <documentation>

--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -306,8 +306,7 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('id', 'title', 'duedate', 'notified', 'description_prev', 'last_editor', 'description')
 			->from('deck_cards')
-			->where($qb->expr()->isNotNull('last_editor'))
-			->andWhere($qb->expr()->isNotNull('description_prev'));
+			->where($qb->expr()->isNotNull('last_editor'));
 		return $this->findEntities($qb);
 	}
 

--- a/lib/Migration/Version1011Date20231106160059.php
+++ b/lib/Migration/Version1011Date20231106160059.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Your name <your@email.com>
+ *
+ * @author Your name <your@email.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Deck\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1011Date20231106160059 extends SimpleMigrationStep {
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		$createIndex = false;
+
+		$table = $schema->getTable('deck_cards');
+
+		if (!$table->hasIndex('idx_last_editor')) {
+			$createIndex = true;
+		}
+
+		if (!$createIndex) {
+			$index = $table->getIndex('idx_last_editor');
+			if (in_array('description_prev', $index->getColumns(), true)) {
+				$table->dropIndex('idx_last_editor');
+				$createIndex = true;
+			}
+		}
+
+		if ($createIndex) {
+			$table->addIndex(['last_editor'], 'idx_last_editor');
+			return $schema;
+		}
+
+		return null;
+	}
+}

--- a/lib/Migration/Version10800Date20220422061816.php
+++ b/lib/Migration/Version10800Date20220422061816.php
@@ -66,7 +66,7 @@ class Version10800Date20220422061816 extends SimpleMigrationStep {
 		$indexAdded = $this->addIndex($schema,
 			'deck_cards',
 			'idx_last_editor', [
-				'last_editor', 'description_prev'
+				'last_editor' /*, 'description_prev' */
 			], [],
 			// Adding a partial index on the description_prev as it is only used for a NULL check
 			['lengths' => [null, 1]]


### PR DESCRIPTION
Postgres as limitations on the index size and the length is actually not applied there. This drops the index and recreates one just with the first column. As we always set or reset the last_editor together with the description_prev column having the index only for the small column is enough to query the relevant entries in the mapper.

Otherwise updating might fail with the following error:

> 
![Screenshot 2023-11-06 at 17 37 31](https://github.com/nextcloud/deck/assets/3404133/4fac0327-9ef8-4efe-aeab-2c3d18f57551)
