### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -254,12 +254,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "ecc412f29a227848dd101912ec925fdc5fa214d7"
+                "reference": "d1cf95fdadf4fdc9bc8fa693d0e7e2943fca5e72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ecc412f29a227848dd101912ec925fdc5fa214d7",
-                "reference": "ecc412f29a227848dd101912ec925fdc5fa214d7",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/d1cf95fdadf4fdc9bc8fa693d0e7e2943fca5e72",
+                "reference": "d1cf95fdadf4fdc9bc8fa693d0e7e2943fca5e72",
                 "shasum": ""
             },
             "require": {
@@ -291,7 +291,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-02-17T00:31:36+00:00"
+            "time": "2024-02-24T00:30:01+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency