### PR TITLE
fix: Avoid failing on public dav URLs

### DIFF
--- a/lib/Service/AssignmentService.php
+++ b/lib/Service/AssignmentService.php
@@ -88,8 +88,6 @@ class AssignmentService {
 		$this->changeHelper = $changeHelper;
 		$this->activityManager = $activityManager;
 		$this->eventDispatcher = $eventDispatcher;
-
-		$this->assignmentServiceValidator->check(compact('userId'));
 		$this->currentUser = $userId;
 	}
 

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -38,7 +38,7 @@ use Psr\Log\LoggerInterface;
 
 class CardService {
 
-	private string $currentUser;
+	private ?string $currentUser;
 
 	public function __construct(
 		private CardMapper $cardMapper,


### PR DESCRIPTION
It seems that the dav plugins are now also called on public share links, so this changes ensure that we do not throw errors as deck is not expecting its classes to be initialized without a user session.