### PR TITLE
perf: Hide user status on avatars where they are not needed

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -122,7 +122,10 @@
 									class="checkbox"
 									:value="user.uid"
 									@change="setFilter">
-								<label :for="user.uid"><NcAvatar :user="user.uid" :size="24" :disable-menu="true" /> {{ user.displayname }}</label>
+								<label :for="user.uid"><NcAvatar :user="user.uid"
+									:size="24"
+									:disable-menu="true"
+									:hide-status="true" /> {{ user.displayname }}</label>
 							</div>
 
 							<h3>{{ t('deck', 'Filter by status') }}</h3>

--- a/src/components/SessionList.vue
+++ b/src/components/SessionList.vue
@@ -13,7 +13,7 @@
 			<NcAvatar :user="session.uid"
 				:display-name="session.displayname"
 				:disable-menu="true"
-				:show-user-status="false"
+				:hide-status="true"
 				:disable-tooltip="true"
 				:size="size" />
 		</div>

--- a/src/components/boards/BoardItem.vue
+++ b/src/components/boards/BoardItem.vue
@@ -16,10 +16,14 @@
 			{{ board.title }}
 		</div>
 		<div class="board-list-avatars-cell" title="">
-			<NcAvatar :user="board.owner.uid" :display-name="board.owner.displayname" class="board-list-avatar" />
+			<NcAvatar :user="board.owner.uid"
+				:display-name="board.owner.displayname"
+				class="board-list-avatar"
+				:hide-status="true" />
 			<NcAvatar v-for="user in limitedAcl"
 				:key="user.id"
 				:user="user.participant.uid"
+				:hide-status="true"
 				:display-name="user.participant.displayname"
 				class="board-list-avatar" />
 			<div v-if="board.acl.length > 5" :title="otherAcl" class="avatardiv popovermenu-wrapper board-list-avatar icon-more" />

--- a/src/components/cards/AvatarList.vue
+++ b/src/components/cards/AvatarList.vue
@@ -17,7 +17,7 @@
 								:user="user.participant.uid"
 								:display-name="user.participant.displayname"
 								:disable-menu="true"
-								:show-user-status="false"
+								:hide-status="true"
 								:size="32" />
 							<NcAvatar v-if="user.type === 1"
 								:user="user.participant.uid"
@@ -42,6 +42,7 @@
 						class="avatar-list-entry">
 						<NcAvatar :user="user.participant.uid"
 							:display-name="user.participant.displayname"
+							:hide-status="true"
 							:disable-menu="true"
 							:is-no-user="user.type !== 0"
 							:size="32" />
@@ -59,6 +60,7 @@
 					:user="user.participant.uid"
 					:display-name="user.participant.displayname"
 					:disable-menu="true"
+					:hide-status="true"
 					:is-no-user="user.type !== 0"
 					:size="24" />
 				{{ user.participant.displayname }}


### PR DESCRIPTION
### Summary

We do not need the user status on the board list and board view when rendering avatars.
For comments and the card details view I kept them for now to also be in line with files comments.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included -> Nothing we should test on our end
- [x] Documentation (manuals or wiki) has been updated or is not required
