### PR TITLE
introduce done and open filters

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -141,6 +141,28 @@
 							<h3>{{ t('deck', 'Filter by due date') }}</h3>
 
 							<div class="filter--item">
+								<input id="open"
+									v-model="filter.open"
+									type="radio"
+									class="radio"
+									:value="true"
+									@change="setFilter"
+									@click="beforeSetFilter">
+								<label for="open">{{ t('deck', 'open') }}</label>
+							</div>
+
+							<div class="filter--item">
+								<input id="done"
+									v-model="filter.done"
+									type="radio"
+									class="radio"
+									:value="true"
+									@change="setFilter"
+									@click="beforeSetFilter">
+								<label for="done">{{ t('deck', 'done') }}</label>
+							</div>
+
+							<div class="filter--item">
 								<input id="overdue"
 									v-model="filter.due"
 									type="radio"
@@ -182,17 +204,6 @@
 									@change="setFilter"
 									@click="beforeSetFilter">
 								<label for="dueMonth">{{ t('deck', 'Next 30 days') }}</label>
-							</div>
-							
-							<div class="filter--item">
-								<input id="open"
-									v-model="filter.open"
-									type="radio"
-									class="radio"
-									:value="true"
-									@change="setFilter"
-									@click="beforeSetFilter">
-								<label for="open">{{ t('deck', 'open') }}</label>
 							</div>
 
 							<div class="filter--item">
