### PR TITLE
chore: Add CODEOWNERS with current app maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# App maintainers
+* @luka-nextcloud @grnd-alt @elzody


### PR DESCRIPTION
According to current app maintenance 