### PR TITLE
fix: skip exporting a deleted card

### DIFF
--- a/lib/Command/UserExport.php
+++ b/lib/Command/UserExport.php
@@ -62,6 +62,7 @@ class UserExport extends Command {
 			if ($board->getDeletedAt() > 0) {
 				continue;
 			}
+
 			$fullBoard = $this->boardMapper->find($board->getId(), true, true);
 			$data[$board->getId()] = $fullBoard->jsonSerialize();
 			$stacks = $this->stackMapper->findAll($board->getId());
@@ -69,13 +70,16 @@ class UserExport extends Command {
 				$data[$board->getId()]['stacks'][$stack->getId()] = $stack->jsonSerialize();
 				$cards = $this->cardMapper->findAllByStack($stack->getId());
 				foreach ($cards as $card) {
+					if ($card->getDeletedAt() > 0) {
+						continue;
+					}
 					$fullCard = $this->cardMapper->find($card->getId());
+
 					$assignedUsers = $this->assignedUsersMapper->findAll($card->getId());
 					$fullCard->setAssignedUsers($assignedUsers);
 
 					$cardDetails = new CardDetails($fullCard, $fullBoard);
 					$comments = $this->commentService->list($card->getId());
-
 					$cardDetails->setCommentsCount(count($comments->getData()));
 
 					$cardJson = $cardDetails->jsonSerialize();

--- a/tests/unit/Command/UserExportTest.php
+++ b/tests/unit/Command/UserExportTest.php
@@ -74,16 +74,23 @@ class UserExportTest extends \Test\TestCase {
 		$board->setTitle('Board ' . $id);
 		return $board;
 	}
+
 	public function getStack($id) {
 		$stack = new Stack();
 		$stack->setId($id);
 		$stack->setTitle('Stack ' . $id);
 		return $stack;
 	}
-	public function getCard($id) {
+
+	public function getCard($id, $deleted = false) {
 		$card = new Card();
 		$card->setId($id);
 		$card->setTitle('Card ' . $id);
+
+		if ($deleted) {
+			$card->setDeletedAt(time());
+		}
+
 		return $card;
 	}
 
@@ -93,6 +100,7 @@ class UserExportTest extends \Test\TestCase {
 		$comment->setMessage('fake comment' . $id);
 		return $comment;
 	}
+
 	public function testExecute() {
 		$input = $this->createMock(InputInterface::class);
 		$input->expects($this->once())->method('getArgument')->with('user-id')->willReturn('admin');
@@ -102,19 +110,12 @@ class UserExportTest extends \Test\TestCase {
 			$this->getBoard(1),
 			$this->getBoard(2),
 		];
-		$this->boardService->expects($this->once())
-			->method('findAll')
-			->willReturn($boards);
-		$this->boardMapper->expects($this->exactly(count($boards)))
-			->method('find')
-			->willReturn($boards[0]);
+
 		$stacks = [
 			$this->getStack(1),
 			$this->getStack(2)
 		];
-		$this->stackMapper->expects($this->exactly(count($boards)))
-			->method('findAll')
-			->willReturn($stacks);
+
 		$cards = [
 			$this->getCard(1),
 			$this->getCard(2),
@@ -126,16 +127,89 @@ class UserExportTest extends \Test\TestCase {
 			$this->getComment(2),
 			$this->getComment(3),
 		];
-		$this->commentService->expects($this->exactly(count($cards) * count($stacks) * count($boards)))->method('list')->willReturn(new DataResponse($comments));
+
+		$this->boardService->expects($this->once())
+			->method('findAll')
+			->willReturn($boards);
+
+		$this->boardMapper->expects($this->exactly(count($boards)))
+			->method('find')
+			->willReturn($boards[0]);
+
+		$this->stackMapper->expects($this->exactly(count($boards)))
+			->method('findAll')
+			->willReturn($stacks);
+
+		$this->commentService->expects($this->exactly(count($cards) * count($stacks) * count($boards)))
+			->method('list')
+			->willReturn(new DataResponse($comments));
+		
 		$this->cardMapper->expects($this->exactly(count($boards) * count($stacks)))
 			->method('findAllByStack')
 			->willReturn($cards);
+
 		$this->cardMapper->expects($this->exactly(count($boards) * count($stacks) * count($cards)))
 			->method('find')
 			->willReturn($cards[0]);
+
 		$this->assignedUserMapper->expects($this->exactly(count($boards) * count($stacks) * count($cards)))
 			->method('findAll')
 			->willReturn([]);
+
+		$result = $this->invokePrivate($this->userExport, 'execute', [$input, $output]);
+		self::assertEquals(0, $result);
+	}
+
+	public function testExecuteWithDeletedCard() {
+		$input = $this->createMock(InputInterface::class);
+		$input->expects($this->once())->method('getArgument')->with('user-id')->willReturn('admin');
+		$output = $this->createMock(OutputInterface::class);
+
+		$boards = [
+			$this->getBoard(1),
+		];
+
+		$stacks = [
+			$this->getStack(1),
+		];
+
+		$cards = [
+			$this->getCard(1),
+			$this->getCard(2, true),
+		];
+
+		$comments = [
+			$this->getComment(1),
+		];
+
+		$this->boardService->expects($this->once())
+			->method('findAll')
+			->willReturn($boards);
+
+		$this->boardMapper->expects($this->once())
+			->method('find')
+			->willReturn($boards[0]);
+
+		$this->stackMapper->expects($this->once())
+			->method('findAll')
+			->willReturn($stacks);
+
+		$this->commentService->expects($this->exactly(count($stacks) * count($boards)))
+			->method('list')
+			->willReturn(new DataResponse($comments));
+		
+		$this->cardMapper->expects($this->once())
+			->method('findAllByStack')
+			->willReturn($cards);
+
+		$this->cardMapper->expects($this->once())
+			->method('find')
+			->willReturn($cards[0]);
+
+		$this->assignedUserMapper->expects($this->once())
+			->method('findAll')
+			->willReturn([]);
+
 		$result = $this->invokePrivate($this->userExport, 'execute', [$input, $output]);
 		self::assertEquals(0, $result);
 	}


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/deck/issues/6446
* Target version: main

### Summary
Checks if the card is deleted before continuing -- if it is, just move on

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
