### PR TITLE
[stable29] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3863,13 +3863,29 @@
       }
     },
     "node_modules/@nextcloud/moment": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/moment/-/moment-1.3.2.tgz",
-      "integrity": "sha512-VfSPnllfciZe1eU4zaHS0fE/4pPWKRUjLFxZSNQec9gkUfbskMsKH2xyPqkYLlYP9FF1uQh2+wZbzkFd6QLc4A==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@nextcloud/moment/-/moment-1.3.4.tgz",
+      "integrity": "sha512-ibc1v3HshmI8q1jkfwj5tKgBnOSCpaVp1Nx0uSqnoStUsh5qdf235xA0UFtro+yFuGgfpTbos4gTzfXIoC2enA==",
       "dependencies": {
-        "@nextcloud/l10n": "^2.2.0",
-        "moment": "^2.30.1",
-        "node-gettext": "^3.0.0"
+        "@nextcloud/l10n": "^3.2.0",
+        "moment": "^2.30.1"
+      },
+      "engines": {
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
+      }
+    },
+    "node_modules/@nextcloud/moment/node_modules/@nextcloud/l10n": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.2.0.tgz",
+      "integrity": "sha512-5TbIc415C0r8YUA0i4bOXKL0iInY8ka+t8PGHihqevzqf/LAkFatd+p6mCLJT3tQPxgkcIRCIuyOkiUM0Lyw5Q==",
+      "dependencies": {
+        "@nextcloud/router": "^3.0.1",
+        "@nextcloud/typings": "^1.9.1",
+        "@types/dompurify": "^3.2.0",
+        "@types/escape-html": "^1.0.4",
+        "dompurify": "^3.2.4",
+        "escape-html": "^1.0.3"
       },
       "engines": {
         "node": "^20.0.0",
@@ -3936,15 +3952,14 @@
       }
     },
     "node_modules/@nextcloud/timezones": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-0.1.1.tgz",
-      "integrity": "sha512-ldLuLyz605sszetnp6jy6mtlThu4ICKsZThxHIZwn6t4QzjQH3xr+k8mRU7GIvKq9egUFDqBp4gBjxm3/ROZig==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-0.2.0.tgz",
+      "integrity": "sha512-1mwQ+asTFOgv9rxPoAMEbDF8JfnenIa2EGNS+8MATCyi6WXxYh0Lhkaq1d3l2+xNbUPHgMnk4cRYsvIo319lkA==",
       "dependencies": {
-        "ical.js": "^2.0.1"
+        "ical.js": "^2.1.0"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20 || ^22"
       }
     },
     "node_modules/@nextcloud/typings": {
@@ -3960,10 +3975,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.26.0.tgz",
-      "integrity": "sha512-7KyPAle4/tL2VzR0vVa5ssLAaAlDv54XJ1HPTPw9R4FIyqxDe9lICe1sRNG+uXsRY0NeYIKEmbJ3sqvbxaWdVQ==",
-      "license": "AGPL-3.0-or-later",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.26.1.tgz",
+      "integrity": "sha512-kaTtiNeaiE2nT4mLe1X3oIbuNZbIYOQknPTa9gF6yCCn8gMwMTfg/JL/7Kr1a+UsLYNLLCizGZoCjEzR2DDpYA==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -3977,7 +3991,7 @@
         "@nextcloud/logger": "^3.0.2",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.3",
-        "@nextcloud/timezones": "^0.1.1",
+        "@nextcloud/timezones": "^0.2.0",
         "@nextcloud/vue-select": "^3.25.1",
         "@vueuse/components": "^11.0.0",
         "@vueuse/core": "^11.0.0",
@@ -11930,9 +11944,9 @@
       }
     },
     "node_modules/ical.js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.0.1.tgz",
-      "integrity": "sha512-uYYb1CwTXbd9NP/xTtgQZ5ivv6bpUjQu9VM98s3X78L3XRu00uJW5ZtmnLwyxhztpf5fSiRyDpFW7ZNCePlaPw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.1.0.tgz",
+      "integrity": "sha512-BOVfrH55xQ6kpS3muGvIXIg2l7p+eoe12/oS7R5yrO3TL/j/bLsR0PR+tYQESFbyTbvGgPHn9zQ6tI4FWyuSaQ=="
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -24841,13 +24855,27 @@
       }
     },
     "@nextcloud/moment": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/moment/-/moment-1.3.2.tgz",
