### PR TITLE
Fix: Make color picker keyboard-focusable

### DIFF
--- a/src/components/navigation/AppNavigationAddBoard.vue
+++ b/src/components/navigation/AppNavigationAddBoard.vue
@@ -10,7 +10,7 @@
 			@click.prevent.stop="startCreateBoard" />
 		<div v-else class="board-create">
 			<NcColorPicker v-model="color" class="app-navigation-entry-bullet-wrapper" :disabled="loading">
-				<div :style="{ backgroundColor: color }" class="color0 icon-colorpicker app-navigation-entry-bullet" />
+				<button :style="{ backgroundColor: color }" class="color0 icon-colorpicker app-navigation-entry-bullet" />
 			</NcColorPicker>
 			<form @submit.prevent.stop="createBoard">
 				<NcTextField ref="inputField"
@@ -117,8 +117,9 @@ export default {
 		height: var(--default-clickable-area);
 		.color0 {
 			width: 24px !important;
-			margin: var(--default-grid-baseline);
 			height: 24px;
+			min-height: 0;
+			margin: var(--default-grid-baseline);
 			border-radius: 50%;
 			background-size: 14px;
 		}

--- a/src/components/navigation/AppNavigationBoard.vue
+++ b/src/components/navigation/AppNavigationBoard.vue
@@ -131,7 +131,7 @@
 		</NcAppNavigationItem>
 		<div v-else-if="editing" class="board-edit">
 			<NcColorPicker v-model="editColor" class="app-navigation-entry-bullet-wrapper">
-				<div :style="{ backgroundColor: getColor }" class="color0 icon-colorpicker app-navigation-entry-bullet" />
+				<button :style="{ backgroundColor: getColor }" class="color0 icon-colorpicker app-navigation-entry-bullet" />
 			</NcColorPicker>
 			<form @submit.prevent.stop="applyEdit">
 				<NcTextField ref="inputField"
@@ -472,8 +472,9 @@ export default {
 		height: var(--default-clickable-area);
 		.color0 {
 			width: 24px !important;
-			margin: var(--default-grid-baseline);
 			height: 24px;
+			min-height: 0;
+			margin: var(--default-grid-baseline);
 			border-radius: 50%;
 			background-size: 14px;
 		}


### PR DESCRIPTION
* Resolves: #7445 
* Target version: main

### Summary
The color picker used a `div` element as the open button which can normally not be focused. I replaced the `div` with a native `button` and adjusted the styling so that the button stays round.

https://github.com/user-attachments/assets/d6b01b6b-b315-4955-827c-b63dfde4af3f

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
