### PR TITLE
[Enhancement] Added events for Stack actions which can be hooked into

### DIFF
--- a/lib/Event/AStackEvent.php
+++ b/lib/Event/AStackEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Deck\Event;
+
+use OCA\Deck\Db\Stack;
+use OCP\EventDispatcher\Event;
+
+abstract class AStackEvent extends Event {
+	private Stack $stack;
+
+	public function __construct(Stack $stack) {
+		parent::__construct();
+
+		$this->stack = $stack;
+	}
+
+	public function getStack(): Stack {
+		return $this->stack;
+	}
+}

--- a/lib/Event/StackCreatedEvent.php
+++ b/lib/Event/StackCreatedEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Deck\Event;
+
+class StackCreatedEvent extends AStackEvent {
+}

--- a/lib/Event/StackDeletedEvent.php
+++ b/lib/Event/StackDeletedEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Deck\Event;
+
+class StackDeletedEvent extends AStackEvent {
+}

--- a/lib/Event/StackUpdatedEvent.php
+++ b/lib/Event/StackUpdatedEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Deck\Event;
+
+use OCA\Deck\Db\Stack;
+
+class StackUpdatedEvent extends AStackEvent {
+	private ?Stack $stackBefore;
+
+	public function __construct(Stack $stack, ?Stack $before = null) {
+		parent::__construct($stack);
+
+		$this->stackBefore = $before;
+	}
+
+	public function getBefore(): ?Stack {
+		return $this->stackBefore;
+	}
+}


### PR DESCRIPTION
* Resolves part of: #7147
* Target version: main

### Summary

Added multiple events for Stacks with the app. We can easily hook into the events when the stacks are updated.

Left the event dispatch for the board within the actions to keep it backwards compatible. Might be a argument to remove them now or later.

### TODO

- [x] Add events for the different type of actions in "StackService"
- [x] Dispatch the correct events within the correct actions in "StackService"

### Checklist

- [ ] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
