### PR TITLE
fix(darkmode): Fix activity icon colors

### DIFF
--- a/src/components/ActivityEntry.vue
+++ b/src/components/ActivityEntry.vue
@@ -6,7 +6,7 @@
 <template>
 	<div v-if="activity" class="activity">
 		<div class="activity--header">
-			<img :src="activity.icon" class="activity--icon">
+			<img :src="activity.icon" class="activity--icon" :class="applyMonochromeIconColor">
 			<NcRichText class="activity--subject" :text="message.subject" :arguments="message.parameters" />
 			<div class="activity--timestamp" :name="formatReadableDate(activity.datetime)">
 				{{ relativeDate(activity.datetime) }}
@@ -94,6 +94,15 @@ export default {
 			}
 		},
 
+		applyMonochromeIconColor() {
+			// copied from https://github.com/nextcloud/activity/blob/db919d45c45356082b17104614018e2c7e691996/js/script.js#L225
+			const monochromeIcon = this.activity.type !== 'file_created' && this.activity.type !== 'file_deleted' && this.activity.type !== 'favorite' && !this.activity.icon.endsWith('-color.svg')
+			if (monochromeIcon) {
+				return 'monochrome'
+			}
+			return ''
+		},
+
 		sanitizedMessage() {
 			return DOMPurify.sanitize(this.activity.message, { ALLOWED_TAGS: ['ins', 'del'], ALLOWED_ATTR: ['class'] })
 		},
@@ -115,6 +124,12 @@ export default {
 			height: 16px;
 			flex-shrink: 0;
 			flex-grow: 0;
+
+			/* colored icons, in addition to core ones */
+			&.monochrome {
+				opacity: 0.8;
+				filter: var(--background-invert-if-dark);
+			}
 		}
 		.activity--subject {
 			margin-left: 10px;


### PR DESCRIPTION
- Copied from https://github.com/nextcloud/activity/blob/e3087f23c417155d44a7d3a3b0320b00ef8481c1/src/components/activities/GenericActivity.vue#L121-L128

Before | After
---|---
<img width="1112" height="518" alt="Bildschirmfoto vom 2025-09-16 15-18-23" src="https://github.com/user-attachments/assets/c1aff643-f4a0-4e88-ad1e-c82355f004fc" /> | <img width="1112" height="518" alt="Bildschirmfoto vom 2025-09-16 15-17-25" src="https://github.com/user-attachments/assets/de68aa2b-6c21-43d9-831a-888f82e8c701" />

Copied from https://github.com/nextcloud/activity/blob/e3087f23c417155d44a7d3a3b0320b00ef8481c1/src/components/activities/GenericActivity.vue#L121-L128

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
