### PR TITLE
Fix: update NcColorPicker event binding to use @update:value

### DIFF
--- a/src/components/board/TagsTabSidebar.vue
+++ b/src/components/board/TagsTabSidebar.vue
@@ -12,7 +12,7 @@
 						<NcColorPicker class="color-picker-wrapper"
 							:value="'#' + editingLabel.color"
 							:advanced-fields="true"
-							@input="updateColor">
+							@update:value="updateColor">
 							<div :style="{ backgroundColor: '#' + editingLabel.color }" class="color0 icon-colorpicker" />
 						</NcColorPicker>
 						<input v-model="editingLabel.title" type="text">

--- a/src/components/navigation/AppNavigationBoard.vue
+++ b/src/components/navigation/AppNavigationBoard.vue
@@ -130,7 +130,7 @@
 			</template>
 		</NcAppNavigationItem>
 		<div v-else-if="editing" class="board-edit">
-			<NcColorPicker class="app-navigation-entry-bullet-wrapper" :value="`#${board.color}`" @input="updateColor">
+			<NcColorPicker class="app-navigation-entry-bullet-wrapper" :value="`#${board.color}`" @update:value="updateColor">
 				<div :style="{ backgroundColor: getColor }" class="color0 icon-colorpicker app-navigation-entry-bullet" />
 			</NcColorPicker>
 			<form @submit.prevent.stop="applyEdit">


### PR DESCRIPTION
* Resolves: #7449
* Target version: main

### Summary
Fix color picker event handlers for changing board and tag colors.

https://github.com/user-attachments/assets/5957e41f-15fe-4518-b852-8bb8be2cac27

TODO: The logic for changing the color of a new tag seems to be more complex.