### PR TITLE
Feat(REST API): add url to (un)archive cards

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -102,6 +102,8 @@ return [
 		['name' => 'card_api#assignUser', 'url' => '/api/v{apiVersion}/boards/{boardId}/stacks/{stackId}/cards/{cardId}/assignUser', 'verb' => 'PUT'],
 		['name' => 'card_api#unassignUser', 'url' => '/api/v{apiVersion}/boards/{boardId}/stacks/{stackId}/cards/{cardId}/unassignUser', 'verb' => 'PUT'],
 		['name' => 'card_api#reorder', 'url' => '/api/v{apiVersion}/boards/{boardId}/stacks/{stackId}/cards/{cardId}/reorder', 'verb' => 'PUT'],
+		['name' => 'card_api#archive', 'url' => '/api/v{apiVersion}/boards/{boardId}/stacks/{stackId}/cards/{cardId}/archive', 'verb' => 'PUT'],
+		['name' => 'card_api#unarchive', 'url' => '/api/v{apiVersion}/boards/{boardId}/stacks/{stackId}/cards/{cardId}/unarchive', 'verb' => 'PUT'],
 		['name' => 'card_api#delete', 'url' => '/api/v{apiVersion}/boards/{boardId}/stacks/{stackId}/cards/{cardId}', 'verb' => 'DELETE'],
 
 		['name' => 'card_api#findAllWithDue', 'url' => '/api/v{apiVersion}/dashboard/due', 'verb' => 'GET'],

--- a/docs/API.md
+++ b/docs/API.md
@@ -347,6 +347,34 @@ A 403 response might be returned if the users ability to create new boards has b
 
 ##### 200 Success
 
+### PUT /boards/{boardId}/stacks/{stackId}/cards/{cardId}/archive - Archive a card
+
+#### Request parameters
+
+| Parameter | Type    | Description                             |
+| --------- | ------- | --------------------------------------- |
+| boardId   | Integer | The id of the board the card belongs to |
+| stackId   | Integer | The id of the stack the card belongs to |
+| cardId    | Integer | The id of the card                      |
+
+#### Response
+
+##### 200 Success
+
+### PUT /boards/{boardId}/stacks/{stackId}/cards/{cardId}/unarchive - Unarchive a card
+
+#### Request parameters
+
+| Parameter | Type    | Description                             |
+| --------- | ------- | --------------------------------------- |
+| boardId   | Integer | The id of the board the card belongs to |
+| stackId   | Integer | The id of the stack the card belongs to |
+| cardId    | Integer | The id of the card                      |
+
+#### Response
+
+##### 200 Success
+
 ### DELETE /boards/{boardId} - Delete a board
 
 #### Request parameters

--- a/lib/Controller/CardApiController.php
+++ b/lib/Controller/CardApiController.php
@@ -157,6 +157,30 @@ class CardApiController extends ApiController {
 	 * @CORS
 	 * @NoCSRFRequired
 	 *
+	 * Archive card
+	 */
+	public function archive($cardId) {
+		$card = $this->cardService->archive($cardId);
+		return new DataResponse($card, HTTP::STATUS_OK);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
+	 *
+	 * Unarchive card
+	 */
+	public function unarchive($cardId) {
+		$card = $this->cardService->unarchive($cardId);
+		return new DataResponse($card, HTTP::STATUS_OK);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
+	 *
 	 * Reorder cards
 	 */
 	public function reorder($stackId, $order) {

--- a/tests/unit/controller/CardApiControllerTest.php
+++ b/tests/unit/controller/CardApiControllerTest.php
@@ -119,6 +119,32 @@ class CardApiControllerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $actual);
 	}
 
+	public function testArchive() {
+		$card = new Card();
+		$card->setId($this->cardExample['id']);
+
+		$this->cardService->expects($this->once())
+			->method('archive')
+			->willReturn($card);
+
+		$expected = new DataResponse($card, HTTP::STATUS_OK);
+		$actual = $this->controller->archive($this->cardExample['id']);
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testUnArchive() {
+		$card = new Card();
+		$card->setId($this->cardExample['id']);
+
+		$this->cardService->expects($this->once())
+			->method('unarchive')
+			->willReturn($card);
+
+		$expected = new DataResponse($card, HTTP::STATUS_OK);
+		$actual = $this->controller->unarchive($this->cardExample['id']);
+		$this->assertEquals($expected, $actual);
+	}
+
 	public function testDelete() {
 		$card = new Card();
 		$card->setId($this->cardExample['id']);


### PR DESCRIPTION
* Resolves: #6132 
* Target version: main

### Summary
I implemented two new routes `/api/v{apiVersion}/boards/{boardId}/stacks/{stackId}/cards/{cardId}/archive` & `/api/v{apiVersion}/boards/{boardId}/stacks/{stackId}/cards/{cardId}/unarchive`, that will archive/unarchive cards via `cardService`. Documentation and unit tests are also included.
Please review my work and let me know what you think.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits 
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required