### PR TITLE
Fix: Prevent error in Whiteboard when adding a Deckboard

### DIFF
--- a/src/components/board/Board.vue
+++ b/src/components/board/Board.vue
@@ -179,7 +179,7 @@ export default {
 				await this.$store.dispatch('loadBoardById', this.id)
 				await this.$store.dispatch('loadStacks', this.id)
 
-				const routeCardId = parseInt(this.$route.params.cardId)
+				const routeCardId = this.$route?.params?.cardId ? parseInt(this.$route.params.cardId) : null
 				// If an archived card is requested, and we cannot find it in the current we load the archived stacks instead
 				if (routeCardId && !this.$store.getters.cardById(routeCardId)) {
 					await this.$store.dispatch('loadArchivedStacks', this.id)


### PR DESCRIPTION
* Resolves: https://support.nextcloud.com/#ticket/zoom/85996
* Target version: main

### Summary
#### Problem
Embedding a Deck board (Vue + Vue Router) inside the Whiteboard app (React) caused a runtime error. The Deck component attempted to access `this.$route.params.cardId` during initialization — but when running inside Whiteboard, there’s no Vue Router context, so `this.$route` was undefined, triggering:
`TypeError: can't access property "params", this.$route is undefined`

#### Root Cause
In `Board.vue`, the `fetchData()` method runs in the `created()` hook and directly references `this.$route.params.cardId`. This works in the full Deck app but fails when embedded.

#### Solution
Added optional chaining to safely access route data:
`const routeCardId = this.$route?.params?.cardId ? parseInt(this.$route.params.cardId) : null`

- In Deck (with router): normal behavior, card ID loads from URL
- In Whiteboard (no router): returns null, preventing the error

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
