### PR TITLE
Change import command's config default argument

### DIFF
--- a/lib/Command/BoardImport.php
+++ b/lib/Command/BoardImport.php
@@ -43,7 +43,7 @@ class BoardImport extends Command {
 				null,
 				InputOption::VALUE_REQUIRED,
 				'Configuration json file.',
-				'config.json'
+				null
 			)
 			->addOption(
 				'data',

--- a/lib/Command/BoardImport.php
+++ b/lib/Command/BoardImport.php
@@ -48,7 +48,7 @@ class BoardImport extends Command {
 			->addOption(
 				'data',
 				null,
-				InputOption::VALUE_OPTIONAL,
+				InputOption::VALUE_REQUIRED,
 				'Data file to import.',
 				'data.json'
 			)


### PR DESCRIPTION
* Resolves: #5235 
* Target version: main

### Summary

- Change the default argument of `deck:import --config ...` from `config.json` to `null`.
  This default value caused a problem (#5235) where if not config was supplied, `config.json` is not found and the message "It's not a valid config file" is shown (#5213)
- Change the `deck:import --data ...` option to `VALUE_REQUIRED`. From reading the [Symfony docs](https://symfony.com/doc/current/console/input.html#using-command-options) I think all options are optional. `VALUE_OPTIONAL` lets you include the option in a command line _without_ giving a value, _e.g._ `deck:import --data` would be valid.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
    - Is this n/a as there are no new features?
- [x] Documentation (manuals or wiki) has been updated or is not required
    - I think this should be consistent with the current docs, where not providing `--config` assumes the data is a deck json.
