### PR TITLE
feat: make card events compatible with webhook listener

### DIFF
--- a/lib/Event/ACardEvent.php
+++ b/lib/Event/ACardEvent.php
@@ -11,8 +11,9 @@ namespace OCA\Deck\Event;
 
 use OCA\Deck\Db\Card;
 use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IWebhookCompatibleEvent;
 
-abstract class ACardEvent extends Event {
+abstract class ACardEvent extends Event implements IWebhookCompatibleEvent {
 	private $card;
 	
 	public function __construct(Card $card) {
@@ -23,5 +24,9 @@ abstract class ACardEvent extends Event {
 
 	public function getCard(): Card {
 		return $this->card;
+	}
+
+	public function getWebhookSerializable(): array {
+		return $this->getCard()->jsonSerialize();
 	}
 }


### PR DESCRIPTION
* Target version: main

### Summary

This PR modifies the base class of the card events to make them compatible with the [webhook_listeners](https://github.com/nextcloud/server/tree/master/apps/webhook_listeners) ([docs](https://docs.nextcloud.com/server/latest/admin_manual/webhook_listeners/index.html)) app, that ships with the Nextcloud server. This is needed, to be able to build flows in Nextcloud Flow / Windmill that should get triggered when a card gets created/updated/deleted in a board.

Please let me know if tests or documentation are required.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
