### PR TITLE
fix: do not change focus when card id stays the same

### DIFF
--- a/src/components/card/CardSidebar.vue
+++ b/src/components/card/CardSidebar.vue
@@ -178,7 +178,8 @@ export default {
 		},
 	},
 	watch: {
-		currentCard() {
+		currentCard(newCard, oldCard) {
+			if (newCard.id === oldCard.id) return
 			this.focusHeader()
 		},
 		'currentCard.title': {


### PR DESCRIPTION
* Resolves: #6528 
* Target version: main

### Summary
the notify_push sends updates when anything on the board changes triggering the watch hook as well.
We should not focus the header when the card id has not actually changed.


### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
