### PR TITLE
Redirect user to overview page after deleting or leaving a board

### DIFF
--- a/src/components/navigation/AppNavigationBoard.vue
+++ b/src/components/navigation/AppNavigationBoard.vue
@@ -334,6 +334,7 @@ export default {
 							.then(() => {
 								this.loading = false
 								this.deleted = true
+								this.redirectToOverviewIfCurrentBoard()
 								this.undoTimeoutHandle = setTimeout(() => {
 									this.$store.dispatch('removeBoard', this.board)
 								}, 7000)
@@ -359,6 +360,7 @@ export default {
 						this.boardApi.leaveBoard(this.board)
 							.then(() => {
 								this.loading = false
+								this.redirectToOverviewIfCurrentBoard()
 								this.$store.dispatch('removeBoard', this.board)
 							})
 							.catch(() => {
@@ -434,6 +436,12 @@ export default {
 					OC.Notification.showTemporary(t('deck', 'An error occurred'))
 					console.error(e)
 				}
+			}
+		},
+		redirectToOverviewIfCurrentBoard() {
+			const currentBoardId = Number.parseInt(this.$route?.params?.id, 10)
+			if (!Number.isNaN(currentBoardId) && currentBoardId === this.board.id) {
+				this.$router.push({ name: 'main' })
 			}
 		},
 	},


### PR DESCRIPTION
* Resolves: #7426
* Target version: main

### Summary

Redirect user to overview page after deleting or leaving a board.

https://github.com/user-attachments/assets/bbc7254f-3b57-41c4-a752-30b7858ba484

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
