### PR TITLE
chore: update workflows to skip stable29

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'master', 'stable31', 'stable30', 'stable29']
+        branches: ['main', 'master', 'stable31', 'stable30']
 
     name: npm-audit-fix-${{ matrix.branches }}
 

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'master', 'stable31', 'stable30', 'stable29']
+        branches: ['main', 'master', 'stable31', 'stable30']
 
     name: update-nextcloud-ocp-${{ matrix.branches }}
 


### PR DESCRIPTION
Update workflows to skip PRs from dependabot for stable29 as it's EOL.