### PR TITLE
feat(cards): add card counters

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -22,7 +22,8 @@
 		<div v-else-if="board" class="board-title">
 			<div :style="{backgroundColor: '#' + board.color}" class="board-bullet" />
 			<h2 dir="auto">
-				{{ board.title }}
+				<span class="board__title-text">{{ board.title }}</span>
+				<span class="board__title-counter">{{ cardsCount }}</span>
 			</h2>
 			<p v-if="showArchived">
 				({{ t('deck', 'Archived cards') }})
@@ -348,6 +349,12 @@ export default {
 			// get user object including displayname from the list of all users with acces
 			return this.board.users.filter((user) => this.board.activeSessions.includes(user.uid))
 		},
+		stacksByBoard() {
+			return this.$store.getters.stacksByBoard(this.board?.id) || []
+		},
+		cardsCount() {
+			return this.stacksByBoard.reduce((count, stack) => count + (this.$store.getters.cardsByStack(stack.id)?.length || 0), 0)
+		},
 	},
 	watch: {
 		board(current, previous) {
@@ -357,6 +364,13 @@ export default {
 			if (current) {
 				this.setPageTitle(current.title)
 			}
+		},
+		stacksByBoard: {
+			handler(newStacks) {
+				this.updateCardsCount(newStacks)
+			},
+			immediate: true,
+			deep: true,
 		},
 	},
 	beforeMount() {
@@ -474,6 +488,9 @@ export default {
 				this.setFilter()
 			}
 		},
+		updateCardsCount(stacks) {
+			this.cardsCount = stacks.reduce((count, stack) => count + (stack.cards?.length || 0), 0)
+		},
 	},
 }
 </script>
@@ -503,6 +520,20 @@ export default {
 				border-radius: 50%;
 				background-color: transparent;
 				margin: var(--default-grid-baseline);
+			}
+
+			.board__title-text {
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+				flex-grow: 1; /* Ocupa el máximo espacio disponible */
+			}
+
+			.board__title-counter {
+				flex-shrink: 0;
+				margin-left: 8px;
+				color: var(--color-info-text);
+				font-size: 0.9em;
 			}
 		}
 

--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -11,7 +11,8 @@
 			:aria-label="stack.title">
 			<transition name="fade" mode="out-in">
 				<h3 v-if="!canManage || isArchived" tabindex="0">
-					{{ stack.title }}
+					<span class="stack__title-text">{{ stack.title }}</span>
+					<span class="stack__title-counter">{{ cardsCount }}</span>
 				</h3>
 				<h3 v-else-if="!editing"
 					title="stack.title"
@@ -21,7 +22,8 @@
 					class="stack__title"
 					@click="startEditing(stack)"
 					@keydown.enter="startEditing(stack)">
-					{{ stack.title }}
+					<span class="stack__title-text">{{ stack.title }}</span>
+					<span class="stack__title-counter">{{ cardsCount }}</span>
 				</h3>
 				<form v-else-if="editing"
 					v-click-outside="cancelEdit"
@@ -203,6 +205,9 @@ export default {
 				}
 				return !card.archived
 			})
+		},
+		cardsCount() {
+			return this.cardsByStack?.length || 0
 		},
 		dragHandleSelector() {
 			return this.canEdit && !this.showArchived ? null : '.no-drag'
@@ -422,10 +427,26 @@ export default {
 			border-radius: 3px;
 			padding: 4px 4px;
 			font-size: var(--default-font-size);
+			display: flex;
+			justify-content: space-between; /* Asegura separación entre título y contador */
 
 			&:focus-visible {
 				outline: 2px solid var(--color-border-dark);
 				border-radius: 3px;
+			}
+
+			.stack__title-text {
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+				flex-grow: 1; /* Ocupa el máximo espacio disponible */
+			}
+
+			.stack__title-counter {
+				flex-shrink: 0;
+				margin-left: 8px;
+				color: var(--color-info-text);
+				font-size: 0.9em;
 			}
 		}
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/deck/issues/3201
* Target version: main

### Summary
Add card counters to each stack

### TODO

- [ ] Add card counters to sidebar: would require to change server response to make counting on server side
- [ ] Add card counters to all boards view (same as before

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
