### PR TITLE
fixed sorting for upcoming cards

### DIFF
--- a/src/components/overview/Overview.vue
+++ b/src/components/overview/Overview.vue
@@ -145,14 +145,16 @@ export default {
 		sortCards(when) {
 			const cards = this.assignedCardsDashboard[when]
 
-			if (!cards) return null
+			if (!cards) {
+				return null
+			} else {
+				return cards.toSorted((current, next) => {
+					const currentDueDate = new Date(current.duedate)
+					const nextDueDate = new Date(next.duedate)
 
-			return cards.toSorted((current, next) => {
-				const currentDueDate = new Date(current.duedate)
-				const nextDueDate = new Date(next.duedate)
-
-				return currentDueDate - nextDueDate
-			})
+					return currentDueDate - nextDueDate
+				})
+			}
 		},
 	},
 

--- a/src/components/overview/Overview.vue
+++ b/src/components/overview/Overview.vue
@@ -33,35 +33,35 @@
 		<div v-else-if="isValidFilter" class="overview">
 			<div class="dashboard-column">
 				<h3>{{ t('deck', 'Overdue') }}</h3>
-				<div v-for="card in assignedCardsDashboard.overdue" :key="card.id">
+				<div v-for="card in sortCards('overdue')" :key="card.id">
 					<CardItem :id="card.id" />
 				</div>
 			</div>
 
 			<div class="dashboard-column">
 				<h3>{{ t('deck', 'Today') }}</h3>
-				<div v-for="card in assignedCardsDashboard.today" :key="card.id">
+				<div v-for="card in sortCards('today')" :key="card.id">
 					<CardItem :id="card.id" />
 				</div>
 			</div>
 
 			<div class="dashboard-column">
 				<h3>{{ t('deck', 'Tomorrow') }}</h3>
-				<div v-for="card in assignedCardsDashboard.tomorrow" :key="card.id">
+				<div v-for="card in sortCards('tomorrow')" :key="card.id">
 					<CardItem :id="card.id" />
 				</div>
 			</div>
 
 			<div class="dashboard-column">
 				<h3>{{ t('deck', 'Next 7 days') }}</h3>
-				<div v-for="card in assignedCardsDashboard.nextSevenDays" :key="card.id">
+				<div v-for="card in sortCards('nextSevenDays')" :key="card.id">
 					<CardItem :id="card.id" />
 				</div>
 			</div>
 
 			<div class="dashboard-column">
 				<h3>{{ t('deck', 'Later') }}</h3>
-				<div v-for="card in assignedCardsDashboard.later" :key="card.id">
+				<div v-for="card in sortCards('later')" :key="card.id">
 					<CardItem :id="card.id" />
 				</div>
 			</div>
@@ -79,7 +79,6 @@
 </template>
 
 <script>
-
 import Controls from '../Controls.vue'
 import CardItem from '../cards/CardItem.vue'
 import { mapGetters } from 'vuex'
@@ -121,9 +120,7 @@ export default {
 				return ''
 			}
 		},
-		...mapGetters([
-			'assignedCardsDashboard',
-		]),
+		...mapGetters(['assignedCardsDashboard']),
 	},
 	watch: {
 		'$route.params.filter'() {
@@ -144,6 +141,18 @@ export default {
 				console.error(e)
 			}
 			this.loading = false
+		},
+		sortCards(when) {
+			const cards = this.assignedCardsDashboard[when]
+
+			if (!cards) return null
+
+			return cards.toSorted((current, next) => {
+				const currentDueDate = new Date(current.duedate)
+				const nextDueDate = new Date(next.duedate)
+
+				return currentDueDate - nextDueDate
+			})
 		},
 	},
 


### PR DESCRIPTION
* Resolves: #5091 
* Target version: main

### Summary

Cards were previously not organized in order of due date (ascending) on the Upcoming Cards screen. These changes fix this.

Cards which have a due date that has already passed are organized in due date (descending), as it likely makes the most sense to see cards which are way past due first. This can be changed if desired.

### Screenshot

![upcoming-cards-sorted](https://github.com/nextcloud/deck/assets/23369449/a569b207-044e-4ac7-af48-e2f3130a2664)
