### PR TITLE
[stable27] fix(CardMenu): introduce cardRichObject in CardMenu

### DIFF
--- a/src/components/cards/CardMenu.vue
+++ b/src/components/cards/CardMenu.vue
@@ -127,6 +127,7 @@ export default {
 			'isArchived',
 			'boards',
 			'cardActions',
+			'stackById',
 		]),
 		...mapState({
 			showArchived: state => state.showArchived,
@@ -154,6 +155,18 @@ export default {
 
 		boardId() {
 			return this.card?.boardId ? this.card.boardId : this.$route.params.id
+		},
+		currentCard() {
+			return this.$store.getters.cardById(this.card.id)
+		},
+		cardRichObject() {
+			return {
+				id: '' + this.currentCard.id,
+				name: this.currentCard.title,
+				boardname: this.currentBoard.title,
+				stackname: this.stackById(this.currentCard.stackId)?.title,
+				link: window.location.protocol + '//' + window.location.host + generateUrl('/apps/deck/') + `#/board/${this.currentBoard.id}/card/${this.currentCard.id}`,
+			}
 		},
 	},
 	methods: {


### PR DESCRIPTION
* Resolves: regression from backport #5286
* As I see, backport wasn't complete, and CardMenuEntries component is missing at stable27
  * CardMenu doesn't have `cardRichObject` computed in any form
  * external plugin click results in undefined:
![image](https://github.com/nextcloud/deck/assets/93392545/09f02f0f-86b7-4bb5-87c1-6b77f7a9bb4e)

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
