### PR TITLE
add Order when cloning board

### DIFF
--- a/lib/Service/BoardService.php
+++ b/lib/Service/BoardService.php
@@ -562,6 +562,11 @@ class BoardService {
 		foreach ($stacks as $stack) {
 			$newStack = new Stack();
 			$newStack->setTitle($stack->getTitle());
+			if ($stack->getOrder() == null) {
+				$newStack->setOrder(999);
+			} else {
+				$newStack->setOrder($stack->getOrder());
+			}
 			$newStack->setBoardId($newBoard->getId());
 			$this->stackMapper->insert($newStack);
 		}


### PR DESCRIPTION
* Resolves: #3752 
* Target version: main

### Summary
having no order set makes it so a stack can't be renamed
-> adding the default order of 999 to every stack keeps all stacks editable
-> adding the order value keeps the order of stacks on the cloned board

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
