### PR TITLE
perf(stack): Optimize fetching all cards from a stack

### DIFF
--- a/lib/Service/StackService.php
+++ b/lib/Service/StackService.php
@@ -82,7 +82,7 @@ class StackService {
 			return;
 		}
 
-		$stack->setCards($this->cardService->enrichCards($cards));
+		$stack->setCards($this->cardService->enrichCards($cards, $stack));
 	}
 
 	private function enrichStacksWithCards($stacks, $since = -1) {


### PR DESCRIPTION
- Don't fetch stack, if we already know it
- fetch all comments at the same time, instead of for each card

Requires https://github.com/nextcloud/server/pull/54409

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
