### PR TITLE
[main] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3943,9 +3943,10 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.21.0.tgz",
-      "integrity": "sha512-at06uh2JJkn8dV3Yzyoag2z1g6omad8MZ8yKWE+9ZAGP+kaysbnI5q3lB7KXu8SVRtX3Rex8/oal0jgsbb6Spg==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.22.0.tgz",
+      "integrity": "sha512-6smeLUVLl8lqh+ia9j+m3nk9fnjra/YNgNO8RI1He8LRuojB9ZQtIy3kGcqIN1BOi6fx9qLiBEkobazWzMmiSw==",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -3982,6 +3983,7 @@
         "splitpanes": "^2.4.1",
         "string-length": "^5.0.1",
         "striptags": "^3.2.0",
+        "tabbable": "^6.2.0",
         "tributejs": "^5.1.3",
         "unified": "^11.0.1",
         "unist-builder": "^4.0.0",


### PR DESCRIPTION
# Audit report

This audit fix resolves 12 of the total 25 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/files](#user-content-\@nextcloud\/files)
* [@nextcloud/moment](#user-content-\@nextcloud\/moment)
* [@nextcloud/webpack-vue-config](#user-content-\@nextcloud\/webpack-vue-config)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [postcss](#user-content-postcss)
* [vue-at](#user-content-vue-at)
* [vue-infinite-loading](#user-content-vue-infinite-loading)
* [vue-loader](#user-content-vue-loader)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
* [vuex](#user-content-vuex)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/files](#user-content-\@nextcloud\/files)
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/files <a href="#user-content-\@nextcloud\/files" id="\@nextcloud\/files">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/files`

### @nextcloud/moment <a href="#user-content-\@nextcloud\/moment" id="\@nextcloud\/moment">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.1
* Package usage:
  * `node_modules/@nextcloud/moment`

### @nextcloud/webpack-vue-config <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-loader](#user-content-vue-loader)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### vue-at <a href="#user-content-vue-at" id="vue-at">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.0.0 || 2.0.0 - 2.5.1
* Package usage:
  * `node_modules/vue-at`

### vue-infinite-loading <a href="#user-content-vue-infinite-loading" id="vue-infinite-loading">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 2.0.0-rc.1 - 2.4.5
* Package usage:
  * `node_modules/vue-infinite-loading`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`

### vuex <a href="#user-content-vuex" id="vuex">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 3.1.3 - 3.6.2
* Package usage:
  * `node_modules/vuex`