### PR TITLE
fix: Fix colors from due dates and done

### DIFF
--- a/src/components/cards/CardBadges.vue
+++ b/src/components/cards/CardBadges.vue
@@ -131,42 +131,6 @@ export default {
 		height: var(--default-clickable-area);
 	}
 
-	.badges .icon.due {
-		background-position: 4px center;
-		border-radius: var(--border-radius);
-		padding: 4px;
-		font-size: 13px;
-		display: flex;
-		align-items: center;
-		opacity: .5;
-		flex-shrink: 1;
-
-		.icon {
-			background-size: contain;
-		}
-
-		&.overdue {
-			background-color: var(--color-error);
-			color: var(--color-primary-element-text);
-			opacity: .7;
-		}
-		&.now {
-			background-color: var(--color-warning);
-			opacity: .7;
-		}
-		&.next {
-			background-color: var(--color-background-dark);
-			opacity: .7;
-		}
-
-		span {
-			margin-left: 20px;
-			white-space: nowrap;
-			text-overflow: ellipsis;
-			overflow: hidden;
-		}
-	}
-
 	.badge-left, .badge-right {
 		display: flex;
 	}

--- a/src/components/cards/badges/DueDate.vue
+++ b/src/components/cards/badges/DueDate.vue
@@ -95,16 +95,16 @@ export default {
 		z-index: 2;
 
 		[data-due-state='Overdue'] & {
-			color: var(--color-error-text);
-			background-color: rgba(var(--color-error-rgb), .1);
+			color: var(--color-element-error, var(--color-error-text));
+			background-color: rgba(var(--color-error-rgb), .5);
 		}
 		[data-due-state='Now'] & {
-			color: var(--color-warning-text);
-			background-color: rgba(var(--color-warning-rgb), .1);
+			color: var(--color-element-warning, var(--color-warning-text));
+			background-color: rgba(var(--color-warning-rgb), .5);
 		}
 		[data-due-state='Done'] & {
-			color: var(--color-success-text);
-			background-color: rgba(var(--color-success-rgb), .1);
+			color: var(--color-element-success, var(--color-success-text));
+			background-color: rgba(var(--color-success-rgb), .5);
 		}
 
 		.due--label {


### PR DESCRIPTION
* Resolves: #7207
* Target version: main

Nextcloud 31 | Before | After
---|---|---
<img width="405" height="422" alt="image" src="https://github.com/user-attachments/assets/19895367-0dfc-4c1a-88ca-235998d507df" /> | <img width="405" height="422" alt="Bildschirmfoto vom 2025-09-16 14-47-24" src="https://github.com/user-attachments/assets/621a30ff-a826-4918-a99d-45439fe5d7b6" /> | <img width="405" height="422" alt="Bildschirmfoto vom 2025-09-16 14-47-08" src="https://github.com/user-attachments/assets/80d9b670-53eb-4530-aeb4-25f17211aa6b" />
<img width="405" height="315" alt="image" src="https://github.com/user-attachments/assets/bd7e1466-d696-41bb-ac00-c80fabd0c2c0" /> | <img width="405" height="315" alt="Bildschirmfoto vom 2025-09-16 14-50-09" src="https://github.com/user-attachments/assets/414176f3-ee9b-4018-a569-6569a03c432d" /> | <img width="405" height="315" alt="Bildschirmfoto vom 2025-09-16 14-49-59" src="https://github.com/user-attachments/assets/e9eab19c-6b70-41c9-b587-e7d619c70c1f" />
<img width="405" height="422" alt="image" src="https://github.com/user-attachments/assets/0aff69b9-f795-446a-aeb6-09fe36ec7fe0" /> | <img width="405" height="422" alt="image" src="https://github.com/user-attachments/assets/8b46dbd8-4094-40eb-afb9-88fbb07052b6" /> | <img width="405" height="422" alt="image" src="https://github.com/user-attachments/assets/11f2d1c9-e967-48f7-9514-722b786926d3" />
<img width="405" height="296" alt="Bildschirmfoto vom 2025-09-16 14-35-34" src="https://github.com/user-attachments/assets/aeac8bc7-a591-444a-8268-b3701e49d0a0" /> | <img width="405" height="296" alt="Bildschirmfoto vom 2025-09-16 14-36-49" src="https://github.com/user-attachments/assets/4803f51d-999c-49f5-9403-076ea1ec00b9" /> | <img width="405" height="296" alt="Bildschirmfoto vom 2025-09-16 14-35-27" src="https://github.com/user-attachments/assets/84e5808d-36f4-44c5-b0ed-a1263ba507b3" />


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
