### PR TITLE
[main] Fix: Do not render empty avatar list

### DIFF
--- a/src/components/cards/AvatarList.vue
+++ b/src/components/cards/AvatarList.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<div class="avatars">
+	<div v-if="users.length > 0" class="avatars">
 		<div>
 			<NcPopover>
 				<template #trigger="{ attrs }">


### PR DESCRIPTION
* Resolves: #7484
* Target version: main

### Summary
Do not render an empty avatar list / popover so that no gray rectangle appears on hover.

https://github.com/user-attachments/assets/725a3931-37d2-459b-a5d6-ef21da47d884