### PR TITLE
[main] Fix: Board cannot be undeleted

### DIFF
--- a/lib/Service/BoardService.php
+++ b/lib/Service/BoardService.php
@@ -246,7 +246,7 @@ class BoardService {
 	public function deleteUndo(int $id): Board {
 		$this->boardServiceValidator->check(compact('id'));
 
-		$this->permissionService->checkPermission($this->boardMapper, $id, Acl::PERMISSION_MANAGE);
+		$this->permissionService->checkPermission($this->boardMapper, $id, Acl::PERMISSION_MANAGE, allowDeletedBoard: true);
 		$board = $this->find($id, allowDeleted: true);
 		$board->setDeletedAt(0);
 		$board = $this->boardMapper->update($board);
@@ -265,7 +265,7 @@ class BoardService {
 	public function deleteForce(int $id): Board {
 		$this->boardServiceValidator->check(compact('id'));
 
-		$this->permissionService->checkPermission($this->boardMapper, $id, Acl::PERMISSION_MANAGE);
+		$this->permissionService->checkPermission($this->boardMapper, $id, Acl::PERMISSION_MANAGE, allowDeletedBoard: true);
 		$board = $this->find($id, allowDeleted: true);
 		$delete = $this->boardMapper->delete($board);
 


### PR DESCRIPTION
* Resolves: #7506 
* Target version: main

Related to: [#3534](https://github.com/nextcloud/deck/issues/3534)

### Summary
On `main` (and maybe other branches/versions), the undelete action is broken. The web endpoint returns a `403 Permission denied` error. 

This is because the `PermissionService::getBoard()` method is called without the allowDeleted parameter (it defaults to false), and, thus, throws a `DoesNotExistException` error. This error is then caught in `PermissionService::getPermissions()`, setting both `$owner = false` and `$acls = []`. This results in all permissions being false.

This pull request adds an optional `allowDeleted` parameter to relevant functions.

### Screencast

https://github.com/user-attachments/assets/ff2fee69-ad0e-415c-95bd-6ac02b5c4809
