### PR TITLE
fix: Can't add or modify comment when mentioning user because parentNode returns null

### DIFF
--- a/src/components/card/CommentForm.vue
+++ b/src/components/card/CommentForm.vue
@@ -123,7 +123,7 @@ export default {
 				// FIXME user names can contain spaces, in that case they need to be wrapped @"user name" [a-zA-Z0-9\ _\.@\-']+
 				let mentionValue
 				if (mention.attributes['data-at-embedded'].value === 'true') {
-					mentionValue = mention.parentNode.parentNode.querySelector('.user-bubble__wrapper').attributes['data-mention-id'].value
+					mentionValue = mention.parentNode.querySelector('.user-bubble__wrapper').attributes['data-mention-id'].value
 				} else {
 					mentionValue = mention.firstChild.attributes['data-mention-id'].value
 				}


### PR DESCRIPTION
* Resolves: #7340 
* Target version: main

### Summary
When requesting parentNode of "div.comment-form__contenteditable" we get null. Request only the first parent.

### Checklist

- [X] Code is properly formatted
- [X] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [X] Documentation (manuals or wiki) has been updated or is not required
