### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -254,12 +254,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "b8ae36e3e98db74bafd3dc7360cc758572e939b0"
+                "reference": "36edf19f7eb41155c1168e6993ad8760ab18a1df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b8ae36e3e98db74bafd3dc7360cc758572e939b0",
-                "reference": "b8ae36e3e98db74bafd3dc7360cc758572e939b0",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/36edf19f7eb41155c1168e6993ad8760ab18a1df",
+                "reference": "36edf19f7eb41155c1168e6993ad8760ab18a1df",
                 "shasum": ""
             },
             "require": {
@@ -291,7 +291,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-04-03T00:32:10+00:00"
+            "time": "2024-04-10T00:32:39+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency