### PR TITLE
chore: remove deprecated setAccessible

### DIFF
--- a/lib/Service/Importer/BoardImportService.php
+++ b/lib/Service/Importer/BoardImportService.php
@@ -106,11 +106,9 @@ class BoardImportService {
 			return;
 		}
 		$propertyEventHandlers = new \ReflectionProperty($this->commentsManager, 'eventHandlers');
-		$propertyEventHandlers->setAccessible(true);
 		$propertyEventHandlers->setValue($this->commentsManager, []);
 
 		$propertyEventHandlerClosures = new \ReflectionProperty($this->commentsManager, 'eventHandlerClosures');
-		$propertyEventHandlerClosures->setAccessible(true);
 		$propertyEventHandlerClosures->setValue($this->commentsManager, []);
 	}
 

--- a/tests/unit/Activity/ActivityManagerTest.php
+++ b/tests/unit/Activity/ActivityManagerTest.php
@@ -503,7 +503,6 @@ class ActivityManagerTest extends TestCase {
 	public function invokePrivate(&$object, $methodName, array $parameters = []) {
 		$reflection = new \ReflectionClass(get_class($object));
 		$method = $reflection->getMethod($methodName);
-		$method->setAccessible(true);
 		return $method->invokeArgs($object, $parameters);
 	}
 }

--- a/tests/unit/Activity/DeckProviderTest.php
+++ b/tests/unit/Activity/DeckProviderTest.php
@@ -516,7 +516,6 @@ class DeckProviderTest extends TestCase {
 	public function invokePrivate(&$object, $methodName, array $parameters = []) {
 		$reflection = new \ReflectionClass(get_class($object));
 		$method = $reflection->getMethod($methodName);
-		$method->setAccessible(true);
 		return $method->invokeArgs($object, $parameters);
 	}
 }

--- a/tests/unit/Listeners/CommentEventListenerTest.php
+++ b/tests/unit/Listeners/CommentEventListenerTest.php
@@ -104,7 +104,6 @@ class CommentEventListenerTest extends TestCase {
 	public function invokePrivate(&$object, $methodName, array $parameters = []) {
 		$reflection = new \ReflectionClass(get_class($object));
 		$method = $reflection->getMethod($methodName);
-		$method->setAccessible(true);
 		return $method->invokeArgs($object, $parameters);
 	}
 }


### PR DESCRIPTION
setAccessible is deprecated with php8.5 and has no effect since php8.1
so we should remove it's usage.
https://www.php.net/manual/en/reflectionproperty.setaccessible.php