### PR TITLE
devcontainer(image): Fix package path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "ghcr.io/juliushaertl/nextcloud-dev-php81:latest",
+    "image": "ghcr.io/juliusknorr/nextcloud-dev-php81:latest",
     "forwardPorts": [80],
     "containerEnv": {
         "NEXTCLOUD_AUTOINSTALL_APPS": "deck",


### PR DESCRIPTION
* Resolves: is not related to an issue
* Target version: main

### Summary
I wanted to work on an issue and started the workspace. Then I got an error message saying that the dockerimge could not be downloaded. After a bit of research, I saw that the path is outdated. That's why I did the PR

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L2-R2): Changed the image from `ghcr.io/juliushaertl/nextcloud-dev-php81:latest` to `ghcr.io/juliusknorr/nextcloud-dev-php81:latest`.


### Checklist

- [X] Code is properly formatted
- [X] Sign-off message is added to all commits
- [X] Tests (unit, integration, api and/or acceptance) are included
- [X] Documentation (manuals or wiki) has been updated or is not required
