### PR TITLE
Focus input field when executing

### DIFF
--- a/src/components/navigation/AppNavigationBoard.vue
+++ b/src/components/navigation/AppNavigationBoard.vue
@@ -294,6 +294,9 @@ export default {
 			this.editTitle = this.board.title
 			this.editColor = '#' + this.board.color
 			this.editing = true
+			this.$nextTick(() => {
+				this.$refs?.inputField.focus()
+			})
 		},
 		async actionClone() {
 			this.loading = true


### PR DESCRIPTION
* Resolves: #7443 
* Target version: main

### Summary
Focuses the text input field when clicking on the 'Edit board' action in the three-dot menu.

https://github.com/user-attachments/assets/8c166281-030a-4816-8b6c-f69a796d48e9

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
