### PR TITLE
fix: resolve MySQL Error 1093 when deleting users from boards

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,6 +6,7 @@
 
 - Adrian Missy <adrian.missy@onewavestudios.com>
 - Alexandru Puiu <alexpuiu20@yahoo.com>
+- Arne Bartelt <arne.bartelt@gmail.com>
 - Chandi Langecker <git@chandi.it>
 - Christoph Wurst <christoph@winzerhof-wurst.at>
 - Gary Kim <gary@garykim.dev>


### PR DESCRIPTION
Should fixes #7125 and #7069 by implementing a two-step deletion process that avoids MySQL's restriction on deleting from a table while selecting from it in a subquery.

The fix separates the `SELECT` and `DELETE` operations:
1. First query: Get card IDs for assignments to delete
2. Second query: Delete assignments using the collected IDs

This approach works on  database systems (MySQL 8.0+, MariaDB 10.x+) and follows MySQL's official best practices for handling Error 1093: 'You can't specify target table for update in FROM clause'. 

The issue occurred because the original [`deleteByParticipantOnBoard()`](https://github.com/nextcloud/deck/blob/main/lib/Db/AssignmentMapper.php#L79-L92) method used a subquery that referenced the same table being deleted from, which [MySQL prohibits](https://dev.mysql.com/doc/refman/8.0/en/delete.html)(Subqueries) but MariaDB allows (explaining why it worked in development but failed in production). 

* Resolves: #7125 #7069
* Target version: main

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included -> also needed here? 
- [x] Documentation (manuals or wiki) has been updated or is not required -> should not be needed.
