### PR TITLE
Bugfix to Optional parameter $userId declared before required parameter

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -214,7 +214,7 @@ class ConfigService {
 		return $this->config->getUserValue($userId ?? $this->getUserId(), 'deck', 'attachment_folder', '/Deck');
 	}
 
-	public function setAttachmentFolder(?string $userId, string $path): void {
+	public function setAttachmentFolder(string $userId, string $path): void {
 		if ($userId === null && $this->getUserId() === null) {
 			throw new NoPermissionException('Must be logged in get the attachment folder');
 		}


### PR DESCRIPTION
Optional parameter $userId declared before required parameter $path is implicitly treated as a required parameter

Since it is treated anyway as a required parameter we can define it as such as well.

* Resolves:  #5823
* Target version: main
