### PR TITLE
fix:allow foreign label deletion

### DIFF
--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -652,9 +652,6 @@ class CardService {
 			throw new StatusException('Operation not allowed. This card is archived.');
 		}
 		$label = $this->labelMapper->find($labelId);
-		if ($label->getBoardId() !== $this->cardMapper->findBoardId($card->getId())) {
-			throw new StatusException('Operation not allowed. Label does not exist.');
-		}
 		$this->cardMapper->removeLabel($cardId, $labelId);
 		$this->changeHelper->cardChanged($cardId);
 		$this->activityManager->triggerEvent(ActivityManager::DECK_OBJECT_CARD, $card, ActivityManager::SUBJECT_LABEL_UNASSING, ['label' => $label]);

--- a/tests/unit/Service/CardServiceTest.php
+++ b/tests/unit/Service/CardServiceTest.php
@@ -475,9 +475,6 @@ class CardServiceTest extends TestCase {
 		$label->setBoardId(1);
 		$this->cardMapper->expects($this->once())->method('find')->willReturn($card);
 		$this->cardMapper->expects($this->once())->method('removeLabel');
-		$this->cardMapper->expects($this->once())
-			->method('findBoardId')
-			->willReturn(1);
 		$this->labelMapper->expects($this->once())
 			->method('find')
 			->willReturn($label);


### PR DESCRIPTION
this check prevented labels from being transferred on card move, as the old label must be deleted.

The repair Step in LabelMismatchCleanup.php works for all the previously false applied labels.