### PR TITLE
Optimize getSharedWith to fetch permissions with initial query instead of one per card

### DIFF
--- a/lib/Db/LabelMapper.php
+++ b/lib/Db/LabelMapper.php
@@ -43,36 +43,40 @@ class LabelMapper extends DeckMapper implements IPermissionMapper {
 	}
 
 	/**
-	 * @param numeric $cardId
-	 * @param int|null $limit
-	 * @param int|null $offset
 	 * @return Label[]
 	 * @throws \OCP\DB\Exception
 	 */
-	public function findAssignedLabelsForCard($cardId, $limit = null, $offset = null): array {
+	public function findAssignedLabelsForCard(int $cardId): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('l.*', 'card_id')
 			->from($this->getTableName(), 'l')
 			->innerJoin('l', 'deck_assigned_labels', 'al', 'l.id = al.label_id')
 			->where($qb->expr()->eq('card_id', $qb->createNamedParameter($cardId, IQueryBuilder::PARAM_INT)))
-			->orderBy('l.id')
-			->setMaxResults($limit)
-			->setFirstResult($offset);
+			->orderBy('l.id');
 
 		return $this->findEntities($qb);
 	}
 
-	public function findAssignedLabelsForCards($cardIds, $limit = null, $offset = null): array {
+	public function findAssignedLabelsForCards(array $cardIds, ?int $limit = null, ?int $offset = null): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('l.*', 'card_id')
 			->from($this->getTableName(), 'l')
 			->innerJoin('l', 'deck_assigned_labels', 'al', 'l.id = al.label_id')
-			->where($qb->expr()->in('card_id', $qb->createNamedParameter($cardIds, IQueryBuilder::PARAM_INT_ARRAY)))
+			->where($qb->expr()->in('card_id', $qb->createParameter('ids')))
 			->orderBy('l.id')
 			->setMaxResults($limit)
 			->setFirstResult($offset);
 
-		return $this->findEntities($qb);
+		$results = [];
+		foreach (array_chunk($cardIds, 1000) as $chunk) {
+			$qb->setParameter('ids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
+
+			foreach ($this->findEntities($qb) as $result) {
+				$results[] = $result;
+			}
+		}
+
+		return $results;
 	}
 
 	/**

--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -19,6 +19,7 @@ use OCA\Deck\NoPermissionException;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\Cache\CappedMemoryCache;
+use OCP\Constants;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IUserManager;
@@ -130,6 +131,20 @@ class PermissionService {
 
 		// Throw NoPermission to not leak information about existing entries
 		throw new NoPermissionException('Permission denied');
+	}
+
+	public function boardToFilePermission(array $permissions): int {
+		$result = 0;
+		foreach ($permissions as $key => $value) {
+			$result |= $value ? match ($key) {
+				Acl::PERMISSION_READ => Constants::PERMISSION_READ,
+				Acl::PERMISSION_EDIT => Constants::PERMISSION_UPDATE | Constants::PERMISSION_DELETE | Constants::PERMISSION_CREATE | Constants::PERMISSION_DELETE,
+				Acl::PERMISSION_SHARE => Constants::PERMISSION_SHARE,
+				default => 0,
+			} : 0;
+		}
+
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
- **fix: Add method to map board to file permissions**
- **perf(sharing): Optimize getSharedWith to fetch permissions right away**
- **fix: Chunk query for getting labels for cards**


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
