### PR TITLE
fix: view mode menu when open archived card by url

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -315,7 +315,6 @@ export default {
 			newStackTitle: '',
 			stack: '',
 			filterVisible: false,
-			showArchived: false,
 			isAddStackVisible: false,
 			filter: { tags: [], users: [], due: '', unassigned: false, completed: 'both' },
 			showAddCardModal: false,
@@ -334,6 +333,7 @@ export default {
 			compactMode: state => state.compactMode,
 			showCardCover: state => state.showCardCover,
 			searchQuery: state => state.searchQuery,
+			showArchived: state => state.showArchived,
 		}),
 		detailsRoute() {
 			return {
@@ -408,7 +408,6 @@ export default {
 		},
 		toggleShowArchived() {
 			this.$store.dispatch('toggleShowArchived')
-			this.showArchived = !this.showArchived
 		},
 		addNewStack() {
 			this.stack = { title: this.newStackTitle }


### PR DESCRIPTION
* Resolves: #7404
* Target version: main

### Summary
Fix wrong view mode menu when open archived card directly by URL


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
