### PR TITLE
Fix board renaming and color picker in board navigation

### DIFF
--- a/src/components/navigation/AppNavigationBoard.vue
+++ b/src/components/navigation/AppNavigationBoard.vue
@@ -129,7 +129,7 @@
 		</template>
 	</NcAppNavigationItem>
 	<div v-else-if="editing" class="board-edit">
-		<NcColorPicker class="app-navigation-entry-bullet-wrapper" :value="`#${board.editColor}`" @update:value="updateColor">
+		<NcColorPicker class="app-navigation-entry-bullet-wrapper" :value="`#${board.color}`" @update:value="updateColor">
 			<div :style="{ backgroundColor: getColor }" class="color0 icon-colorpicker app-navigation-entry-bullet" />
 		</NcColorPicker>
 		<form @submit.prevent="applyEdit">


### PR DESCRIPTION
* Resolves: #7425
* Target version: main

### Summary

When renaming the board in the board navigation and submitting with the Enter key, the changes are saved instead of being dismissed. Additionally, the color picker now works again.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
