### PR TITLE
fix(sharing): list accounts with matches in email

### DIFF
--- a/cypress/e2e/sharingFeatures.js
+++ b/cypress/e2e/sharingFeatures.js
@@ -6,11 +6,14 @@ import { randUser } from '../utils/index.js'
 import { sampleBoard } from '../utils/sampleBoard'
 const user = randUser()
 const recipient = randUser()
+const domain = Math.random().toString(36).replace(/[^a-z]+/g, '').slice(0, 10)
 
 describe('Board', function() {
 	before(function() {
 		cy.createUser(user)
 		cy.createUser(recipient)
+		cy.login(recipient)
+		cy.setUserEmail(recipient, `${recipient.userId}@${domain}.com`)
 	})
 
 	beforeEach(function() {
@@ -25,6 +28,24 @@ describe('Board', function() {
 			cy.get('.board-title').contains(board.title)
 
 			cy.shareBoardWithUi(recipient.userId)
+
+			cy.login(recipient)
+			cy.visit(`/apps/deck/#/board/${boardId}`)
+			cy.get('.board-title').contains(board.title)
+			cy.get('.button-vue[aria-label*="Add card"]')
+				.should('not.exist')
+		})
+	})
+
+	it('Share a board to a user by email', function() {
+		const board = sampleBoard('Shared by email')
+		cy.createExampleBoard({ user, board }).then((board) => {
+			const boardId = board.id
+			cy.visit(`/apps/deck/#/board/${boardId}`)
+			cy.get('.board-title').contains(board.title)
+
+			// domain is only in the email address - not in user ids.
+			cy.shareBoardWithUi(domain, recipient.userId)
 
 			cy.login(recipient)
 			cy.visit(`/apps/deck/#/board/${boardId}`)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -4,11 +4,20 @@
  */
 
 import { addCommands } from '@nextcloud/cypress'
+import axios from '@nextcloud/axios'
 
 addCommands()
 
 const url = Cypress.config('baseUrl').replace(/\/index.php\/?$/g, '')
 Cypress.env('baseUrl', url)
+
+// prepare main cypress window so we can use axios there
+// and it will successfully fetch csrf tokens when needed.
+window.OC = {
+	config: { modRewriteWorking: false },
+}
+// Prevent @nextcloud/router from reading window.location
+window._oc_webroot = url
 
 Cypress.Commands.add('openLeftSidebar', () => {
 	cy.get('.app-navigation button.app-navigation-toggle').click()
@@ -89,15 +98,23 @@ Cypress.Commands.add('getNavigationEntry', (boardTitle) => {
 		.find('a.app-navigation-entry-link')
 })
 
-Cypress.Commands.add('shareBoardWithUi', (userId) => {
-	cy.intercept({ method: 'GET', url: `**/ocs/v2.php/apps/files_sharing/api/v1/sharees?search=${userId}*` }).as('fetchRecipients')
+Cypress.Commands.add('shareBoardWithUi', (query, userId=query) => {
+	cy.intercept({ method: 'GET', url: `**/ocs/v2.php/apps/files_sharing/api/v1/sharees?search=${query}*` }).as('fetchRecipients')
 	cy.get('[aria-label="Open details"]').click()
 	cy.get('.app-sidebar').should('be.visible')
-	cy.get('.select input').type(`${userId}`)
+	cy.get('.select input').type(`${query}`)
 	cy.wait('@fetchRecipients', { timeout: 7000 })
 
-	cy.get('.vs__dropdown-menu .option').first().contains(userId)
+	cy.get('.vs__dropdown-menu .option').first().contains(query)
 	cy.get('.select input').type('{enter}')
 
 	cy.get('.shareWithList').contains(userId)
+})
+
+Cypress.Commands.add('setUserEmail', (user, value) => {
+	Cypress.log()
+	return axios.put(
+		`${url}/ocs/v2.php/cloud/users/${user.userId}`,
+		{ key: 'email', value },
+	)
 })

--- a/src/components/board/SharingTabSidebar.vue
+++ b/src/components/board/SharingTabSidebar.vue
@@ -141,9 +141,13 @@ export default {
 		},
 		formatedSharees() {
 			return this.unallocatedSharees.map(item => {
+				const subname = item.label === item.shareWithDisplayNameUnique
+					? ''
+					: item.shareWithDisplayNameUnique
 				const sharee = {
 					user: item.value.shareWith,
 					displayName: item.label,
+					subname,
 					icon: 'icon-user',
 					multiselectKey: item.shareType + ':' + item.primaryKey,
 				}


### PR DESCRIPTION
* Target version: main

### Summary

* List email addresses in sharing dialog.
* Show users with matches in the email address.

`NcSelect` filters the options based on matches in `label` and `subname`.

### Todo

- [x] Write more verbose commit message.
- [x] Add cypress test to prevent regressions.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation is not required
