### PR TITLE
perf: don't enrich cards when finding calendar entries

### DIFF
--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -159,9 +159,7 @@ class CardService {
 			$this->logger->error('Unable to check permission for a previously obtained board ' . $boardId, ['exception' => $e]);
 			return [];
 		}
-		$cards = $this->cardMapper->findCalendarEntries($boardId);
-		$this->enrichCards($cards);
-		return $cards;
+		return $this->cardMapper->findCalendarEntries($boardId);
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: # _none_
* Target version: main

### Summary

When calendar events are requests via Deck's calendar backend implementation, the cards of the corresponding boards are fetched and enriched. However, the enriched data is never used, effectively wasting a lot of CPU cycles.

I did some research and the basic entity is sufficient to generate VCALENDAR objects (see `\OCA\Deck\Db\Card::getCalendarObject()`). Other than that, only the two getters `getCalendarPrefix()` and `getId()` are accessed which are forwarded by `CardDetails` to `Card` anyway.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
