### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -254,12 +254,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "d23dac5fbce5d4eb53696da612285f4cbb666c90"
+                "reference": "1d42e4d74cfac4dd5d0587ba3865b619dea6c73b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/d23dac5fbce5d4eb53696da612285f4cbb666c90",
-                "reference": "d23dac5fbce5d4eb53696da612285f4cbb666c90",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/1d42e4d74cfac4dd5d0587ba3865b619dea6c73b",
+                "reference": "1d42e4d74cfac4dd5d0587ba3865b619dea6c73b",
                 "shasum": ""
             },
             "require": {
@@ -291,7 +291,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-03-09T00:30:46+00:00"
+            "time": "2024-03-17T00:34:40+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency