### PR TITLE
fix: Use new query builder

### DIFF
--- a/lib/Db/BoardMapper.php
+++ b/lib/Db/BoardMapper.php
@@ -210,7 +210,7 @@ class BoardMapper extends QBMapper implements IPermissionMapper {
 		}
 
 		// shared with user
-		$qb->resetQueryParts();
+		$qb = $this->db->getQueryBuilder();
 		$qb->select('b.id', 'title', 'owner', 'color', 'archived', 'deleted_at', 'last_modified')
 			//->selectAlias('1', 'shared')
 			->from('deck_boards', 'b')


### PR DESCRIPTION
Avoid reusing a query builder instance for another query which causes some log spam and should not be done anyways