### PR TITLE
perf: Avoid fetching labels and owner details on permission check

### DIFF
--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -113,7 +113,7 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 		return parent::update($cardUpdate);
 	}
 
-	public function find($id): Card {
+	public function find($id, bool $enhance = true): Card {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from('deck_cards')
@@ -122,9 +122,11 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 			->addOrderBy('id');
 		/** @var Card $card */
 		$card = $this->findEntity($qb);
-		$labels = $this->labelMapper->findAssignedLabelsForCard($card->getId());
-		$card->setLabels($labels);
-		$this->mapOwner($card);
+		if ($enhance) {
+			$labels = $this->labelMapper->findAssignedLabelsForCard($card->getId());
+			$card->setLabels($labels);
+			$this->mapOwner($card);
+		}
 		return $card;
 	}
 

--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -119,7 +119,7 @@ class PermissionService {
 		if ($permissions[$permission] === true) {
 
 			if (!$allowDeletedCard && $mapper instanceof CardMapper) {
-				$card = $mapper->find((int)$id);
+				$card = $mapper->find((int)$id, false);
 				if ($card->getDeletedAt() > 0) {
 					throw new NoPermissionException('Card is deleted');
 				}


### PR DESCRIPTION
Save some queries as well as a decent amount of CPU time when checking card permissions during file system setup for deck shares.

On our instance this is around 5% of total CPU time in a 1h sample during non-peak times.

<img width="1595" alt="Screenshot 2024-06-20 at 08 31 52" src="https://github.com/nextcloud/deck/assets/3404133/43d157d6-6847-4ebb-934a-01260b63dbcb">

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
