### PR TITLE
fix(done): Mark card as undone when updating card

### DIFF
--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -355,6 +355,8 @@ class CardService {
 		}
 		if ($done !== null) {
 			$card->setDone($done->getValue());
+		} else {
+			$card->setDone(null);
 		}
 
 


### PR DESCRIPTION
* Resolves: #534
* Target version: main

### Summary

As stated in https://github.com/nextcloud/deck/issues/534#issuecomment-1892061055 updating the done property of a card via the REST API (without calling the /done and /undone endpoints explicitly) does only work "one way".

This commit allows setting null as new value thus allowing to mark cards as undone without an additional HTTP request but within a usual update request.

Refs: #534 #4137 c3b4ed6e1fe706195176e011c6004d3a301a9458
CC: @desperateCoder @juliushaertl @TehThanos

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
