### PR TITLE
fix: Add debounce to update due date

### DIFF
--- a/src/components/card/CardSidebarTabDetails.vue
+++ b/src/components/card/CardSidebarTabDetails.vue
@@ -37,7 +37,8 @@
 
 		<DueDateSelector :card="card"
 			:can-edit="canEdit"
-			@change="updateCardDue" />
+			@change="updateCardDue"
+			@input="debouncedUpdateCardDue" />
 
 		<div v-if="projectsEnabled" class="section-wrapper">
 			<CollectionList v-if="card.id"
@@ -68,6 +69,7 @@ import Description from './Description.vue'
 import TagSelector from './TagSelector.vue'
 import AssignmentSelector from './AssignmentSelector.vue'
 import DueDateSelector from './DueDateSelector.vue'
+import { debounce } from 'lodash'
 
 export default {
 	name: 'CardSidebarTabDetails',
@@ -161,6 +163,10 @@ export default {
 				duedate: val ? (new Date(val)).toISOString() : null,
 			})
 		},
+
+		debouncedUpdateCardDue: debounce(function(val) {
+			this.updateCardDue(val)
+		}, 500),
 
 		addLabelToCard(newLabel) {
 			this.copiedCard.labels.push(newLabel)

--- a/src/components/card/DueDateSelector.vue
+++ b/src/components/card/DueDateSelector.vue
@@ -156,7 +156,7 @@ export default defineComponent({
 				return this.card?.duedate ? new Date(this.card.duedate) : null
 			},
 			set(val) {
-				this.$emit('change', val ? new Date(val) : null)
+				this.$emit('input', val ? new Date(val) : null)
 			},
 		},
 
@@ -216,9 +216,12 @@ export default defineComponent({
 		},
 		removeDue() {
 			this.duedate = null
+			this.$emit('change', null)
+
 		},
 		selectShortcut(shortcut) {
 			this.duedate = shortcut.timestamp
+			this.$emit('change', shortcut.timestamp)
 		},
 		getTimestamp(momentObject) {
 			return momentObject?.minute(0).second(0).millisecond(0).toDate() || null

--- a/src/views/CreateNewCardCustomPicker.vue
+++ b/src/views/CreateNewCardCustomPicker.vue
@@ -64,7 +64,10 @@
 				@select="onSelectUser"
 				@remove="onRemoveUser" />
 
-			<DueDateSelector :card="card" :can-edit="!loading && !!selectedBoard" @change="updateCardDue" />
+			<DueDateSelector :card="card"
+				:can-edit="!loading && !!selectedBoard"
+				@change="updateCardDue"
+				@input="updateCardDue" />
 
 			<Description :key="card.id"
 				:card="card"


### PR DESCRIPTION
Fix #5398

Not perfect but for now a quick improvement.

We could save only when leaving the input or closing the modal but that might have the risk to not save a due date unless we do larger changes to combine that with autosaving after some time and block closing the browser window on unsaved changes.