### PR TITLE
Remove old project from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Deck is a kanban style organization tool aimed at personal planning and project 
 
 - [Nextcloud Deck app for Android](https://github.com/stefan-niedermann/nextcloud-deck) - It is available in [F-Droid](https://f-droid.org/de/packages/it.niedermann.nextcloud.deck/) and the [Google Play Store](https://play.google.com/store/apps/details?id=it.niedermann.nextcloud.deck.play)
 - [Nextcloud Deck app for iOS](https://github.com/StCyr/deck-react-native) - It is available in [Apple App store](https://apps.apple.com/ml/app/nextcloud-deck/id1570892788)
-- [deck NG for Android and iOS](https://github.com/meltzow/deck-ng) - It is available in [Google Play Store](https://play.google.com/store/apps/details?id=net.meltzow.deckng) and [Apple App Store](https://apps.apple.com/us/app/deck-ng/id6443334702)
 
 ### 3rd-Party Integrations
 


### PR DESCRIPTION
Deck-NG was archived in July 2024 - https://github.com/meltzow/deck-ng

* Target version: main

### Summary
Fixed a broken link


### Checklist

- [X] Code is properly formatted
- [X] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [X] Documentation (manuals or wiki) has been updated or is not required