-      "integrity": "sha512-VfSPnllfciZe1eU4zaHS0fE/4pPWKRUjLFxZSNQec9gkUfbskMsKH2xyPqkYLlYP9FF1uQh2+wZbzkFd6QLc4A==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@nextcloud/moment/-/moment-1.3.4.tgz",
+      "integrity": "sha512-ibc1v3HshmI8q1jkfwj5tKgBnOSCpaVp1Nx0uSqnoStUsh5qdf235xA0UFtro+yFuGgfpTbos4gTzfXIoC2enA==",
       "requires": {
-        "@nextcloud/l10n": "^2.2.0",
-        "moment": "^2.30.1",
-        "node-gettext": "^3.0.0"
+        "@nextcloud/l10n": "^3.2.0",
+        "moment": "^2.30.1"
+      },
+      "dependencies": {
+        "@nextcloud/l10n": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.2.0.tgz",
+          "integrity": "sha512-5TbIc415C0r8YUA0i4bOXKL0iInY8ka+t8PGHihqevzqf/LAkFatd+p6mCLJT3tQPxgkcIRCIuyOkiUM0Lyw5Q==",
+          "requires": {
+            "@nextcloud/router": "^3.0.1",
+            "@nextcloud/typings": "^1.9.1",
+            "@types/dompurify": "^3.2.0",
+            "@types/escape-html": "^1.0.4",
+            "dompurify": "^3.2.4",
+            "escape-html": "^1.0.3"
+          }
+        }
       }
     },
     "@nextcloud/notify_push": {
@@ -24889,11 +24917,11 @@
       "requires": {}
     },
     "@nextcloud/timezones": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-0.1.1.tgz",
-      "integrity": "sha512-ldLuLyz605sszetnp6jy6mtlThu4ICKsZThxHIZwn6t4QzjQH3xr+k8mRU7GIvKq9egUFDqBp4gBjxm3/ROZig==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-0.2.0.tgz",
+      "integrity": "sha512-1mwQ+asTFOgv9rxPoAMEbDF8JfnenIa2EGNS+8MATCyi6WXxYh0Lhkaq1d3l2+xNbUPHgMnk4cRYsvIo319lkA==",
       "requires": {
-        "ical.js": "^2.0.1"
+        "ical.js": "^2.1.0"
       }
     },
     "@nextcloud/typings": {
@@ -24905,9 +24933,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.26.0.tgz",
-      "integrity": "sha512-7KyPAle4/tL2VzR0vVa5ssLAaAlDv54XJ1HPTPw9R4FIyqxDe9lICe1sRNG+uXsRY0NeYIKEmbJ3sqvbxaWdVQ==",
+      "version": "8.26.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.26.1.tgz",
+      "integrity": "sha512-kaTtiNeaiE2nT4mLe1X3oIbuNZbIYOQknPTa9gF6yCCn8gMwMTfg/JL/7Kr1a+UsLYNLLCizGZoCjEzR2DDpYA==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -24921,7 +24949,7 @@
         "@nextcloud/logger": "^3.0.2",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.3",
-        "@nextcloud/timezones": "^0.1.1",
+        "@nextcloud/timezones": "^0.2.0",
         "@nextcloud/vue-select": "^3.25.1",
         "@vueuse/components": "^11.0.0",
         "@vueuse/core": "^11.0.0",
@@ -30753,9 +30781,9 @@
       "peer": true
     },
     "ical.js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.0.1.tgz",
-      "integrity": "sha512-uYYb1CwTXbd9NP/xTtgQZ5ivv6bpUjQu9VM98s3X78L3XRu00uJW5ZtmnLwyxhztpf5fSiRyDpFW7ZNCePlaPw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.1.0.tgz",
+      "integrity": "sha512-BOVfrH55xQ6kpS3muGvIXIg2l7p+eoe12/oS7R5yrO3TL/j/bLsR0PR+tYQESFbyTbvGgPHn9zQ6tI4FWyuSaQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",


### PR DESCRIPTION
# Audit report

This audit fix resolves 1 of the total 22 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/moment](#user-content-\\@nextcloud\\/moment)
## Fixed vulnerabilities

### `@nextcloud/moment` <a href="#user-content-\@nextcloud\/moment" id="\@nextcloud\/moment">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [node-gettext](#user-content-node-gettext)
* Affected versions: 1.1.1 - 1.3.2
* Package usage:
  * `node_modules/@nextcloud/moment`