### PR TITLE
[stable29] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -254,12 +254,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "55e817ce1b36e2fb92839d5368f38d2ea97ee536"
+                "reference": "5ee6a24cf01fbfd0ca32a4e568279de6eadd68f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/55e817ce1b36e2fb92839d5368f38d2ea97ee536",
-                "reference": "55e817ce1b36e2fb92839d5368f38d2ea97ee536",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5ee6a24cf01fbfd0ca32a4e568279de6eadd68f7",
+                "reference": "5ee6a24cf01fbfd0ca32a4e568279de6eadd68f7",
                 "shasum": ""
             },
             "require": {
@@ -290,7 +290,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable29"
             },
-            "time": "2025-01-27T08:38:56+00:00"
+            "time": "2025-02-04T00:42:54+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency