### PR TITLE
copy labels when moving cards between boards

### DIFF
--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -40,6 +40,7 @@ class CardService {
 	private StackMapper $stackMapper;
 	private BoardMapper $boardMapper;
 	private LabelMapper $labelMapper;
+	private LabelService $labelService;
 	private PermissionService $permissionService;
 	private BoardService $boardService;
 	private NotificationHelper $notificationHelper;
@@ -61,6 +62,7 @@ class CardService {
 		StackMapper $stackMapper,
 		BoardMapper $boardMapper,
 		LabelMapper $labelMapper,
+		LabelService $labelService,
 		PermissionService $permissionService,
 		BoardService $boardService,
 		NotificationHelper $notificationHelper,
@@ -81,6 +83,7 @@ class CardService {
 		$this->stackMapper = $stackMapper;
 		$this->boardMapper = $boardMapper;
 		$this->labelMapper = $labelMapper;
+		$this->labelService = $labelService;
 		$this->permissionService = $permissionService;
 		$this->boardService = $boardService;
 		$this->notificationHelper = $notificationHelper;
@@ -349,8 +352,34 @@ class CardService {
 		}
 		$card->setDescription($description);
 
-
+		// @var Card $card
 		$card = $this->cardMapper->update($card);
+		$oldBoardId = $this->stackMapper->findBoardId($changes->getBefore()->getStackId());
+		$boardId = $this->cardMapper->findBoardId($card->getId());
+		if($boardId !== $oldBoardId) {
+			$stack = $this->stackMapper->find($card->getStackId());
+			$board = $this->boardService->find($this->cardMapper->findBoardId($card->getId()));
+			$boardLabels = $board->getLabels() ?? [];
+			foreach($card->getLabels() as $cardLabel) {
+				$this->removeLabel($card->getId(), $cardLabel->getId());
+				$label = $this->labelMapper->find($cardLabel->getId());
+				$filteredLabels = array_values(array_filter($boardLabels, fn ($item) => $item->getTitle() === $label->getTitle()));
+				// clone labels that are assigned to card but don't exist in new board
+				if (empty($filteredLabels)) {
+					if ($this->permissionService->getPermissions($boardId)[Acl::PERMISSION_MANAGE] === true) {
+						$newLabel = $this->labelService->create($label->getTitle(), $label->getColor(), $board->getId());
+						$boardLabels[] = $label;
+						$this->assignLabel($card->getId(), $newLabel->getId());
+					}
+				} else {
+					$this->assignLabel($card->getId(), $filteredLabels[0]->getId());
+				}
+			}
+			$board->setLabels($boardLabels);
+			$this->boardMapper->update($board);
+			$this->changeHelper->boardChanged($board->getId());
+		}
+
 		if ($resetDuedateNotification) {
 			$this->notificationHelper->markDuedateAsRead($card);
 		}

--- a/lib/Service/Importer/Systems/DeckJsonService.php
+++ b/lib/Service/Importer/Systems/DeckJsonService.php
@@ -125,8 +125,10 @@ class DeckJsonService extends ABoardImportService {
 		foreach ($this->tmpCards as $sourceCard) {
 			foreach ($sourceCard->labels as $label) {
 				$cardId = $this->cards[$sourceCard->id]->getId();
-				$labelId = $this->labels[$label->id]->getId();
-				$cardsLabels[$cardId][] = $labelId;
+				if ($this->getImportService()->getData()->id === $label->boardId) {
+					$labelId = $this->labels[$label->id]->getId();
+					$cardsLabels[$cardId][] = $labelId;
+				}
 			}
 		}
 		return $cardsLabels;

--- a/tests/unit/Service/CardServiceTest.php
+++ b/tests/unit/Service/CardServiceTest.php
@@ -68,6 +68,8 @@ class CardServiceTest extends TestCase {
 	private $boardService;
 	/** @var LabelMapper|MockObject */
 	private $labelMapper;
+	/** @var LabelService|MockObject */
+	private $labelService;
 	private $boardMapper;
 	/** @var AttachmentService|MockObject */
 	private $attachmentService;
@@ -96,6 +98,7 @@ class CardServiceTest extends TestCase {
 		$this->stackMapper = $this->createMock(StackMapper::class);
 		$this->boardMapper = $this->createMock(BoardMapper::class);
 		$this->labelMapper = $this->createMock(LabelMapper::class);
+		$this->labelService = $this->createMock(LabelService::class);
 		$this->permissionService = $this->createMock(PermissionService::class);
 		$this->boardService = $this->createMock(BoardService::class);
 		$this->notificationHelper = $this->createMock(NotificationHelper::class);
@@ -118,6 +121,7 @@ class CardServiceTest extends TestCase {
 			$this->stackMapper,
 			$this->boardMapper,
 			$this->labelMapper,
+			$this->labelService,
 			$this->permissionService,
 			$this->boardService,
 			$this->notificationHelper,


### PR DESCRIPTION
* Target version: main

### Summary
labels assigned to cards that move between boards now get cloned
old json deck files that have cross referencing labels now skip those labels instead of throwing an error

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
