### PR TITLE
fix: close modal after deleting card

### DIFF
--- a/src/components/cards/CardMenuEntries.vue
+++ b/src/components/cards/CardMenuEntries.vue
@@ -140,6 +140,9 @@ export default {
 			this.$store.dispatch('deleteCard', this.card)
 			const undoCard = { ...this.card, deletedAt: 0 }
 			showUndo(t('deck', 'Card deleted'), () => this.$store.dispatch('cardUndoDelete', undoCard))
+			if (this.$router.currentRoute.name === 'card') {
+				this.$router.push({ name: 'board' })
+			}
 		},
 		changeCardDoneStatus() {
 			this.$store.dispatch('changeCardDoneStatus', { ...this.card, done: !this.card.done })


### PR DESCRIPTION
* Resolves: # 6263 -> https://github.com/nextcloud/deck/issues/6263
* Target version: main

### Summary
When a card is opened in the modal or sidebar and then deleted, the router now goes to the board, so that the modal closes. The sidebar was already closing, but incorrectly kept the URL for the card.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
