### PR TITLE
fix: not show Share with a Deck card for unauthorized users

### DIFF
--- a/src/views/FileSharingPicker.js
+++ b/src/views/FileSharingPicker.js
@@ -42,5 +42,7 @@ export default {
 
 		})
 	},
-	condition: self => true,
+	condition: self => {
+		return !!OC.appswebroots.deck
+	},
 }


### PR DESCRIPTION
* Resolves: #7025
* Target version: main

### Summary
Users who do not have access to the Deck app should not see the "Share with a Deck card" option in the search sharing input.

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
