### PR TITLE
[stable26] fix: allow null label colors in trello json importer

### DIFF
--- a/lib/Service/Importer/Systems/TrelloJsonService.php
+++ b/lib/Service/Importer/Systems/TrelloJsonService.php
@@ -332,7 +332,7 @@ class TrelloJsonService extends ABoardImportService {
 		return $return;
 	}
 
-	private function translateColor(string $color): string {
+	private function translateColor(?string $color): string {
 		switch ($color) {
 			case 'red':
 				return 'ff0000';


### PR DESCRIPTION
Backport of #5354