@@ -304,7 +315,7 @@ export default {
 			filterVisible: false,
 			showArchived: false,
 			isAddStackVisible: false,
-			filter: { tags: [], users: [], due: '', unassigned: false, open: false},
+			filter: { tags: [], users: [], due: '', unassigned: false, open: false, done: false},
 			showAddCardModal: false,
 			defaultPageTitle: false,
 			isNotifyPushEnabled: isNotifyPushEnabled(),
@@ -328,7 +339,7 @@ export default {
 			}
 		},
 		isFilterActive() {
-			return this.filter.tags.length !== 0 || this.filter.users.length !== 0 || this.filter.due !== '' || this.filter.open;
+			return this.filter.tags.length !== 0 || this.filter.users.length !== 0 || this.filter.due !== '' || this.filter.open || this.filter.done;
 		},
 		labelsSorted() {
 			return [...this.board.labels].sort((a, b) => (a.title < b.title) ? -1 : 1)
@@ -376,6 +387,11 @@ export default {
 				this.filter.open = !this.filter.open
 				this.$store.dispatch('setFilter', { ...this.filter })
 			}
+
+			if (e.target.id === 'done') {
+				this.filter.done = !this.filter.done
+				this.$store.dispatch('setFilter', { ...this.filter })
+			}
 		},
 		setFilter() {
 			if (this.filter.users.length > 0) {
@@ -417,7 +433,7 @@ export default {
 			}
 		},
 		clearFilter() {
-			const filterReset = { tags: [], users: [], due: '' ,open: false}
+			const filterReset = { tags: [], users: [], due: '' ,open: false, done:false}
 			this.$store.dispatch('setFilter', { ...filterReset })
 			this.filter = filterReset
 		},

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -138,8 +138,7 @@
 								<label :for="user.uid"><NcAvatar :user="user.uid" :size="24" :disable-menu="true" /> {{ user.displayname }}</label>
 							</div>
 
-							<h3>{{ t('deck', 'Filter by due date') }}</h3>
-
+							<h3>{{ t('deck', 'Filter by done') }}</h3>
 							<div class="filter--item">
 								<input id="open"
 									v-model="filter.open"
@@ -162,6 +161,7 @@
 								<label for="done">{{ t('deck', 'done') }}</label>
 							</div>
 
+							<h3>{{ t('deck', 'Filter by due date') }}</h3>
 							<div class="filter--item">
 								<input id="overdue"
 									v-model="filter.due"

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -183,6 +183,17 @@
 									@click="beforeSetFilter">
 								<label for="dueMonth">{{ t('deck', 'Next 30 days') }}</label>
 							</div>
+							
+							<div class="filter--item">
+								<input id="open"
+									v-model="filter.open"
+									type="radio"
+									class="radio"
+									:value="true"
+									@change="setFilter"
+									@click="beforeSetFilter">
+								<label for="open">{{ t('deck', 'open') }}</label>
+							</div>
 
 							<div class="filter--item">
 								<input id="noDue"
@@ -293,7 +304,7 @@ export default {
 			filterVisible: false,
 			showArchived: false,
 			isAddStackVisible: false,
-			filter: { tags: [], users: [], due: '', unassigned: false },
+			filter: { tags: [], users: [], due: '', unassigned: false, open: false},
 			showAddCardModal: false,
 			defaultPageTitle: false,
 			isNotifyPushEnabled: isNotifyPushEnabled(),
@@ -317,7 +328,7 @@ export default {
 			}
 		},
 		isFilterActive() {
-			return this.filter.tags.length !== 0 || this.filter.users.length !== 0 || this.filter.due !== ''
+			return this.filter.tags.length !== 0 || this.filter.users.length !== 0 || this.filter.due !== '' || this.filter.open;
 		},
 		labelsSorted() {
 			return [...this.board.labels].sort((a, b) => (a.title < b.title) ? -1 : 1)
@@ -361,6 +372,10 @@ export default {
 			if (e.target.value === 'unassigned') {
 				this.filter.users = []
 			}
+			if (e.target.id === 'open') {
+				this.filter.open = !this.filter.open
+				this.$store.dispatch('setFilter', { ...this.filter })
+			}
 		},
 		setFilter() {
 			if (this.filter.users.length > 0) {
@@ -402,7 +417,7 @@ export default {
 			}
 		},
 		clearFilter() {
-			const filterReset = { tags: [], users: [], due: '' }
+			const filterReset = { tags: [], users: [], due: '' ,open: false}
 			this.$store.dispatch('setFilter', { ...filterReset })
 			this.filter = filterReset
 		},

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -141,23 +141,23 @@
 							<h3>{{ t('deck', 'Filter by completed') }}</h3>
 							<div class="filter--item">
 								<input id="filter-option-both"
-									v-model="filter.completedOrOpen"
+									v-model="filter.completed"
 									type="radio"
 									class="radio"
-									:value="true"
+									value="both"
 									@change="setFilter"
 									@click="beforeSetFilter">
-								<label for="filter-option-both">{{ t('deck', 'both') }}</label>
+								<label for="filter-option-both">{{ t('deck', 'Open and completed') }}</label>
 							</div>
 							<div class="filter--item">
 								<input id="filter-option-open"
-									v-model="filter.open"
+									v-model="filter.completed"
 									type="radio"
 									class="radio"
-									:value="true"
+									value="open"
 									@change="setFilter"
 									@click="beforeSetFilter">
-								<label for="filter-option-open">{{ t('deck', 'open') }}</label>
+								<label for="filter-option-open">{{ t('deck', 'Open') }}</label>
 							</div>
 
 							<div class="filter--item">
@@ -165,10 +165,10 @@
 									v-model="filter.completed"
 									type="radio"
 									class="radio"
-									:value="true"
+									value="completed"
 									@change="setFilter"
 									@click="beforeSetFilter">
-								<label for="filter-option-completed">{{ t('deck', 'completed') }}</label>
+								<label for="filter-option-completed">{{ t('deck', 'Completed') }}</label>
 							</div>
 
 							<h3>{{ t('deck', 'Filter by due date') }}</h3>
@@ -325,7 +325,7 @@ export default {
 			filterVisible: false,
 			showArchived: false,
 			isAddStackVisible: false,
-			filter: { tags: [], users: [], due: '', unassigned: false, open: false, completed: false, completedOrOpen: true },
+			filter: { tags: [], users: [], due: '', unassigned: false, completed: 'both' },
 			showAddCardModal: false,
 			defaultPageTitle: false,
 			isNotifyPushEnabled: isNotifyPushEnabled(),
@@ -349,7 +349,7 @@ export default {
 			}
 		},
 		isFilterActive() {
-			return this.filter.tags.length !== 0 || this.filter.users.length !== 0 || this.filter.due !== '' || this.filter.open || this.filter.completed || !this.filter.completedOrOpen
+			return this.filter.tags.length !== 0 || this.filter.users.length !== 0 || this.filter.due !== '' || this.filter.completed !== 'both'
 		},
 		labelsSorted() {
 			return [...this.board.labels].sort((a, b) => (a.title < b.title) ? -1 : 1)
@@ -393,22 +393,8 @@ export default {
 			if (e.target.value === 'unassigned') {
 				this.filter.users = []
 				this.$store.dispatch('setFilter', { ...this.filter })
-			}
-			if (e.target.id === 'filter-option-open') {
-				this.filter.open = !this.filter.open
-				this.$store.dispatch('setFilter', { ...this.filter })
-			}
-			if (e.target.id === 'filter-option-completed') {
-				this.filter.completed = !this.filter.completed
-				this.$store.dispatch('setFilter', { ...this.filter })
-			}
-			if (e.target.id !== 'filter-option-both') {
-				this.filter.completedOrOpen = !(this.filter.open || this.filter.completed)
-				this.$store.dispatch('setFilter', { ...this.filter })
 			} else {
-				this.filter.completedOrOpen = true
-				this.filter.open = false
-				this.filter.completed = false
+				this.filter.completed = 'both'
 				this.$store.dispatch('setFilter', { ...this.filter })
 			}
 			this.$store.dispatch('setFilter', { ...this.filter })
@@ -453,7 +439,7 @@ export default {
 			}
 		},
 		clearFilter() {
-			const filterReset = { tags: [], users: [], due: '', open: false, completed: false, completedOrOpen: true }
+			const filterReset = { tags: [], users: [], due: '', completed: 'both' }
 			this.$store.dispatch('setFilter', { ...filterReset })
 			this.filter = filterReset
 		},
@@ -570,7 +556,6 @@ export default {
 		input + label {
 			display: block;
 			padding: 6px 0;
-			vertical-align: middle;
 			.avatardiv {
 				vertical-align: middle;
 				margin-bottom: 2px;

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -315,7 +315,7 @@ export default {
 			filterVisible: false,
 			showArchived: false,
 			isAddStackVisible: false,
-			filter: { tags: [], users: [], due: '', unassigned: false, open: false, done: false},
+			filter: { tags: [], users: [], due: '', unassigned: false, open: false, done: false },
 			showAddCardModal: false,
 			defaultPageTitle: false,
 			isNotifyPushEnabled: isNotifyPushEnabled(),
@@ -339,7 +339,7 @@ export default {
 			}
 		},
 		isFilterActive() {
-			return this.filter.tags.length !== 0 || this.filter.users.length !== 0 || this.filter.due !== '' || this.filter.open || this.filter.done;
+			return this.filter.tags.length !== 0 || this.filter.users.length !== 0 || this.filter.due !== '' || this.filter.open || this.filter.done
 		},
 		labelsSorted() {
 			return [...this.board.labels].sort((a, b) => (a.title < b.title) ? -1 : 1)
@@ -433,7 +433,7 @@ export default {
 			}
 		},
 		clearFilter() {
-			const filterReset = { tags: [], users: [], due: '' ,open: false, done:false}
+			const filterReset = { tags: [], users: [], due: '', open: false, done: false }
 			this.$store.dispatch('setFilter', { ...filterReset })
 			this.filter = filterReset
 		},

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -138,27 +138,37 @@
 								<label :for="user.uid"><NcAvatar :user="user.uid" :size="24" :disable-menu="true" /> {{ user.displayname }}</label>
 							</div>
 
-							<h3>{{ t('deck', 'Filter by done') }}</h3>
+							<h3>{{ t('deck', 'Filter by completed') }}</h3>
 							<div class="filter--item">
-								<input id="open"
+								<input id="filter-option-both"
+									v-model="filter.completedOrOpen"
+									type="radio"
+									class="radio"
+									:value="true"
+									@change="setFilter"
+									@click="beforeSetFilter">
+								<label for="filter-option-both">{{ t('deck', 'both') }}</label>
+							</div>
+							<div class="filter--item">
+								<input id="filter-option-open"
 									v-model="filter.open"
 									type="radio"
 									class="radio"
 									:value="true"
 									@change="setFilter"
 									@click="beforeSetFilter">
-								<label for="open">{{ t('deck', 'open') }}</label>
+								<label for="filter-option-open">{{ t('deck', 'open') }}</label>
 							</div>
 
 							<div class="filter--item">
-								<input id="done"
-									v-model="filter.done"
+								<input id="filter-option-completed"
+									v-model="filter.completed"
 									type="radio"
 									class="radio"
 									:value="true"
 									@change="setFilter"
 									@click="beforeSetFilter">
-								<label for="done">{{ t('deck', 'done') }}</label>
+								<label for="filter-option-completed">{{ t('deck', 'completed') }}</label>
 							</div>
 
 							<h3>{{ t('deck', 'Filter by due date') }}</h3>
@@ -315,7 +325,7 @@ export default {
 			filterVisible: false,
 			showArchived: false,
 			isAddStackVisible: false,
-			filter: { tags: [], users: [], due: '', unassigned: false, open: false, done: false },
+			filter: { tags: [], users: [], due: '', unassigned: false, open: false, completed: false, completedOrOpen: true },
 			showAddCardModal: false,
 			defaultPageTitle: false,
 			isNotifyPushEnabled: isNotifyPushEnabled(),
@@ -339,7 +349,7 @@ export default {
 			}
 		},
 		isFilterActive() {
-			return this.filter.tags.length !== 0 || this.filter.users.length !== 0 || this.filter.due !== '' || this.filter.open || this.filter.done
+			return this.filter.tags.length !== 0 || this.filter.users.length !== 0 || this.filter.due !== '' || this.filter.open || this.filter.completed || !this.filter.completedOrOpen
 		},
 		labelsSorted() {
 			return [...this.board.labels].sort((a, b) => (a.title < b.title) ? -1 : 1)
@@ -382,16 +392,26 @@ export default {
 			}
 			if (e.target.value === 'unassigned') {
 				this.filter.users = []
+				this.$store.dispatch('setFilter', { ...this.filter })
 			}
-			if (e.target.id === 'open') {
+			if (e.target.id === 'filter-option-open') {
 				this.filter.open = !this.filter.open
 				this.$store.dispatch('setFilter', { ...this.filter })
 			}
-
-			if (e.target.id === 'done') {
-				this.filter.done = !this.filter.done
+			if (e.target.id === 'filter-option-completed') {
+				this.filter.completed = !this.filter.completed
 				this.$store.dispatch('setFilter', { ...this.filter })
 			}
+			if (e.target.id !== 'filter-option-both') {
+				this.filter.completedOrOpen = !(this.filter.open || this.filter.completed)
+				this.$store.dispatch('setFilter', { ...this.filter })
+			} else {
+				this.filter.completedOrOpen = true
+				this.filter.open = false
+				this.filter.completed = false
+				this.$store.dispatch('setFilter', { ...this.filter })
+			}
+			this.$store.dispatch('setFilter', { ...this.filter })
 		},
 		setFilter() {
 			if (this.filter.users.length > 0) {
@@ -433,7 +453,7 @@ export default {
 			}
 		},
 		clearFilter() {
-			const filterReset = { tags: [], users: [], due: '', open: false, done: false }
+			const filterReset = { tags: [], users: [], due: '', open: false, completed: false, completedOrOpen: true }
 			this.$store.dispatch('setFilter', { ...filterReset })
 			this.filter = filterReset
 		},

--- a/src/store/card.js
+++ b/src/store/card.js
@@ -33,9 +33,12 @@ export default {
 	getters: {
 		cardsByStack: (state, getters, rootState) => (id) => {
 			return state.cards.filter((card) => {
-				const { tags, users, due, unassigned,open } = rootState.filter
+				const { tags, users, due, unassigned,open, done } = rootState.filter
 
-				if (open && card.done !== null) return false;
+				if (open && card.done !== null)
+					return false;
+				if (done && card.done == null)
+					return false;
 				let allTagsMatch = true
 				let allUsersMatch = true
 

--- a/src/store/card.js
+++ b/src/store/card.js
@@ -33,7 +33,9 @@ export default {
 	getters: {
 		cardsByStack: (state, getters, rootState) => (id) => {
 			return state.cards.filter((card) => {
-				const { tags, users, due, unassigned } = rootState.filter
+				const { tags, users, due, unassigned,open } = rootState.filter
+
+				if (open && card.done !== null) return false;
 				let allTagsMatch = true
 				let allUsersMatch = true
 

--- a/src/store/card.js
+++ b/src/store/card.js
@@ -33,10 +33,10 @@ export default {
 	getters: {
 		cardsByStack: (state, getters, rootState) => (id) => {
 			return state.cards.filter((card) => {
-				const { tags, users, due, unassigned, open, completed } = rootState.filter
+				const { tags, users, due, unassigned, completed } = rootState.filter
 
-				if (open && card.done !== null) { return false }
-				if (completed && card.done == null) { return false }
+				if (completed === 'open' && card.done !== null) { return false }
+				if (completed === 'completed' && card.done == null) { return false }
 				let allTagsMatch = true
 				let allUsersMatch = true
 

--- a/src/store/card.js
+++ b/src/store/card.js
@@ -33,12 +33,10 @@ export default {
 	getters: {
 		cardsByStack: (state, getters, rootState) => (id) => {
 			return state.cards.filter((card) => {
-				const { tags, users, due, unassigned,open, done } = rootState.filter
+				const { tags, users, due, unassigned, open, done } = rootState.filter
 
-				if (open && card.done !== null)
-					return false;
-				if (done && card.done == null)
-					return false;
+				if (open && card.done !== null) { return false }
+				if (done && card.done == null) { return false }
 				let allTagsMatch = true
 				let allUsersMatch = true
 

--- a/src/store/card.js
+++ b/src/store/card.js
@@ -33,10 +33,10 @@ export default {
 	getters: {
 		cardsByStack: (state, getters, rootState) => (id) => {
 			return state.cards.filter((card) => {
-				const { tags, users, due, unassigned, open, done } = rootState.filter
+				const { tags, users, due, unassigned, open, completed } = rootState.filter
 
 				if (open && card.done !== null) { return false }
-				if (done && card.done == null) { return false }
+				if (completed && card.done == null) { return false }
 				let allTagsMatch = true
 				let allUsersMatch = true
 

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -74,7 +74,7 @@ export default new Vuex.Store({
 		searchQuery: '',
 		activity: [],
 		activityLoadMore: true,
-		filter: { tags: [], users: [], due: '', open:false},
+		filter: { tags: [], users: [], due: '', open:false, done: false},
 		shortcutLock: false,
 	},
 	getters: {

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -74,7 +74,7 @@ export default new Vuex.Store({
 		searchQuery: '',
 		activity: [],
 		activityLoadMore: true,
-		filter: { tags: [], users: [], due: '', open: false, completed: false, completedOrOpen: true },
+		filter: { tags: [], users: [], due: '', completed: 'both' },
 		shortcutLock: false,
 	},
 	getters: {

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -74,7 +74,7 @@ export default new Vuex.Store({
 		searchQuery: '',
 		activity: [],
 		activityLoadMore: true,
-		filter: { tags: [], users: [], due: '' },
+		filter: { tags: [], users: [], due: '', open:false},
 		shortcutLock: false,
 	},
 	getters: {

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -74,7 +74,7 @@ export default new Vuex.Store({
 		searchQuery: '',
 		activity: [],
 		activityLoadMore: true,
-		filter: { tags: [], users: [], due: '', open: false, done: false },
+		filter: { tags: [], users: [], due: '', open: false, completed: false, completedOrOpen: true },
 		shortcutLock: false,
 	},
 	getters: {

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -74,7 +74,7 @@ export default new Vuex.Store({
 		searchQuery: '',
 		activity: [],
 		activityLoadMore: true,
-		filter: { tags: [], users: [], due: '', open:false, done: false},
+		filter: { tags: [], users: [], due: '', open: false, done: false },
 		shortcutLock: false,
 	},
 	getters: {


### PR DESCRIPTION
* Resolves: #5406
* Target version: main

### Summary
introduces two new filters.
done filter: shows only cards that are done on the board
open filter: shows only cards that are open on the board

Screenshot:
![image](https://github.com/nextcloud/deck/assets/56235737/09022b6e-9fd8-44d6-b84d-acce68a0c3a8)


### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
