### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -254,12 +254,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "1166f284566bbb6a7ceca6954c367504b87832f4"
+                "reference": "446b922114c1a6d5e0a9a81a207388080f6a94c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/1166f284566bbb6a7ceca6954c367504b87832f4",
-                "reference": "1166f284566bbb6a7ceca6954c367504b87832f4",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/446b922114c1a6d5e0a9a81a207388080f6a94c2",
+                "reference": "446b922114c1a6d5e0a9a81a207388080f6a94c2",
                 "shasum": ""
             },
             "require": {
@@ -291,7 +291,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-05-17T00:34:39+00:00"
+            "time": "2024-05-25T00:33:43+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency