### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -254,12 +254,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "6a23d33b2cfd8660aa2a23ee377329773451dcf7"
+                "reference": "0988e496b6f9c5086e4cf6b9364cba9360b4c808"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6a23d33b2cfd8660aa2a23ee377329773451dcf7",
-                "reference": "6a23d33b2cfd8660aa2a23ee377329773451dcf7",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/0988e496b6f9c5086e4cf6b9364cba9360b4c808",
+                "reference": "0988e496b6f9c5086e4cf6b9364cba9360b4c808",
                 "shasum": ""
             },
             "require": {
@@ -291,7 +291,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-06-28T00:36:28+00:00"
+            "time": "2024-07-06T00:35:19+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency