### PR TITLE
fix: Reorder `info.xml` entries to make it valid

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,14 +23,14 @@
     <version>2.0.0-dev.0</version>
     <licence>agpl</licence>
     <author>Julius Härtl</author>
-    <documentation>
-        <user>https://deck.readthedocs.io/en/latest/User_documentation_en/</user>
-        <developer>https://deck.readthedocs.io/en/latest/API/</developer>
-    </documentation>
     <namespace>Deck</namespace>
     <types>
         <dav/>
     </types>
+    <documentation>
+        <user>https://deck.readthedocs.io/en/latest/User_documentation_en/</user>
+        <developer>https://deck.readthedocs.io/en/latest/API/</developer>
+    </documentation>
     <category>organization</category>
     <category>office</category>
     <website>https://github.com/nextcloud/deck</website>


### PR DESCRIPTION
* Target version: main

### Summary

The order of the entries is fixed in the `info.xsd`, so to make it validate correctly we need to reorder some attributes (`namespace` and `types`).

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
