### PR TITLE
use deleted_users for users that do not exist

### DIFF
--- a/lib/Activity/DeckProvider.php
+++ b/lib/Activity/DeckProvider.php
@@ -86,10 +86,18 @@ class DeckProvider implements IProvider {
 				'user' => [
 					'type' => 'user',
 					'id' => $author,
-					'name' => $user !== null ? $user->getDisplayName() : $author
+					'name' => $user->getDisplayName()
 				],
 			];
 			$event->setAuthor($author);
+		} else {
+			$params = [
+				'user' => [
+					'type' => 'user',
+					'id' => 'deleted_users',
+					'name' => 'deleted_users',
+				]
+			];
 		}
 		if ($event->getObjectType() === ActivityManager::DECK_OBJECT_BOARD) {
 			if (!$this->activityManager->canSeeBoardActivity($event->getObjectId(), $event->getAffectedUser())) {


### PR DESCRIPTION
### Summary
When a user is deleted the activity tab of deck causes errors for all activities done by that user. To prevent that we should use a deleted_users value just as we do for deck comments already

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
