### PR TITLE
Clear selected stack when selected board changed

### DIFF
--- a/cypress/e2e/cardFeatures.js
+++ b/cypress/e2e/cardFeatures.js
@@ -374,6 +374,9 @@ describe('Card', function () {
 
 			cy.get('.app-sidebar-header .action-item__menutoggle').click()
 			cy.get('.v-popper__popper button:contains("Move/copy card")').click()
+			cy.get('.vs__dropdown-menu span[title="MyTestBoard"]').should('be.visible').click()
+			cy.get('[data-cy="select-stack"] .vs__dropdown-toggle').should('be.visible').click()
+			cy.get('.vs__dropdown-menu span[title="TestList"]').should('be.visible').click()
 			cy.get('.modal-container button:contains("Copy card")').click()
 			cy.wait('@clone', { timeout: 7000 })
 			cy.get('.card:contains("Hello world")').should('have.length', 2)

--- a/src/CardMoveDialog.vue
+++ b/src/CardMoveDialog.vue
@@ -18,6 +18,7 @@
 				:input-label="t('deck', 'Select a list')"
 				:options="stacksFromBoard"
 				:max-height="100"
+				data-cy="select-stack"
 				label="title" />
 		</div>
 		<template #actions>
@@ -57,6 +58,15 @@ export default {
 		},
 		isBoardAndStackChoosen() {
 			return !(this.selectedBoard === '' || this.selectedStack === '')
+		},
+	},
+	watch: {
+		selectedBoard: {
+			immediate: true,
+			handler() {
+				this.selectedStack = ''
+				this.stacksFromBoard = []
+			},
 		},
 	},
 	mounted() {


### PR DESCRIPTION
* Resolves: #6901
* Target version: main

### Summary
In the "Move/Copy Card" dialog, the selected stack should be cleared upon changing the selected board. This enhancement prevents confusion when multiple boards have stacks with identical names, which could lead to incorrect stack selection and card was not moved correctly.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
