### PR TITLE
[main]: Clear value in new board dialog when a new board was created or the edit canceled

### DIFF
--- a/src/components/navigation/AppNavigationAddBoard.vue
+++ b/src/components/navigation/AppNavigationAddBoard.vue
@@ -88,10 +88,12 @@ export default {
 			this.loading = false
 			this.editing = false
 			this.color = randomColor()
+			this.value = ''
 		},
 		cancelEdit(e) {
 			this.editing = false
 			this.color = randomColor()
+			this.value = ''
 		},
 	},
 }


### PR DESCRIPTION
* Resolves: #7482
* Target version: main

### Summary
The value for the text input is now cleared after a new board is created or the editing is canceled. When clicking on the 'Add board' button again, an empty text input field is shown.

https://github.com/user-attachments/assets/de947f52-afe1-45a3-96af-4badac3be869

**Note:** I do not like how the existing code does not check if the `createBoard` action was successful. I think the current code now clears the input whether the network request was OK or not. A board title is not very much information to lose, but nonetheless not great UX. 