### PR TITLE
fix: Properly show attachment extension

### DIFF
--- a/cypress/e2e/cardFeatures.js
+++ b/cypress/e2e/cardFeatures.js
@@ -187,7 +187,8 @@ describe('Card', function () {
 			cy.get('.file-picker__main [data-filename="welcome.txt"]', { timeout: 30000 }).should('be.visible')
 				.click()
 			cy.get('.dialog__actions button.button-vue--vue-primary').click()
-			cy.get('.attachment-list .basename').contains('welcome.txt')
+			cy.get('.attachment-list .filename').contains('welcome')
+			cy.get('.attachment-list .filename .extension').contains('txt')
 		})
 
 		it('Shows the modal with the editor', () => {

--- a/src/components/card/AttachmentList.vue
+++ b/src/components/card/AttachmentList.vue
@@ -24,7 +24,8 @@
 				<div class="details">
 					<a>
 						<div class="filename">
-							<span class="basename">{{ attachment.name }}</span>
+							<span>{{ attachmentBasename(attachment) }}</span>
+							<span class="extension">.{{ attachmentExtension(attachment) }}</span>
 						</div>
 						<progress :value="attachment.progress" max="100" />
 					</a>
@@ -41,7 +42,8 @@
 				<div class="details">
 					<a :href="internalLink(attachment)" @click.prevent="showViewer(attachment)">
 						<div class="filename">
-							<span class="basename">{{ attachment.data }}</span>
+							<span>{{ attachmentBasename(attachment) }}</span>
+							<span class="extension">.{{ attachmentExtension(attachment) }}</span>
 						</div>
 						<div v-if="attachment.deletedAt === 0">
 							<span class="filesize">{{ formattedFileSize(attachment.extendedData.filesize) }}</span>
@@ -182,6 +184,14 @@ export default {
 			} else {
 				return t('deck', 'Drop your files to upload')
 			}
+		},
+		attachmentBasename() {
+			return (attachment) => attachment?.extendedData?.info.filename
+				?? (attachment?.name ?? attachment.data).replace(/\.[^/.]+$/, '')
+		},
+		attachmentExtension() {
+			return (attachment) => attachment?.extendedData?.info?.extension
+				?? (attachment?.name ?? attachment.data).split('.').pop()
 		},
 	},
 	watch: {

--- a/src/components/card/Description.vue
+++ b/src/components/card/Description.vue
@@ -239,15 +239,18 @@ export default {
 		},
 		addAttachment(attachment) {
 			const asImage = (attachment.type === 'file' && attachment.extendedData.hasPreview) || attachment.extendedData.mimetype.includes('image')
+			// We need to strip those as text does not support rtl yet, so we cannot insert them separately
+			const stripRTLO = (text) => text.replaceAll('\u202e', '')
+			const fileName = stripRTLO(attachment.extendedData.info.filename) + '.' + stripRTLO(attachment.extendedData.info.extension)
 			if (this.editor) {
 				this.editor.insertAtCursor(
 					asImage
 						? `<a href="${this.attachmentPreview(attachment)}"><img src="${this.attachmentPreview(attachment)}" alt="${attachment.data}" /></a>`
-						: `<a href="${this.attachmentPreview(attachment)}">${attachment.data}</a>`,
+						: `<a href="${this.attachmentPreview(attachment)}">${fileName}</a>`,
 				)
 				return
 			} else {
-				const attachmentString = (asImage ? '!' : '') + '[📎 ' + attachment.data + '](' + this.attachmentPreview(attachment) + ')'
+				const attachmentString = (asImage ? '!' : '') + '[📎 ' + fileName + '](' + this.attachmentPreview(attachment) + ')'
 				const descString = this.$refs.markdownEditor.easymde.value()
 				const newContent = descString + '\n' + attachmentString
 				this.$refs.markdownEditor.easymde.value(newContent)


### PR DESCRIPTION
Properly show attachment extensions as a separate dom element to avoid mixing up filenames and extensions.