### PR TITLE
scroll board by dragging

### DIFF
--- a/src/components/board/Board.vue
+++ b/src/components/board/Board.vue
@@ -54,7 +54,11 @@
 					</form>
 				</template>
 			</NcEmptyContent>
-			<div v-else-if="!isEmpty && !loading" key="board" class="board">
+			<div v-else-if="!isEmpty && !loading"
+				key="board"
+				ref="board"
+				class="board"
+				@mousedown="onMouseDown">
 				<Container lock-axix="y"
 					orientation="horizontal"
 					:drag-handle-selector="dragHandleSelector"
@@ -65,6 +69,7 @@
 					<Draggable v-for="stack in stacksByBoard"
 						:key="stack.id"
 						data-click-closes-sidebar="true"
+						data-dragscroll-enabled
 						class="stack-draggable-wrapper">
 						<Stack :stack="stack" :dragging="draggingStack" data-click-closes-sidebar="true" />
 					</Draggable>
@@ -117,6 +122,8 @@ export default {
 			draggingStack: false,
 			loading: true,
 			newStackTitle: '',
+			currentScrollPosX: null,
+			currentMousePosX: null,
 		}
 	},
 	computed: {
@@ -184,12 +191,40 @@ export default {
 			this.$store.dispatch('createStack', newStack)
 			this.newStackTitle = ''
 		},
+
+		onMouseDown(event) {
+			this.startMouseDrag(event)
+		},
+
+		startMouseDrag(event) {
+			if (!('dragscrollEnabled' in event.target.dataset)) {
+				return
+			}
+
+			event.preventDefault()
+			this.currentMousePosX = event.clientX
+			this.currentScrollPosX = this.$refs.board.scrollLeft
+			window.addEventListener('mousemove', this.handleMouseDrag)
+			window.addEventListener('mouseup', this.stopMouseDrag)
+			window.addEventListener('mouseleave', this.stopMouseDrag)
+		},
+
+		handleMouseDrag(event) {
+			event.preventDefault()
+			const deltaX = event.clientX - this.currentMousePosX
+			this.$refs.board.scrollLeft = this.currentScrollPosX - deltaX
+		},
+
+		stopMouseDrag(event) {
+			window.removeEventListener('mousemove', this.handleMouseDrag)
+			window.removeEventListener('mouseup', this.stopMouseDrag)
+			window.removeEventListener('mouseleave', this.stopMouseDrag)
+		},
 	},
 }
 </script>
 
 <style lang="scss" scoped>
-
 	@import '../../css/animations';
 	@import '../../css/variables';
 

--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -132,6 +132,7 @@
 			data-click-closes-sidebar="true"
 			non-drag-area-selector=".dragDisabled"
 			:drag-handle-selector="dragHandleSelector"
+			data-dragscroll-enabled
 			@should-accept-drop="canEdit"
 			@drag-start="draggingCard = true"
 			@drag-end="draggingCard = false"


### PR DESCRIPTION
* Resolves: #2480
* Target version: main

### Summary

Motivated by the recent uptake of activity in this repo i decided to finally tackle this issue. The PR adds horizontal scrolling of boards by dragging without adding another dependency.

If you wan't the logic out of the board component, i can refactor. I felt like the change was small enough to keep it in there, but feel free to criticize ;)

### TODO

- [ ] Test behavior on mobile. I don't have a tablet lying around, but if you have access to a BrowserStack account or similar i'd be happy to test it that way.
- [ ] Test potential edge cases i have not thought about?!

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
