### PR TITLE
Completed card button wording change

### DIFF
--- a/src/components/card/DueDateSelector.vue
+++ b/src/components/card/DueDateSelector.vue
@@ -50,7 +50,7 @@
 				<template #icon>
 					<CheckIcon :size="20" />
 				</template>
-				{{ t('deck', 'Completed') }}
+				{{ t('deck', 'Mark as done') }}
 			</NcButton>
 		</template>
 		<template v-else>
@@ -66,7 +66,7 @@
 			<div class="due-actions">
 				<NcButton v-if="!card.archived"
 					type="tertiary"
-					:name="t('deck', 'Not completed')"
+					:name="t('deck', 'Not done')"
 					@click="changeCardDoneStatus()">
 					<template #icon>
 						<ClearIcon :size="20" />


### PR DESCRIPTION
My colleagues and I have been using Deck every day, several times a day, for years. 

Several of my colleagues and I regularly click on the “Completed” button by mistake (or are tempted to click on it) ... as if to save the changes made to the map (perhaps because “Completed” sounds in their heads like “Fieds are completed”.

I can't say whether this is a problem of button placement or design, but it's certainly a problem of user experience here. 

The easiest way to avoid this is to change the label from “Completed” to “Mark as done”. 

Below is the wording that I would like to change thanks to this PR, if I am not mistaken (I also changed the reverse action wording - check the commit):

![2024-05-06_15-26](https://github.com/nextcloud/deck/assets/33763786/c0878ba4-1bd1-4f62-a4d5-dfa2a9563984)

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
