### PR TITLE
Clean attachment sharing records after permanent deleted

### DIFF
--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -645,4 +645,16 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 
 		$result->closeCursor();
 	}
+
+	public function getAllCardIds(): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('id')
+			->from('deck_cards');
+		$result = $qb->executeQuery();
+		$ids = [];
+		while ($row = $result->fetch()) {
+			$ids[] = (int)$row['id'];
+		}
+		return $ids;
+	}
 }

--- a/lib/Sharing/DeckShareProvider.php
+++ b/lib/Sharing/DeckShareProvider.php
@@ -1046,4 +1046,21 @@ class DeckShareProvider implements \OCP\Share\IShareProvider {
 		}
 		$cursor->closeCursor();
 	}
+
+	public function getOrphanedAttachmentShares(): array {
+		$allCardIds = $this->cardMapper->getAllCardIds();
+		$qb = $this->dbConnection->getQueryBuilder();
+		$qb->select('*')
+			->from('share', 's')
+			->where($qb->expr()->eq('s.share_type', $qb->createNamedParameter(IShare::TYPE_DECK)))
+			->andWhere($qb->expr()->notIn('s.share_with', $qb->createNamedParameter($allCardIds, IQueryBuilder::PARAM_STR_ARRAY)));
+
+		$cursor = $qb->execute();
+		$shares = [];
+		while ($data = $cursor->fetch()) {
+			$shares[] = $this->createShareObject($data);
+		}
+
+		return $shares;
+	}
 }

--- a/tests/unit/Cron/DeleteCronTest.php
+++ b/tests/unit/Cron/DeleteCronTest.php
@@ -35,6 +35,7 @@ use OCA\Deck\Db\StackMapper;
 use OCA\Deck\InvalidAttachmentType;
 use OCA\Deck\Service\AttachmentService;
 use OCA\Deck\Service\IAttachmentService;
+use OCA\Deck\Sharing\DeckShareProvider;
 use OCP\AppFramework\Utility\ITimeFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
@@ -53,6 +54,8 @@ class DeleteCronTest extends TestCase {
 	private $attachmentMapper;
 	/** @var StackMapper|MockObject */
 	private $stackMapper;
+	/** @var DeckShareProvider */
+	private $deckShareProvider;
 	/** @var DeleteCron */
 	protected $deleteCron;
 
@@ -64,7 +67,16 @@ class DeleteCronTest extends TestCase {
 		$this->attachmentService = $this->createMock(AttachmentService::class);
 		$this->attachmentMapper = $this->createMock(AttachmentMapper::class);
 		$this->stackMapper = $this->createMock(StackMapper::class);
-		$this->deleteCron = new DeleteCron($this->timeFactory, $this->boardMapper, $this->cardMapper, $this->attachmentService, $this->attachmentMapper, $this->stackMapper);
+		$this->deckShareProvider = $this->createMock(DeckShareProvider::class);
+		$this->deleteCron = new DeleteCron(
+			$this->timeFactory,
+			$this->boardMapper,
+			$this->cardMapper,
+			$this->attachmentService,
+			$this->attachmentMapper,
+			$this->stackMapper,
+			$this->deckShareProvider,
+		);
 	}
 
 	protected function getBoard($id) {


### PR DESCRIPTION
* Resolves: #7176
* Target version: main

### Summary
Clear related attachment sharing records of deleted cards after permanently deleting cards in background job DeleteCron


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
