### PR TITLE
Next cloud deck table scrolling

### DIFF
--- a/css/deck.css
+++ b/css/deck.css
@@ -7,3 +7,9 @@
 	background-image: url(../img/deck.svg);
 	filter: var(--background-invert-if-dark);
 }
+
+/* Add horizontal scrollbar for tables in card descriptions */
+.card-description table {
+	width: 100%; /* Ensure the table takes 100% width of the container */
+	overflow-x: auto; /* Enable horizontal scrolling */
+}

--- a/src/components/cards/CardItem.vue
+++ b/src/components/cards/CardItem.vue
@@ -434,6 +434,12 @@ export default {
 		}
 	}
 
+	/* Add horizontal scrollbar for tables in card descriptions */
+	.description-container table {
+    	width: 100%;
+    	overflow-x: auto;
+  	}
+
 	@media (prefers-color-scheme: dark) {
 		.card {
 			@include dark-card;


### PR DESCRIPTION
Description:
Currently, when a table is created within a Deck card description, and the table width exceeds the display-box width, users have to use a touchpad to scroll horizontally. This can be inconvenient, as there are no visible horizontal scrollbars indicating additional columns.

Proposal:
I suggest implementing a horizontal scrollbar for tables within the Deck card description. This can be achieved with a simple CSS tweak, such as adding overflow-x: scroll; to the relevant style.