### PR TITLE
 fix: make bin icon red on button hover 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     timezone: Europe/Paris
   open-pull-requests-limit: 10
   reviewers:
-  - juliushaertl
+  - juliusknorr
   - luka-nextcloud
 
 - package-ecosystem: npm
@@ -90,7 +90,7 @@ updates:
     timezone: Europe/Paris
   open-pull-requests-limit: 10
   reviewers:
-  - juliushaertl
+  - juliusknorr
   - luka-nextcloud
 
 - package-ecosystem: composer
@@ -102,7 +102,7 @@ updates:
     timezone: Europe/Paris
   open-pull-requests-limit: 10
   reviewers:
-  - juliushaertl
+  - juliusknorr
   - luka-nextcloud
 
 - package-ecosystem: github-actions
@@ -114,5 +114,5 @@ updates:
     timezone: Europe/Paris
   open-pull-requests-limit: 10
   reviewers:
-  - juliushaertl
+  - juliusknorr
   - luka-nextcloud

--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ You can enable HMR (Hot module replacement) to avoid page reloads when working o
 docker run --rm \
     -p 8080:80 \
     -v $PWD:/var/www/html/apps-extra/deck \
-    ghcr.io/juliushaertl/nextcloud-dev-php81:latest
+    ghcr.io/juliusknorr/nextcloud-dev-php81:latest
 ```
 
 ### Full Nextcloud development environment
 
-You need to setup a [development environment](https://docs.nextcloud.com/server/latest/developer_manual//getting_started/devenv.html) of the current Nextcloud version. You can also alternatively install & run the [nextcloud docker container](https://github.com/juliushaertl/nextcloud-docker-dev).
+You need to setup a [development environment](https://docs.nextcloud.com/server/latest/developer_manual//getting_started/devenv.html) of the current Nextcloud version. You can also alternatively install & run the [nextcloud docker container](https://github.com/juliusknorr/nextcloud-docker-dev).
 After the finished installation, you can clone the deck project directly in the `/[nextcloud-docker-dev-dir]/workspace/server/apps/` folder.
 
 ### Running tests

--- a/css/deck.css
+++ b/css/deck.css
@@ -21,3 +21,8 @@ input[type=text]:focus+input[type=submit].icon-confirm,
 input[type=text]:hover+input[type=submit].icon-confirm {
 	border-color: var(--color-main-text) !important;
 }
+
+button:focus .icon-delete,
+button:hover .icon-delete {
+	background-image: var(--icon-delete-color-red);
+}


### PR DESCRIPTION
* Resolves: N/A
* Target version: main

### Summary

The bin icon would only highlight in red when specifically hovered over the icon, when it should've probably been when hovered over the button.

This just fixes that!

### Screenshots

#### Befor

https://github.com/user-attachments/assets/994bfabd-e7ec-4867-ab2e-1208da8e4cd6

#### After

https://github.com/user-attachments/assets/53c0f779-956e-4633-8224-ec70b28f082d

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included — N/A
- [x] Documentation (manuals or wiki) has been updated or is not required - N/A

### Chores

Also does a chore!

The image `ghcr.io/juliushaertl/nextcloud-dev-php81:latest` is a 4xx error now. 

A maintainer of the project changed their GitHub username, which broke the command in the README for running the nextcloud-dev Docker container. This needs to have their up-to-date username in the image path.

While updating that, I also changed a few other references as well.