### PR TITLE
refactor: Migrate away from deprecated `ILogger` interface to PSR-3

### DIFF
--- a/lib/Cron/ScheduledNotifications.php
+++ b/lib/Cron/ScheduledNotifications.php
@@ -12,27 +12,17 @@ use OCA\Deck\Notification\NotificationHelper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\Job;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 class ScheduledNotifications extends Job {
 
-	/** @var CardMapper */
-	protected $cardMapper;
-	/** @var NotificationHelper */
-	protected $notificationHelper;
-	/** @var ILogger */
-	protected $logger;
-
 	public function __construct(
 		ITimeFactory $time,
-		CardMapper $cardMapper,
-		NotificationHelper $notificationHelper,
-		ILogger $logger
+		protected CardMapper $cardMapper,
+		protected NotificationHelper $notificationHelper,
+		protected LoggerInterface $logger
 	) {
 		parent::__construct($time);
-		$this->cardMapper = $cardMapper;
-		$this->notificationHelper = $notificationHelper;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Cron/SessionsCleanup.php
+++ b/lib/Cron/SessionsCleanup.php
@@ -14,21 +14,19 @@ namespace OCA\Deck\Cron;
 use OCA\Deck\Service\SessionService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 class SessionsCleanup extends TimedJob {
-	private $sessionService;
 	private $documentService;
-	private $logger;
 	private $imageService;
 
 
-	public function __construct(ITimeFactory $time,
-		SessionService $sessionService,
-		ILogger $logger) {
+	public function __construct(
+		ITimeFactory $time,
+		private SessionService $sessionService,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct($time);
-		$this->sessionService = $sessionService;
-		$this->logger = $logger;
 		$this->setInterval(SessionService::SESSION_VALID_TIME);
 	}
 

--- a/lib/Middleware/DefaultBoardMiddleware.php
+++ b/lib/Middleware/DefaultBoardMiddleware.php
@@ -10,27 +10,17 @@ use OCA\Deck\Service\DefaultBoardService;
 use OCA\Deck\Service\PermissionService;
 use OCP\AppFramework\Middleware;
 use OCP\IL10N;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 class DefaultBoardMiddleware extends Middleware {
 
-	/** @var ILogger */
-	private $logger;
-	/** @var IL10N */
-	private $l10n;
-	/** @var DefaultBoardService */
-	private $defaultBoardService;
-	/** @var PermissionService */
-	private $permissionService;
-	/** @var string|null */
-	private $userId;
-
-	public function __construct(ILogger $logger, IL10N $l10n, DefaultBoardService $defaultBoardService, PermissionService $permissionService, $userId) {
-		$this->logger = $logger;
-		$this->l10n = $l10n;
-		$this->defaultBoardService = $defaultBoardService;
-		$this->permissionService = $permissionService;
-		$this->userId = $userId;
+	public function __construct(
+		private LoggerInterface $logger,
+		private IL10N $l10n,
+		private DefaultBoardService $defaultBoardService,
+		private PermissionService $permissionService,
+		private ?string $userId,
+	) {
 	}
 
 	public function beforeController($controller, $methodName) {
@@ -39,7 +29,7 @@ class DefaultBoardMiddleware extends Middleware {
 				$this->defaultBoardService->createDefaultBoard($this->l10n->t('Personal'), $this->userId, '0087C5');
 			}
 		} catch (\Throwable $e) {
-			$this->logger->logException($e);
+			$this->logger->error('Could not create default board', ['exception' => $e]);
 		}
 	}
 }

--- a/lib/Middleware/ExceptionMiddleware.php
+++ b/lib/Middleware/ExceptionMiddleware.php
@@ -15,28 +15,19 @@ use OCP\AppFramework\Middleware;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCSController;
 use OCP\IConfig;
-use OCP\ILogger;
 use OCP\IRequest;
+use Psr\Log\LoggerInterface;
 
 class ExceptionMiddleware extends Middleware {
 
-	/** @var ILogger */
-	private $logger;
-	/** @var IConfig */
-	private $config;
-	/** @var IRequest */
-	private $request;
-
 	/**
 	 * SharingMiddleware constructor.
-	 *
-	 * @param ILogger $logger
-	 * @param IConfig $config
 	 */
-	public function __construct(ILogger $logger, IConfig $config, IRequest $request) {
-		$this->logger = $logger;
-		$this->config = $config;
-		$this->request = $request;
+	public function __construct(
+		private LoggerInterface $logger,
+		private IConfig $config,
+		private IRequest $request,
+	) {
 	}
 
 	/**
@@ -69,9 +60,7 @@ class ExceptionMiddleware extends Middleware {
 		}
 
 		if ($exception instanceof StatusException) {
-			if ($this->config->getSystemValue('loglevel', ILogger::WARN) === ILogger::DEBUG) {
-				$this->logger->logException($exception);
-			}
+			$this->logger->debug($exception->getMessage(), ['exception' => $exception]);
 
 			if ($exception instanceof ConflictException) {
 				return new JSONResponse([
@@ -98,7 +87,7 @@ class ExceptionMiddleware extends Middleware {
 				'message' => $exceptionMessage,
 				'requestId' => $this->request->getId(),
 			];
-			$this->logger->logException($exception);
+			$this->logger->error($exception->getMessage(), ['exception' => $exception]);
 			if ($debugMode === true) {
 				$response['exception'] = (array) $exception;
 			}

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -20,37 +20,21 @@ use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
+use Psr\Log\LoggerInterface;
 
 class FileService implements IAttachmentService {
-	private $l10n;
-	private $appData;
-	private $request;
-	private $logger;
-	private $rootFolder;
-	private $config;
-	private $attachmentMapper;
-	private $mimeTypeDetector;
 
 	public function __construct(
-		IL10N $l10n,
-		IAppData $appData,
-		IRequest $request,
-		ILogger $logger,
-		IRootFolder $rootFolder,
-		IConfig $config,
-		AttachmentMapper $attachmentMapper,
-		IMimeTypeDetector $mimeTypeDetector
+		private IL10N $l10n,
+		private IAppData $appData,
+		private IRequest $request,
+		private LoggerInterface $logger,
+		private IRootFolder $rootFolder,
+		private IConfig $config,
+		private AttachmentMapper $attachmentMapper,
+		private IMimeTypeDetector $mimeTypeDetector
 	) {
-		$this->l10n = $l10n;
-		$this->appData = $appData;
-		$this->request = $request;
-		$this->logger = $logger;
-		$this->rootFolder = $rootFolder;
-		$this->config = $config;
-		$this->attachmentMapper = $attachmentMapper;
-		$this->mimeTypeDetector = $mimeTypeDetector;
 	}
 
 	/**
@@ -193,6 +177,7 @@ class FileService implements IAttachmentService {
 	/**
 	 * Workaround until ISimpleFile can be fetched as a resource
 	 *
+	 * @return \OCP\Files\File
 	 * @throws \Exception
 	 */
 	private function getFileFromRootFolder(Attachment $attachment) {

--- a/tests/unit/Cron/ScheduledNoificationsTest.php
+++ b/tests/unit/Cron/ScheduledNoificationsTest.php
@@ -27,29 +27,24 @@ use OCA\Deck\Db\Card;
 use OCA\Deck\Db\CardMapper;
 use OCA\Deck\Notification\NotificationHelper;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\ILogger;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class ScheduledNoificationsTest extends TestCase {
 
-	/** @var ITimeFactory|MockObject */
-	protected $timeFactory;
-	/** @var CardMapper|MockObject */
-	protected $cardMapper;
-	/** @var NotificationHelper|MockObject */
-	protected $notificationHelper;
-	/** @var ILogger|MockObject */
-	protected $logger;
-	/** @var ScheduledNotifications */
-	protected $scheduledNotifications;
+	protected ITimeFactory&MockObject $timeFactory;
+	protected CardMapper&MockObject $cardMapper;
+	protected NotificationHelper&MockObject $notificationHelper;
+	protected LoggerInterface&MockObject $logger;
+	protected ScheduledNotifications $scheduledNotifications;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->cardMapper = $this->createMock(CardMapper::class);
 		$this->notificationHelper = $this->createMock(NotificationHelper::class);
-		$this->logger = $this->createMock(ILogger::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->scheduledNotifications = new ScheduledNotifications($this->timeFactory, $this->cardMapper, $this->notificationHelper, $this->logger);
 	}
 

--- a/tests/unit/Middleware/ExceptionMiddlewareTest.php
+++ b/tests/unit/Middleware/ExceptionMiddlewareTest.php
@@ -32,21 +32,20 @@ use OCA\Deck\Service\PermissionService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IConfig;
-use OCP\ILogger;
 use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 class ExceptionMiddlewareTest extends \Test\TestCase {
 
-	/** @var ILogger */
-	private $logger;
-	/** @var IConfig */
-	private $config;
-	private $request;
-	private $controller;
+	private LoggerInterface&MockObject $logger;
+	private IConfig&MockObject $config;
+	private IRequest&MockObject $request;
+	private Controller&MockObject $controller;
 	private $exceptionMiddleware;
 
 	public function setUp(): void {
-		$this->logger = $this->createMock(ILogger::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->request = $this->createMock(IRequest::class);
 		$this->controller = $this->createMock(Controller::class);

--- a/tests/unit/Service/FileServiceTest.php
+++ b/tests/unit/Service/FileServiceTest.php
@@ -34,38 +34,29 @@ use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class FileServiceTest extends TestCase {
 
-	/** @var IL10N|MockObject */
-	private $l10n;
-	/** @var IAppData|MockObject */
-	private $appData;
-	/** @var IRequest|MockObject */
-	private $request;
-	/** @var ILogger|MockObject */
-	private $logger;
-	/** @var FileService */
-	private $fileService;
-	/** @var IRootFolder */
-	private $rootFolder;
-	/** @var IConfig */
-	private $config;
-	/** @var AttachmentMapper|MockObject */
-	private $attachmentMapper;
-	/** @var IMimeTypeDetector|MockObject */
-	private $mimeTypeDetector;
-
+	private IL10N&MockObject $l10n;
+	private IAppData&MockObject $appData;
+	private IRequest&MockObject $request;
+	private LoggerInterface&MockObject $logger;
+	private IRootFolder&MockObject $rootFolder;
+	private IConfig&MockObject $config;
+	private AttachmentMapper&MockObject $attachmentMapper;
+	private IMimeTypeDetector&MockObject $mimeTypeDetector;
+	private FileService $fileService;
+	
 	public function setUp(): void {
 		parent::setUp();
 		$this->request = $this->createMock(IRequest::class);
 		$this->appData = $this->createMock(IAppData::class);
 		$this->l10n = $this->createMock(IL10N::class);
-		$this->logger = $this->createMock(ILogger::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->rootFolder = $this->createMock(IRootFolder::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->attachmentMapper = $this->createMock(AttachmentMapper::class);


### PR DESCRIPTION
* Target version: main

### Summary
Mostly replace `ILogger` with `LoggerInterface` and some minor cleanup (constructor property promotion).

Some places used the deprecated `logException` this is easy to migrate by simply use the appropriate log level on the logger and place the exception under the `exception` key in the context.
Also the manual checking of the configured log level is not needed, as this is already done by the logger.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
