### PR TITLE
fix: allow null label colors in trello json importer

### DIFF
--- a/lib/Service/Importer/Systems/TrelloJsonService.php
+++ b/lib/Service/Importer/Systems/TrelloJsonService.php
@@ -332,7 +332,7 @@ class TrelloJsonService extends ABoardImportService {
 		return $return;
 	}
 
-	private function translateColor(string $color): string {
+	private function translateColor(?string $color): string {
 		switch ($color) {
 			case 'red':
 				return 'ff0000';


### PR DESCRIPTION
* Resolves: #5353
* Target version: main

### Summary
Sometimes the exported json from trello contains null values for labels. This causes an error on import
This is caused by the `translateColor` method, which expects a string. 
The PR solves this by making the passed in `$color` optional, and falling back to using the default color.

### Checklist

- [x] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
