### PR TITLE
fix: parse arguments to CardService.reorder correctly to int

### DIFF
--- a/lib/Controller/CardApiController.php
+++ b/lib/Controller/CardApiController.php
@@ -185,7 +185,7 @@ class CardApiController extends ApiController {
 	 * Reorder cards
 	 */
 	public function reorder($stackId, $order) {
-		$card = $this->cardService->reorder($this->request->getParam('cardId'), $stackId, $order);
+		$card = $this->cardService->reorder((int)$this->request->getParam('cardId'), (int)$stackId, (int)$order);
 		return new DataResponse($card, HTTP::STATUS_OK);
 	}
 }

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -439,7 +439,7 @@ class CardService {
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 * @throws BadRequestException
 	 */
-	public function reorder($id, $stackId, $order) {
+	public function reorder(int $id, int $stackId, int $order) {
 		$this->cardServiceValidator->check(compact('id', 'stackId', 'order'));
 
 		$this->permissionService->checkPermission($this->cardMapper, $id, Acl::PERMISSION_EDIT);


### PR DESCRIPTION
* Resolves: #6960 #6830 
* Target version: main

### Summary

This correctly casts cardId and stackId (and order, just for consistency) into `integers` in CardService.reorder, no matter where CardService.reorder is called from.  This fixes the call from CardApiController.reorder, because it passes cardId and stackId as strings.  I've seen other places where there is no type cast applied, but it seems it is not an issue most of the time when no identity operator `===` or `!==` is used. Reorder does use it, so that is why it broke. 

The type casting currently is a little bit inconsistent:  There is everything from relying on php's implicit type casts from type defs in function parameters, to explicit type casting or none at all, but I was too afraid to touch it, as it might break things. So I kept my change minimal. 

Tested this from the native client by modifying the URL in CardApi.reorder: 

```js
	reorderCard(card) {
		return axios.put(this.url(`/api/v1.0/boards/$YOUR_BOARD_ID_HARDCODED/stacks/${card.stackId}/cards/${card.id}/reorder`), card)
			.then(
				(response) => {
					return Promise.resolve(response.data)
				},
				(err) => {
					return Promise.reject(err)
				},
			)
			.catch((err) => {
				return Promise.reject(err)
			})
	}
```

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
