### PR TITLE
chore: Move comments event handler to use proper event dispatcher

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -9,7 +9,6 @@ namespace OCA\Deck\AppInfo;
 use Closure;
 use Exception;
 use OCA\Circles\Events\CircleDestroyedEvent;
-use OCA\Deck\Activity\CommentEventHandler;
 use OCA\Deck\Capabilities;
 use OCA\Deck\Collaboration\Resources\ResourceProvider;
 use OCA\Deck\Collaboration\Resources\ResourceProviderCard;
@@ -28,6 +27,7 @@ use OCA\Deck\Event\CardUpdatedEvent;
 use OCA\Deck\Event\SessionClosedEvent;
 use OCA\Deck\Event\SessionCreatedEvent;
 use OCA\Deck\Listeners\BeforeTemplateRenderedListener;
+use OCA\Deck\Listeners\CommentEventListener;
 use OCA\Deck\Listeners\FullTextSearchEventListener;
 use OCA\Deck\Listeners\LiveUpdateListener;
 use OCA\Deck\Listeners\ParticipantCleanupListener;
@@ -56,7 +56,7 @@ use OCP\Collaboration\Reference\RenderReferenceEvent;
 use OCP\Collaboration\Resources\IProviderManager;
 use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent;
 use OCP\Comments\CommentsEntityEvent;
-use OCP\Comments\ICommentsManager;
+use OCP\Comments\CommentsEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Group\Events\GroupDeletedEvent;
 use OCP\IConfig;
@@ -91,7 +91,6 @@ class Application extends App implements IBootstrap {
 
 	public function boot(IBootContext $context): void {
 		$context->injectFn(Closure::fromCallable([$this, 'registerCommentsEntity']));
-		$context->injectFn(Closure::fromCallable([$this, 'registerCommentsEventHandler']));
 		$context->injectFn(Closure::fromCallable([$this, 'registerCollaborationResources']));
 
 		$context->injectFn(function (IManager $shareManager) {
@@ -141,6 +140,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(AclCreatedEvent::class, FullTextSearchEventListener::class);
 		$context->registerEventListener(AclUpdatedEvent::class, FullTextSearchEventListener::class);
 		$context->registerEventListener(AclDeletedEvent::class, FullTextSearchEventListener::class);
+		$context->registerEventListener(CommentsEvent::class, CommentEventListener::class);
 
 		// Handling cache invalidation for collections
 		$context->registerEventListener(AclCreatedEvent::class, ResourceListener::class);
@@ -181,12 +181,6 @@ class Application extends App implements IBootstrap {
 					return false;
 				}
 			});
-		});
-	}
-
-	protected function registerCommentsEventHandler(ICommentsManager $commentsManager): void {
-		$commentsManager->registerEventHandler(function () {
-			return $this->getContainer()->query(CommentEventHandler::class);
 		});
 	}
 

--- a/lib/Listeners/CommentEventListener.php
+++ b/lib/Listeners/CommentEventListener.php
@@ -1,43 +1,37 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OCA\Deck\Activity;
+namespace OCA\Deck\Listeners;
 
+use OCA\Deck\Activity\ActivityManager;
 use OCA\Deck\Db\CardMapper;
 use OCA\Deck\Db\ChangeHelper;
 use OCA\Deck\Notification\NotificationHelper;
 use OCP\Comments\CommentsEvent;
-use OCP\Comments\IComment;
-use OCP\Comments\ICommentsEventHandler;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
 
-class CommentEventHandler implements ICommentsEventHandler {
+/** @template-implements IEventListener<CommentsEvent|Event> */
+class CommentEventListener implements IEventListener {
 
-	/** @var ActivityManager */
-	private $activityManager;
-
-	/** @var NotificationHelper */
-	private $notificationHelper;
-
-	/** @var CardMapper */
-	private $cardMapper;
-
-	/** @var ChangeHelper */
-	private $changeHelper;
-
-	public function __construct(ActivityManager $activityManager, NotificationHelper $notificationHelper, CardMapper $cardMapper, ChangeHelper $changeHelper) {
-		$this->notificationHelper = $notificationHelper;
-		$this->activityManager = $activityManager;
-		$this->cardMapper = $cardMapper;
-		$this->changeHelper = $changeHelper;
+	public function __construct(
+		private ActivityManager $activityManager,
+		private NotificationHelper $notificationHelper,
+		private CardMapper $cardMapper,
+		private ChangeHelper $changeHelper,
+	) {
 	}
 
-	/**
-	 * @param CommentsEvent $event
-	 */
-	public function handle(CommentsEvent $event) {
+	public function handle(Event $event): void {
+		if (!$event instanceof CommentsEvent) {
+			return;
+		}
+
 		if ($event->getComment()->getObjectType() !== 'deckCard') {
 			return;
 		}
@@ -61,20 +55,13 @@ class CommentEventHandler implements ICommentsEventHandler {
 		}
 	}
 
-	/**
-	 * @param CommentsEvent $event
-	 */
-	private function activityHandler(CommentsEvent $event) {
-		/** @var IComment $comment */
+	private function activityHandler(CommentsEvent $event): void {
 		$comment = $event->getComment();
 		$card = $this->cardMapper->find($comment->getObjectId());
 		$this->activityManager->triggerEvent(ActivityManager::DECK_OBJECT_CARD, $card, ActivityManager::SUBJECT_CARD_COMMENT_CREATE, ['comment' => $comment]);
 	}
 
-	/**
-	 * @param CommentsEvent $event
-	 */
-	private function notificationHandler(CommentsEvent $event) {
+	private function notificationHandler(CommentsEvent $event): void {
 		$this->notificationHelper->sendMention($event->getComment());
 	}
 }

--- a/tests/unit/Listeners/CommentEventListenerTest.php
+++ b/tests/unit/Listeners/CommentEventListenerTest.php
@@ -21,8 +21,9 @@
  *
  */
 
-namespace OCA\Deck\Activity;
+namespace OCA\Deck\Listeners;
 
+use OCA\Deck\Activity\ActivityManager;
 use OCA\Deck\Db\Card;
 use OCA\Deck\Db\CardMapper;
 use OCA\Deck\Db\ChangeHelper;
@@ -31,9 +32,9 @@ use OCP\Comments\CommentsEvent;
 use OCP\Comments\IComment;
 use PHPUnit\Framework\TestCase;
 
-class CommentEventHandlerTest extends TestCase {
+class CommentEventListenerTest extends TestCase {
 
-	/** @var CommentEventHandler */
+	/** @var CommentEventListener */
 	private $commentEventHandler;
 	/** @var ActivityManager */
 	private $activityManager;
@@ -49,7 +50,7 @@ class CommentEventHandlerTest extends TestCase {
 		$this->notificationHelper = $this->createMock(NotificationHelper::class);
 		$this->cardMapper = $this->createMock(CardMapper::class);
 		$this->changeHelper = $this->createMock(ChangeHelper::class);
-		$this->commentEventHandler = new CommentEventHandler(
+		$this->commentEventHandler = new CommentEventListener(
 			$this->activityManager,
 			$this->notificationHelper,
 			$this->cardMapper,


### PR DESCRIPTION
Similar to https://github.com/nextcloud/server/pull/45951 this moves away from the not so lazy registration of comment event handlers.

- [x] Requires https://github.com/nextcloud/server/pull/45951/files#diff-862a3988c96ee1f18bc17076a3152274d876dec178266a6b2d237b9ae7f03cd0R1534

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
