### PR TITLE
feat: Add markdown support for comments

### DIFF
--- a/src/components/card/CommentForm.vue
+++ b/src/components/card/CommentForm.vue
@@ -167,7 +167,10 @@ export default {
 
 	.comment-form__contenteditable {
 		word-break: break-word;
-		border-radius: var(--border-radius-large)
+		border-radius: var(--border-radius-large);
+		padding: var(--default-grid-baseline);
+		max-height: 200px;
+		overflow: auto;
 	}
 
 	.atwho-wrap {

--- a/src/components/card/CommentItem.vue
+++ b/src/components/card/CommentItem.vue
@@ -18,6 +18,7 @@
 			</div>
 			<NcRichText class="comment--content"
 				dir="auto"
+				use-markdown
 				:text="richText(comment)"
 				:arguments="richArgs(comment)"
 				:autolink="true" />
@@ -63,6 +64,7 @@
 		<div v-show="!edit" ref="richTextElement">
 			<NcRichText class="comment--content"
 				dir="auto"
+				use-markdown
 				:text="richText(comment)"
 				:arguments="richArgs(comment)"
 				:autolink="true" />

--- a/src/css/comments.scss
+++ b/src/css/comments.scss
@@ -23,10 +23,13 @@
 		padding: 13px;
 		background-color: transparent;
 		border: none;
-		opacity: .3;
 		position: absolute;
-		bottom: 0;
-		right: 0;
+		bottom: var(--default-grid-baseline);
+		right: var(--default-grid-baseline);
+
+		&:disabled {
+			opacity: .7;
+		}
 	}
 }
 


### PR DESCRIPTION
As this was very easy to implement. This contributes to https://github.com/nextcloud/server/issues/17375 for deck and has been requested in the past here directly https://github.com/nextcloud/deck/issues/2905

<img width="979" alt="Screenshot 2024-10-16 at 15 43 03" src="https://github.com/user-attachments/assets/7fab78bd-dd49-4bfd-821a-e683af850624">

