### PR TITLE
fix: Get proper rich object for card actions

### DIFF
--- a/src/components/card/CardSidebar.vue
+++ b/src/components/card/CardSidebar.vue
@@ -83,7 +83,6 @@
 
 <script>
 import { NcActionButton, NcAppSidebar, NcAppSidebarTab } from '@nextcloud/vue'
-import { generateUrl } from '@nextcloud/router'
 import { mapState, mapGetters } from 'vuex'
 import CardSidebarTabDetails from './CardSidebarTabDetails.vue'
 import CardSidebarTabAttachments from './CardSidebarTabAttachments.vue'
@@ -159,15 +158,6 @@ export default {
 		},
 		subtitleTooltip() {
 			return t('deck', 'Modified') + ': ' + this.formatDate(this.currentCard.lastModified) + '\n' + t('deck', 'Created') + ': ' + this.formatDate(this.currentCard.createdAt)
-		},
-		cardRichObject() {
-			return {
-				id: '' + this.currentCard.id,
-				name: this.currentCard.title,
-				boardname: this.currentBoard.title,
-				stackname: this.stackById(this.currentCard.stackId)?.title,
-				link: window.location.protocol + '//' + window.location.host + generateUrl('/apps/deck/') + `#/board/${this.currentBoard.id}/card/${this.currentCard.id}`,
-			}
 		},
 		cardDetailsInModal: {
 			get() {

--- a/src/components/cards/CardMenuEntries.vue
+++ b/src/components/cards/CardMenuEntries.vue
@@ -136,6 +136,8 @@ export default {
 			'isArchived',
 			'boards',
 			'cardActions',
+			'stackById',
+			'boardById',
 		]),
 		...mapState({
 			showArchived: state => state.showArchived,
@@ -165,7 +167,17 @@ export default {
 		},
 
 		boardId() {
-			return this.card?.boardId ? this.card.boardId : this.$route.params.id
+			return this.card?.boardId ? this.card.boardId : Number(this.$route.params.id)
+		},
+
+		cardRichObject() {
+			return {
+				id: '' + this.card.id,
+				name: this.card.title,
+				boardname: this.boardById(this.boardId)?.title,
+				stackname: this.stackById(this.card.stackId)?.title,
+				link: window.location.protocol + '//' + window.location.host + generateUrl('/apps/deck/') + `card/${this.card.id}`,
+			}
 		},
 	},
 	methods: {


### PR DESCRIPTION
When moving over the card actions to a different component the computed `cardRichObject` was missing. 

The actions are now covered with a test case registering a dummy action and asserting that its callback gets triggered with the expected result rich object when clicking the action.

We should think about enabling vue/no-undef-properties as eslint rule which could have catched this but unfortunately it throws a lot of unrelated errors with vuex mapGetters/mapState methods.

* Resolves: https://github.com/nextcloud/spreed/issues/10330
* Target version: main