### PR TITLE
fix: add retry and show warning on description saving error

### DIFF
--- a/src/components/card/CardSidebar.vue
+++ b/src/components/card/CardSidebar.vue
@@ -87,7 +87,7 @@ import HomeIcon from 'vue-material-design-icons/Home.vue'
 import CommentIcon from 'vue-material-design-icons/Comment.vue'
 import ActivityIcon from 'vue-material-design-icons/LightningBolt.vue'
 
-import { showError } from '@nextcloud/dialogs'
+import { showError, showWarning } from '@nextcloud/dialogs'
 import { getLocale } from '@nextcloud/l10n'
 import CardMenuEntries from '../cards/CardMenuEntries.vue'
 
@@ -139,6 +139,7 @@ export default {
 		...mapState({
 			isFullApp: (state) => state.isFullApp,
 			currentBoard: (state) => state.currentBoard,
+			hasCardSaveError: (state) => state.hasCardSaveError,
 		}),
 		...mapGetters(['canEdit', 'assignables', 'cardActions', 'stackById']),
 		currentCard() {
@@ -198,6 +199,10 @@ export default {
 		},
 
 		closeSidebar() {
+			if (this.hasCardSaveError) {
+				showWarning(t('deck', 'Cannot close unsaved card!'))
+				return
+			}
 			this.$router?.push({ name: 'board' })
 			this.$emit('close')
 		},

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -50,6 +50,7 @@ export default new Vuex.Store({
 		sidebarShown: false,
 		currentBoard: null,
 		currentCard: null,
+		hasCardSaveError: false,
 		boards: loadState('deck', 'initialBoards', []),
 		sharees: [],
 		assignableUsers: [],
@@ -130,6 +131,9 @@ export default new Vuex.Store({
 	mutations: {
 		setFullApp(state, isFullApp) {
 			Vue.set(state, 'isFullApp', isFullApp)
+		},
+		setHasCardSaveError(state, hasCardSaveError) {
+			Vue.set(state, 'hasCardSaveError', hasCardSaveError)
 		},
 		SET_CONFIG(state, { key, value }) {
 			const [scope, id, configKey] = key.split(':', 3)


### PR DESCRIPTION
* Resolves: #6896
* Target version: main

### Summary
- Show warning message when card description save fails
- Add retry when card description save fails


### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
