### PR TITLE
fix: ensure correct type when filtering events

### DIFF
--- a/src/components/ActivityList.vue
+++ b/src/components/ActivityList.vue
@@ -87,7 +87,7 @@ export default {
 				// to tell the backend to fetch all activites related to cards of a given board
 				activities = activities.filter((activity) => {
 					return (activity.object_type === 'deck_board' && activity.object_id === this.objectId)
-							|| (activity.object_type === 'deck_card' && activity.subject_rich[1].board.id === this.objectId)
+							|| (activity.object_type === 'deck_card' && activity.subject_rich[1].board.id === this.objectId.toString())
 				})
 			}
 			this.activities.push(...activities)


### PR DESCRIPTION
resolves #6858

caused because id in activity.subject_rich[1].board.id for card events is a string now: https://github.com/nextcloud/deck/pull/6898
but object_id in board events is still a number, so need a type cast in the filtering.
open for discussion to just change it in the php code to make it uniform, but this pr also works.