### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -254,12 +254,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "14e4b4c5bb3f9189b78c9d29bfc6a049046c2d71"
+                "reference": "e84a723ae9c0d590e3a4deaba9d4fba54bd66184"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/14e4b4c5bb3f9189b78c9d29bfc6a049046c2d71",
-                "reference": "14e4b4c5bb3f9189b78c9d29bfc6a049046c2d71",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e84a723ae9c0d590e3a4deaba9d4fba54bd66184",
+                "reference": "e84a723ae9c0d590e3a4deaba9d4fba54bd66184",
                 "shasum": ""
             },
             "require": {
@@ -291,7 +291,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-04-24T00:33:09+00:00"
+            "time": "2024-05-01T00:36:22+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency