### PR TITLE
[main] Fix: Adding new tag creates a 'ghost' tag

### DIFF
--- a/src/components/card/CardSidebarTabDetails.vue
+++ b/src/components/card/CardSidebarTabDetails.vue
@@ -152,17 +152,23 @@ export default {
 		}, 500),
 
 		addLabelToCard(newLabel) {
-			this.copiedCard.labels.push(newLabel)
-			const data = {
-				card: this.copiedCard,
-				labelId: newLabel.id,
+			if (!newLabel?.id || !this.card?.id) {
+				return
 			}
-			this.$store.dispatch('addLabel', data)
+
+			this.$store.dispatch('addLabel', {
+				card: { id: this.card.id },
+				labelId: newLabel.id,
+			})
 		},
 
 		async addLabelToBoardAndCard(name) {
+			if (!name || !this.card?.id) {
+				return
+			}
+
 			await this.$store.dispatch('addLabelToCurrentBoardAndCard', {
-				card: this.copiedCard,
+				card: { id: this.card.id },
 				newLabel: {
 					title: name,
 					color: this.randomColor(),
@@ -171,18 +177,14 @@ export default {
 		},
 
 		removeLabelFromCard(removedLabel) {
-			const removeIndex = this.copiedCard.labels.findIndex((label) => {
-				return label.id === removedLabel.id
-			})
-			if (removeIndex !== -1) {
-				this.copiedCard.labels.splice(removeIndex, 1)
+			if (!removedLabel?.id || !this.card?.id) {
+				return
 			}
 
-			const data = {
-				card: this.copiedCard,
+			this.$store.dispatch('removeLabel', {
+				card: { id: this.card.id },
 				labelId: removedLabel.id,
-			}
-			this.$store.dispatch('removeLabel', data)
+			})
 		},
 		stringify(date) {
 			return moment(date).locale(this.locale).format('LLL')

--- a/src/components/card/TagSelector.vue
+++ b/src/components/card/TagSelector.vue
@@ -74,15 +74,31 @@ export default {
 		},
 	},
 	methods: {
-		onSelect(options) {
-			const addedLabel = options.filter(option => !this.card.labels.includes(option))
-			this.$emit('select', addedLabel[0])
+		onSelect(optionOrOptions) {
+			const option = Array.isArray(optionOrOptions)
+				? optionOrOptions[optionOrOptions.length - 1]
+				: optionOrOptions
+
+			if (!option || !option.id) {
+				return
+			}
+
+			this.$emit('select', option)
 		},
 		onRemove(removedLabel) {
+			if (!removedLabel || !removedLabel.id) {
+				return
+			}
+
 			this.$emit('remove', removedLabel)
 		},
 		async onNewTag(option) {
-			this.$emit('newtag', option.title)
+			const labelText = option?.title || option?.label
+			if (!labelText) {
+				return
+			}
+
+			this.$emit('newtag', labelText)
 		},
 	},
 }


### PR DESCRIPTION
* Resolves: #6680
* Target version: main

### Summary
 - Preventing ghost/duplicate tag pills by letting the tag selector emit only labels with ids and by using NcSelect’s tracked id to avoid placeholder options. However, the user has to wait for the server to create a new tag and send it back to the client before it is getting rendered in the browser. This will result in a small delay before the new tag appears.
- Removed Vuex strict-mode warnings.

### Screencasts

**Before:**

https://github.com/user-attachments/assets/c75f1150-8b35-4c74-af7d-7b43c3d36092

**After:**

https://github.com/user-attachments/assets/96256af5-19e5-44e7-8c00-4242d1bea393
