### PR TITLE
feat: Add support for Automation

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -41,6 +41,12 @@ return [
 		['name' => 'stack#deleted', 'url' => '/{boardId}/stacks/deleted', 'verb' => 'GET'],
 		['name' => 'stack#archived', 'url' => '/stacks/{boardId}/archived', 'verb' => 'GET'],
 
+		// stack automations
+		['name' => 'stack_automation#index', 'url' => '/stacks/{stackId}/automations', 'verb' => 'GET'],
+		['name' => 'stack_automation#create', 'url' => '/stacks/{stackId}/automations', 'verb' => 'POST'],
+		['name' => 'stack_automation#update', 'url' => '/automations/{id}', 'verb' => 'PUT'],
+		['name' => 'stack_automation#delete', 'url' => '/automations/{id}', 'verb' => 'DELETE'],
+
 		// cards
 		['name' => 'card#read', 'url' => '/cards/{cardId}', 'verb' => 'GET'],
 		['name' => 'card#create', 'url' => '/cards', 'verb' => 'POST'],

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -29,6 +29,7 @@ use OCA\Deck\Event\SessionClosedEvent;
 use OCA\Deck\Event\SessionCreatedEvent;
 use OCA\Deck\Listeners\AclCreatedRemovedListener;
 use OCA\Deck\Listeners\BeforeTemplateRenderedListener;
+use OCA\Deck\Listeners\CardAutomationListener;
 use OCA\Deck\Listeners\CommentEventListener;
 use OCA\Deck\Listeners\FullTextSearchEventListener;
 use OCA\Deck\Listeners\LiveUpdateListener;
@@ -143,6 +144,12 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(CardCreatedEvent::class, FullTextSearchEventListener::class);
 		$context->registerEventListener(CardUpdatedEvent::class, FullTextSearchEventListener::class);
 		$context->registerEventListener(CardDeletedEvent::class, FullTextSearchEventListener::class);
+
+		// Event listening for stack automations
+		$context->registerEventListener(CardCreatedEvent::class, CardAutomationListener::class);
+		$context->registerEventListener(CardUpdatedEvent::class, CardAutomationListener::class);
+		$context->registerEventListener(CardDeletedEvent::class, CardAutomationListener::class);
+
 		$context->registerEventListener(AclCreatedEvent::class, FullTextSearchEventListener::class);
 		$context->registerEventListener(AclUpdatedEvent::class, FullTextSearchEventListener::class);
 		$context->registerEventListener(AclDeletedEvent::class, FullTextSearchEventListener::class);

--- a/lib/Automation/ActionFactory.php
+++ b/lib/Automation/ActionFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Automation;
+
+use OCA\Deck\Automation\Actions\AddLabelAction;
+use OCA\Deck\Automation\Actions\ArchiveAction;
+use OCA\Deck\Automation\Actions\RemoveDoneAction;
+use OCA\Deck\Automation\Actions\RemoveLabelAction;
+use OCA\Deck\Automation\Actions\SetDoneAction;
+use OCA\Deck\Automation\Actions\WebhookAction;
+use OCA\Deck\Db\CardMapper;
+use OCA\Deck\Db\LabelMapper;
+use OCA\Deck\Service\CardService;
+use OCP\Http\Client\IClientService;
+use Psr\Log\LoggerInterface;
+
+class ActionFactory {
+	public const ACTION_ADD_LABEL = 'add_label';
+	public const ACTION_REMOVE_LABEL = 'remove_label';
+	public const ACTION_SET_DONE = 'set_done';
+	public const ACTION_REMOVE_DONE = 'remove_done';
+	public const ACTION_WEBHOOK = 'webhook';
+	public const ACTION_ARCHIVE = 'archive';
+
+	public function __construct(
+		private CardMapper $cardMapper,
+		private LabelMapper $labelMapper,
+		private IClientService $clientService,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function createAction(string $actionType): ?ActionInterface {
+		return match ($actionType) {
+			self::ACTION_ADD_LABEL => new AddLabelAction($this->cardMapper, $this->labelMapper, $this->logger),
+			self::ACTION_REMOVE_LABEL => new RemoveLabelAction($this->cardMapper, $this->labelMapper, $this->logger),
+			self::ACTION_SET_DONE => new SetDoneAction($this->cardMapper, $this->logger),
+			self::ACTION_REMOVE_DONE => new RemoveDoneAction($this->cardMapper, $this->logger),
+			self::ACTION_WEBHOOK => new WebhookAction($this->clientService, $this->logger),
+			self::ACTION_ARCHIVE => new ArchiveAction($this->cardMapper, $this->logger),
+			default => null,
+		};
+	}
+
+	public function getSupportedActions(): array {
+		return [
+			self::ACTION_ADD_LABEL,
+			self::ACTION_REMOVE_LABEL,
+			self::ACTION_SET_DONE,
+			self::ACTION_REMOVE_DONE,
+			self::ACTION_WEBHOOK,
+			self::ACTION_ARCHIVE,
+		];
+	}
+}

--- a/lib/Automation/ActionInterface.php
+++ b/lib/Automation/ActionInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Automation;
+
+use OCA\Deck\Db\Card;
+
+interface ActionInterface {
+	/**
+	 * Execute the action on the given card
+	 *
+	 * @param Card $card The card to execute the action on
+	 * @param AutomationEvent $event The event that triggered the action
+	 * @param array $config The action configuration
+	 * @throws \Exception If the action fails
+	 */
+	public function execute(Card $card, AutomationEvent $event, array $config = []): void;
+
+	/**
+	 * Validate the action configuration
+	 *
+	 * @param array $config The configuration to validate
+	 * @return bool True if valid, false otherwise
+	 */
+	public function validateConfig(array $config): bool;
+
+	/**
+	 * Check if this action is applicable for the given event
+	 * For example, adding labels doesn't make sense on card deletion
+	 *
+	 * @param AutomationEvent $event The event to check
+	 * @return bool True if the action should be executed, false otherwise
+	 */
+	public function isApplicableForEvent(AutomationEvent $event): bool;
+
+	/**
+	 * Get a human-readable description of the action
+	 *
+	 * @param array $config The action configuration
+	 * @return string Description of the action
+	 */
+	public function getDescription(array $config): string;
+}

--- a/lib/Automation/Actions/AddLabelAction.php
+++ b/lib/Automation/Actions/AddLabelAction.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Automation\Actions;
+
+use OCA\Deck\Automation\ActionInterface;
+use OCA\Deck\Automation\AutomationEvent;
+use OCA\Deck\Db\Card;
+use OCA\Deck\Db\CardMapper;
+use OCA\Deck\Db\LabelMapper;
+use Psr\Log\LoggerInterface;
+
+class AddLabelAction implements ActionInterface {
+	public function __construct(
+		private CardMapper $cardMapper,
+		private LabelMapper $labelMapper,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function execute(Card $card, AutomationEvent $event, array $config = []): void {
+		$labelIds = $config['labelIds'] ?? [];
+
+		if (empty($labelIds) || !is_array($labelIds)) {
+			$this->logger->warning('AddLabelAction: Missing or invalid labelIds in configuration');
+			return;
+		}
+
+		try {
+			// Get currently assigned labels
+			$assignedLabels = $this->labelMapper->findAssignedLabelsForCard($card->getId());
+			$assignedLabelIds = array_map(fn($label) => $label->getId(), $assignedLabels);
+
+			foreach ($labelIds as $labelId) {
+				// Only add if not already assigned
+				if (!in_array((int)$labelId, $assignedLabelIds, true)) {
+					$this->cardMapper->assignLabel($card->getId(), (int)$labelId);
+				}
+			}
+		} catch (\Exception $e) {
+			$this->logger->error('AddLabelAction failed: ' . $e->getMessage(), ['exception' => $e]);
+			throw $e;
+		}
+	}
+
+	public function validateConfig(array $config): bool {
+		return isset($config['labelIds'])
+			&& is_array($config['labelIds'])
+			&& !empty($config['labelIds'])
+			&& array_reduce($config['labelIds'], fn($valid, $id) => $valid && is_numeric($id), true);
+	}
+
+	public function isApplicableForEvent(AutomationEvent $event): bool {
+		return $event->getEventName() !== AutomationEvent::EVENT_DELETE;
+	}
+
+	public function getDescription(array $config): string {
+		$labelIds = $config['labelIds'] ?? [];
+		$count = count($labelIds);
+		return $count > 0 ? "Add {$count} label(s)" : "Add labels";
+	}
+}

--- a/lib/Automation/Actions/ArchiveAction.php
+++ b/lib/Automation/Actions/ArchiveAction.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Automation\Actions;
+
+use OCA\Deck\Automation\ActionInterface;
+use OCA\Deck\Automation\AutomationEvent;
+use OCA\Deck\Db\Card;
+use OCA\Deck\Db\CardMapper;
+use Psr\Log\LoggerInterface;
+
+class ArchiveAction implements ActionInterface {
+	public function __construct(
+		private CardMapper $cardMapper,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function execute(Card $card, AutomationEvent $event, array $config = []): void {
+		try {
+			$card->setArchived(true);
+			$this->cardMapper->update($card);
+		} catch (\Exception $e) {
+			$this->logger->error('ArchiveAction failed: ' . $e->getMessage(), ['exception' => $e]);
+			throw $e;
+		}
+	}
+
+	public function validateConfig(array $config): bool {
+		// No configuration needed
+		return true;
+	}
+
+	public function isApplicableForEvent(AutomationEvent $event): bool {
+		return $event->getEventName() !== AutomationEvent::EVENT_DELETE;
+	}
+
+	public function getDescription(array $config): string {
+		return "Archive card";
+	}
+}

--- a/lib/Automation/Actions/RemoveDoneAction.php
+++ b/lib/Automation/Actions/RemoveDoneAction.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Automation\Actions;
+
+use OCA\Deck\Automation\ActionInterface;
+use OCA\Deck\Automation\AutomationEvent;
+use OCA\Deck\Db\Card;
+use OCA\Deck\Db\CardMapper;
+use Psr\Log\LoggerInterface;
+
+class RemoveDoneAction implements ActionInterface {
+	public function __construct(
+		private CardMapper $cardMapper,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function execute(Card $card, AutomationEvent $event, array $config = []): void {
+		try {
+			$card->setDone(null);
+			$this->cardMapper->update($card);
+		} catch (\Exception $e) {
+			$this->logger->error('RemoveDoneAction failed: ' . $e->getMessage(), ['exception' => $e]);
+			throw $e;
+		}
+	}
+
+	public function validateConfig(array $config): bool {
+		// No configuration needed
+		return true;
+	}
+
+	public function isApplicableForEvent(AutomationEvent $event): bool {
+		return $event->getEventName() !== AutomationEvent::EVENT_DELETE;
+	}
+
+	public function getDescription(array $config): string {
+		return "Unmark card as done";
+	}
+}

--- a/lib/Automation/Actions/RemoveLabelAction.php
+++ b/lib/Automation/Actions/RemoveLabelAction.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Automation\Actions;
+
+use OCA\Deck\Automation\ActionInterface;
+use OCA\Deck\Automation\AutomationEvent;
+use OCA\Deck\Db\Card;
+use OCA\Deck\Db\CardMapper;
+use OCA\Deck\Db\LabelMapper;
+use Psr\Log\LoggerInterface;
+
+class RemoveLabelAction implements ActionInterface {
+	public function __construct(
+		private CardMapper $cardMapper,
+		private LabelMapper $labelMapper,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function execute(Card $card, AutomationEvent $event, array $config = []): void {
+		$labelIds = $config['labelIds'] ?? [];
+
+		if (empty($labelIds) || !is_array($labelIds)) {
+			$this->logger->warning('RemoveLabelAction: Missing or invalid labelIds in configuration');
+			return;
+		}
+
+		try {
+			// Get currently assigned labels
+			$assignedLabels = $this->labelMapper->findAssignedLabelsForCard($card->getId());
+			$assignedLabelIds = array_map(fn($label) => $label->getId(), $assignedLabels);
+
+			foreach ($labelIds as $labelId) {
+				// Only remove if currently assigned
+				if (in_array((int)$labelId, $assignedLabelIds, true)) {
+					$this->cardMapper->removeLabel($card->getId(), (int)$labelId);
+				}
+			}
+		} catch (\Exception $e) {
+			$this->logger->error('RemoveLabelAction failed: ' . $e->getMessage(), ['exception' => $e]);
+			throw $e;
+		}
+	}
+
+	public function validateConfig(array $config): bool {
+		return isset($config['labelIds'])
+			&& is_array($config['labelIds'])
+			&& !empty($config['labelIds'])
+			&& array_reduce($config['labelIds'], fn($valid, $id) => $valid && is_numeric($id), true);
+	}
+
+	public function isApplicableForEvent(AutomationEvent $event): bool {
+		return $event->getEventName() !== AutomationEvent::EVENT_DELETE;
+	}
+
+	public function getDescription(array $config): string {
+		$labelIds = $config['labelIds'] ?? [];
+		$count = count($labelIds);
+		return $count > 0 ? "Remove {$count} label(s)" : "Remove labels";
+	}
+}

--- a/lib/Automation/Actions/SetDoneAction.php
+++ b/lib/Automation/Actions/SetDoneAction.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Automation\Actions;
+
+use OCA\Deck\Automation\ActionInterface;
+use OCA\Deck\Automation\AutomationEvent;
+use OCA\Deck\Db\Card;
+use OCA\Deck\Db\CardMapper;
+use Psr\Log\LoggerInterface;
+
+class SetDoneAction implements ActionInterface {
+	public function __construct(
+		private CardMapper $cardMapper,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function execute(Card $card, AutomationEvent $event, array $config = []): void {
+		try {
+			$card->setDone(time());
+			$this->cardMapper->update($card);
+		} catch (\Exception $e) {
+			$this->logger->error('SetDoneAction failed: ' . $e->getMessage(), ['exception' => $e]);
+			throw $e;
+		}
+	}
+
+	public function validateConfig(array $config): bool {
+		// No configuration needed
+		return true;
+	}
+
+	public function isApplicableForEvent(AutomationEvent $event): bool {
+		return $event->getEventName() !== AutomationEvent::EVENT_DELETE;
+	}
+
+	public function getDescription(array $config): string {
+		return "Mark card as done";
+	}
+}

--- a/lib/Automation/Actions/WebhookAction.php
+++ b/lib/Automation/Actions/WebhookAction.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Automation\Actions;
+
+use OCA\Deck\Automation\ActionInterface;
+use OCA\Deck\Automation\AutomationEvent;
+use OCA\Deck\Db\Card;
+use OCP\Http\Client\IClientService;
+use Psr\Log\LoggerInterface;
+
+class WebhookAction implements ActionInterface {
+	public function __construct(
+		private IClientService $clientService,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function execute(Card $card, AutomationEvent $event, array $config = []): void {
+		$url = $config['url'] ?? null;
+		$method = $config['method'] ?? 'POST';
+		$headers = $config['headers'] ?? [];
+
+		if ($url === null || !filter_var($url, FILTER_VALIDATE_URL)) {
+			$this->logger->warning('WebhookAction: Invalid or missing URL in configuration');
+			return;
+		}
+
+		try {
+			$client = $this->clientService->newClient();
+
+			$options = [
+				'headers' => $headers,
+				'timeout' => 10,
+			];
+
+			if ($method === 'POST') {
+				$payload = [
+					'cardId' => $card->getId(),
+					'cardTitle' => $card->getTitle(),
+					'stackId' => $card->getStackId(),
+					'event' => $event->getEventName(),
+					'fromStackId' => $event->getFromStackId(),
+					'toStackId' => $event->getToStackId(),
+				];
+
+				$options['json'] = $payload;
+				$client->post($url, $options);
+			} elseif ($method === 'GET') {
+				$client->get($url, $options);
+			} else {
+				$this->logger->warning('WebhookAction: Unsupported HTTP method: ' . $method);
+			}
+		} catch (\Exception $e) {
+			$this->logger->error('WebhookAction failed: ' . $e->getMessage(), ['exception' => $e]);
+			// Don't throw - webhook failures shouldn't block card operations
+		}
+	}
+
+	public function validateConfig(array $config): bool {
+		if (!isset($config['url'])) {
+			return false;
+		}
+		if (!filter_var($config['url'], FILTER_VALIDATE_URL)) {
+			return false;
+		}
+		if (isset($config['method']) && !in_array($config['method'], ['GET', 'POST'])) {
+			return false;
+		}
+		return true;
+	}
+
+	public function isApplicableForEvent(AutomationEvent $event): bool {
+		return true;
+	}
+
+	public function getDescription(array $config): string {
+		$url = $config['url'] ?? 'unknown';
+		$method = $config['method'] ?? 'POST';
+		return "Call webhook {$method} {$url}";
+	}
+}

--- a/lib/Automation/AutomationEvent.php
+++ b/lib/Automation/AutomationEvent.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Automation;
+
+/**
+ * Simple event class for automation actions
+ * Note: This is different from OCA\Deck\Event\* classes which are Nextcloud event dispatcher events
+ */
+class AutomationEvent {
+public const EVENT_CREATE = 'create';
+public const EVENT_DELETE = 'delete';
+public const EVENT_ENTER = 'enter';
+public const EVENT_EXIT = 'exit';
+
+private string $eventName;
+private ?int $fromStackId;
+private ?int $toStackId;
+
+public function __construct(
+string $eventName,
+?int $fromStackId = null,
+?int $toStackId = null
+) {
+$this->eventName = $eventName;
+$this->fromStackId = $fromStackId;
+$this->toStackId = $toStackId;
+}
+
+public function getEventName(): string {
+return $this->eventName;
+}
+
+public function getFromStackId(): ?int {
+return $this->fromStackId;
+}
+
+public function getToStackId(): ?int {
+return $this->toStackId;
+}
+}

--- a/lib/Controller/StackAutomationController.php
+++ b/lib/Controller/StackAutomationController.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Controller;
+
+use OCA\Deck\Db\StackAutomation;
+use OCA\Deck\Service\StackAutomationService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+class StackAutomationController extends Controller {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private StackAutomationService $automationService,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * Get all automations for a stack
+	 *
+	 * @return StackAutomation[]
+	 */
+	#[NoAdminRequired]
+	public function index(int $stackId): array {
+		return $this->automationService->getAutomations($stackId);
+	}
+
+	/**
+	 * Create a new automation
+	 */
+	#[NoAdminRequired]
+	public function create(int $stackId, string $event, string $actionType, array $config, int $order = 0): JSONResponse {
+		try {
+			$automation = $this->automationService->createAutomation($stackId, $event, $actionType, $config, $order);
+			return new JSONResponse($automation, 201);
+		} catch (\InvalidArgumentException $e) {
+			return new JSONResponse(['error' => $e->getMessage()], 400);
+		} catch (\Exception $e) {
+			return new JSONResponse(['error' => 'Failed to create automation'], 500);
+		}
+	}
+
+	/**
+	 * Update an automation
+	 */
+	#[NoAdminRequired]
+	public function update(int $id, string $event, string $actionType, array $config, int $order): JSONResponse {
+		try {
+			$automation = $this->automationService->updateAutomation($id, $event, $actionType, $config, $order);
+			return new JSONResponse($automation);
+		} catch (\InvalidArgumentException $e) {
+			return new JSONResponse(['error' => $e->getMessage()], 400);
+		} catch (\Exception $e) {
+			return new JSONResponse(['error' => 'Failed to update automation'], 500);
+		}
+	}
+
+	/**
+	 * Delete an automation
+	 */
+	#[NoAdminRequired]
+	public function delete(int $id): JSONResponse {
+		try {
+			$this->automationService->deleteAutomation($id);
+			return new JSONResponse(['success' => true]);
+		} catch (\Exception $e) {
+			return new JSONResponse(['error' => 'Failed to delete automation'], 500);
+		}
+	}
+}

--- a/lib/Db/StackAutomation.php
+++ b/lib/Db/StackAutomation.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Db;
+
+/**
+ * @method int getId()
+ * @method void setId(int $id)
+ * @method int getStackId()
+ * @method void setStackId(int $stackId)
+ * @method string getEvent()
+ * @method void setEvent(string $event)
+ * @method string getActionType()
+ * @method void setActionType(string $actionType)
+ * @method string getActionConfig()
+ * @method void setActionConfig(string $actionConfig)
+ * @method int getOrder()
+ * @method void setOrder(int $order)
+ * @method int getCreatedAt()
+ * @method void setCreatedAt(int $createdAt)
+ * @method int getUpdatedAt()
+ * @method void setUpdatedAt(int $updatedAt)
+ */
+class StackAutomation extends RelationalEntity {
+	protected $stackId;
+	protected $event;
+	protected $actionType;
+	protected $actionConfig;
+	protected $order;
+	protected $createdAt;
+	protected $updatedAt;
+
+	public function __construct() {
+		$this->addType('stackId', 'integer');
+		$this->addType('order', 'integer');
+		$this->addType('createdAt', 'integer');
+		$this->addType('updatedAt', 'integer');
+	}
+
+	public function jsonSerialize(): array {
+		$data = parent::jsonSerialize();
+		// Decode JSON config for easier frontend consumption
+		if (isset($data['actionConfig'])) {
+			$data['actionConfig'] = json_decode($data['actionConfig'], true) ?? [];
+		}
+		return $data;
+	}
+
+	public function setActionConfigArray(array $config): void {
+		$this->setActionConfig(json_encode($config));
+	}
+
+	public function getActionConfigArray(): array {
+		$decoded = json_decode($this->actionConfig ?? '{}', true);
+		return is_array($decoded) ? $decoded : [];
+	}
+}

--- a/lib/Db/StackAutomationMapper.php
+++ b/lib/Db/StackAutomationMapper.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Db;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * @template-extends QBMapper<StackAutomation>
+ */
+class StackAutomationMapper extends QBMapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'deck_stack_automations', StackAutomation::class);
+	}
+
+	/**
+	 * @param int $id
+	 * @return StackAutomation
+	 */
+	public function find(int $id): StackAutomation {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+
+		return $this->findEntity($qb);
+	}
+
+	/**
+	 * @param int $stackId
+	 * @return StackAutomation[]
+	 */
+	public function findByStackId(int $stackId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('stack_id', $qb->createNamedParameter($stackId, IQueryBuilder::PARAM_INT)))
+			->orderBy('order', 'ASC')
+			->addOrderBy('id', 'ASC');
+
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * @param int $stackId
+	 * @param string $event
+	 * @return StackAutomation[]
+	 */
+	public function findByStackIdAndEvent(int $stackId, string $event): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('stack_id', $qb->createNamedParameter($stackId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('event', $qb->createNamedParameter($event, IQueryBuilder::PARAM_STR)))
+			->orderBy('order', 'ASC')
+			->addOrderBy('id', 'ASC');
+
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * @param int $stackId
+	 */
+	public function deleteByStackId(int $stackId): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('stack_id', $qb->createNamedParameter($stackId, IQueryBuilder::PARAM_INT)));
+		$qb->executeStatement();
+	}
+}

--- a/lib/Listeners/CardAutomationListener.php
+++ b/lib/Listeners/CardAutomationListener.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Listeners;
+
+use OCA\Deck\Event\CardCreatedEvent;
+use OCA\Deck\Event\CardDeletedEvent;
+use OCA\Deck\Event\CardUpdatedEvent;
+use OCA\Deck\Service\StackAutomationService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @template-implements IEventListener<CardCreatedEvent|CardUpdatedEvent|CardDeletedEvent>
+ */
+class CardAutomationListener implements IEventListener {
+	public function __construct(
+		private StackAutomationService $automationService,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if ($event instanceof CardCreatedEvent) {
+			$this->handleCardCreated($event);
+		} elseif ($event instanceof CardUpdatedEvent) {
+			$this->handleCardUpdated($event);
+		} elseif ($event instanceof CardDeletedEvent) {
+			$this->handleCardDeleted($event);
+		}
+	}
+
+	private function handleCardCreated(CardCreatedEvent $event): void {
+		try {
+			$card = $event->getCard();
+			$this->automationService->executeAutomationsForEvent($event, 'create', $card->getStackId());
+		} catch (\Exception $e) {
+			$this->logger->error('Failed to execute automations on card create', ['exception' => $e]);
+		}
+	}
+
+	private function handleCardUpdated(CardUpdatedEvent $event): void {
+		try {
+			$card = $event->getCard();
+			$cardBefore = $event->getCardBefore();
+			
+			if ($cardBefore === null) {
+				return;
+			}
+
+			$oldStackId = $cardBefore->getStackId();
+			$newStackId = $card->getStackId();
+
+			// Check if card moved between stacks
+			if ($oldStackId !== $newStackId) {
+				// Execute EXIT on old stack
+				$this->automationService->executeAutomationsForEvent($event, 'exit', $oldStackId);
+				// Execute ENTER on new stack
+				$this->automationService->executeAutomationsForEvent($event, 'enter', $newStackId);
+			}
+		} catch (\Exception $e) {
+			$this->logger->error('Failed to execute automations on card update', ['exception' => $e]);
+		}
+	}
+
+	private function handleCardDeleted(CardDeletedEvent $event): void {
+		try {
+			$card = $event->getCard();
+			$this->automationService->executeAutomationsForEvent($event, 'delete', $card->getStackId());
+		} catch (\Exception $e) {
+			$this->logger->error('Failed to execute automations on card delete', ['exception' => $e]);
+		}
+	}
+}

--- a/lib/Migration/Version11100Date20260123000000.php
+++ b/lib/Migration/Version11100Date20260123000000.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version11100Date20260123000000 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('deck_stack_automations')) {
+			$table = $schema->createTable('deck_stack_automations');
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'unsigned' => true,
+			]);
+			$table->addColumn('stack_id', Types::BIGINT, [
+				'notnull' => true,
+				'unsigned' => true,
+			]);
+			$table->addColumn('event', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('action_type', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('action_config', Types::TEXT, [
+				'notnull' => true,
+				'default' => '{}',
+			]);
+			$table->addColumn('order', Types::INTEGER, [
+				'notnull' => true,
+				'default' => 0,
+				'unsigned' => true,
+			]);
+			$table->addColumn('created_at', Types::BIGINT, [
+				'notnull' => true,
+				'unsigned' => true,
+			]);
+			$table->addColumn('updated_at', Types::BIGINT, [
+				'notnull' => true,
+				'unsigned' => true,
+			]);
+
+			$table->setPrimaryKey(['id']);
+			$table->addIndex(['stack_id'], 'deck_stack_auto_stack_idx');
+			$table->addIndex(['event'], 'deck_stack_auto_event_idx');
+
+			return $schema;
+		}
+
+		return null;
+	}
+}

--- a/lib/Service/StackAutomationService.php
+++ b/lib/Service/StackAutomationService.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Service;
+
+use OCA\Deck\Automation\ActionFactory;
+use OCA\Deck\Automation\AutomationEvent;
+use OCA\Deck\Db\Card;
+use OCA\Deck\Db\StackAutomation;
+use OCA\Deck\Db\StackAutomationMapper;
+use Psr\Log\LoggerInterface;
+
+class StackAutomationService {
+	public function __construct(
+		private StackAutomationMapper $automationMapper,
+		private ActionFactory $actionFactory,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Get all automations for a stack
+	 *
+	 * @param int $stackId
+	 * @return StackAutomation[]
+	 */
+	public function getAutomations(int $stackId): array {
+		return $this->automationMapper->findByStackId($stackId);
+	}
+
+	/**
+	 * Create a new automation rule
+	 */
+	public function createAutomation(int $stackId, string $event, string $actionType, array $config, int $order = 0): StackAutomation {
+		// Validate action type
+		if (!in_array($actionType, $this->actionFactory->getSupportedActions())) {
+			throw new \InvalidArgumentException('Unsupported action type: ' . $actionType);
+		}
+
+		// Validate configuration
+		$action = $this->actionFactory->createAction($actionType);
+		if ($action && !$action->validateConfig($config)) {
+			throw new \InvalidArgumentException('Invalid configuration for action: ' . $actionType);
+		}
+
+		// Validate event
+		if (!in_array($event, [AutomationEvent::EVENT_CREATE, AutomationEvent::EVENT_DELETE, AutomationEvent::EVENT_ENTER, AutomationEvent::EVENT_EXIT])) {
+			throw new \InvalidArgumentException('Invalid event: ' . $event);
+		}
+
+		$automation = new StackAutomation();
+		$automation->setStackId($stackId);
+		$automation->setEvent($event);
+		$automation->setActionType($actionType);
+		$automation->setActionConfigArray($config);
+		$automation->setOrder($order);
+		$automation->setCreatedAt(time());
+		$automation->setUpdatedAt(time());
+
+		return $this->automationMapper->insert($automation);
+	}
+
+	/**
+	 * Update an existing automation rule
+	 */
+	public function updateAutomation(int $id, string $event, string $actionType, array $config, int $order): StackAutomation {
+		$automation = $this->automationMapper->find($id);
+
+		// Validate action type
+		if (!in_array($actionType, $this->actionFactory->getSupportedActions())) {
+			throw new \InvalidArgumentException('Unsupported action type: ' . $actionType);
+		}
+
+		// Validate configuration
+		$action = $this->actionFactory->createAction($actionType);
+		if ($action && !$action->validateConfig($config)) {
+			throw new \InvalidArgumentException('Invalid configuration for action: ' . $actionType);
+		}
+
+		// Validate event
+		if (!in_array($event, [AutomationEvent::EVENT_CREATE, AutomationEvent::EVENT_DELETE, AutomationEvent::EVENT_ENTER, AutomationEvent::EVENT_EXIT])) {
+			throw new \InvalidArgumentException('Invalid event: ' . $event);
+		}
+
+		$automation->setEvent($event);
+		$automation->setActionType($actionType);
+		$automation->setActionConfigArray($config);
+		$automation->setOrder($order);
+		$automation->setUpdatedAt(time());
+
+		return $this->automationMapper->update($automation);
+	}
+
+	/**
+	 * Delete an automation rule
+	 */
+	public function deleteAutomation(int $id): void {
+		$automation = $this->automationMapper->find($id);
+		$this->automationMapper->delete($automation);
+	}
+
+	/**
+	 * Execute automations for a specific event using Nextcloud event objects
+	 */
+	public function executeAutomationsForEvent(\OCP\EventDispatcher\Event $event, string $eventName, int $stackId): void {
+		$card = null;
+		
+		if ($event instanceof \OCA\Deck\Event\CardCreatedEvent || 
+		    $event instanceof \OCA\Deck\Event\CardUpdatedEvent || 
+		    $event instanceof \OCA\Deck\Event\CardDeletedEvent) {
+			$card = $event->getCard();
+		}
+		
+		if ($card === null) {
+			$this->logger->warning('Card not found in event for automation execution');
+			return;
+		}
+		
+		$this->executeAutomations($stackId, $eventName, $card);
+	}
+
+	/**
+	 * Execute automations for a given stack and event
+	 */
+	public function executeAutomations(int $stackId, string $eventName, Card $card, ?int $fromStackId = null, ?int $toStackId = null): void {
+		$this->logger->info('Executing automations for stack', [
+			'stackId' => $stackId,
+			'eventName' => $eventName,
+			'cardId' => $card->getId(),
+		]);
+
+		$automations = $this->automationMapper->findByStackIdAndEvent($stackId, $eventName);
+		
+		$this->logger->info('Found automations', [
+			'count' => count($automations),
+			'automations' => array_map(fn($a) => ['id' => $a->getId(), 'event' => $a->getEvent(), 'actionType' => $a->getActionType()], $automations),
+		]);
+
+		if (empty($automations)) {
+			return;
+		}
+
+		$event = new AutomationEvent($eventName, $fromStackId, $toStackId);
+
+		foreach ($automations as $automation) {
+			$action = $this->actionFactory->createAction($automation->getActionType());
+			
+			if ($action === null) {
+				$this->logger->warning('Unknown action type: ' . $automation->getActionType());
+				continue;
+			}
+
+			// Check if action is applicable for this event
+			if (!$action->isApplicableForEvent($event)) {
+				$this->logger->debug('Action not applicable for event', [
+					'actionType' => $automation->getActionType(),
+					'eventName' => $eventName,
+				]);
+				continue;
+			}
+
+			try {
+				$config = $automation->getActionConfigArray();
+				$action->execute($card, $event, $config);
+				$this->logger->info('Automation executed successfully', [
+					'automationId' => $automation->getId(),
+					'actionType' => $automation->getActionType(),
+					'cardId' => $card->getId(),
+				]);
+			} catch (\Exception $e) {
+				$this->logger->error('Automation execution failed', [
+					'automationId' => $automation->getId(),
+					'actionType' => $automation->getActionType(),
+					'cardId' => $card->getId(),
+					'error' => $e->getMessage(),
+				]);
+				// Continue with other automations even if one fails
+			}
+		}
+	}
+}

--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -40,19 +40,25 @@
 				</form>
 			</transition>
 			<NcActions v-if="canManage && !isArchived" :force-menu="true">
-				<NcActionButton v-if="!showArchived" icon="icon-archive" @click="modalArchivAllCardsShow=true">
+				<NcActionButton :close-after-click="true" @click="showAutomationSettings = true">
+					<template #icon>
+						<CogIcon decorative />
+					</template>
+					{{ t('deck', 'Automation rules') }}
+				</NcActionButton>
+				<NcActionButton v-if="!showArchived" :close-after-click="true" icon="icon-archive" @click="modalArchivAllCardsShow=true">
 					<template #icon>
 						<ArchiveIcon decorative />
 					</template>
 					{{ t('deck', 'Archive all cards') }}
 				</NcActionButton>
-				<NcActionButton v-if="showArchived" @click="modalArchivAllCardsShow=true">
+				<NcActionButton v-if="showArchived" :close-after-click="true" @click="modalArchivAllCardsShow=true">
 					<template #icon>
 						<ArchiveIcon decorative />
 					</template>
 					{{ t('deck', 'Unarchive all cards') }}
 				</NcActionButton>
-				<NcActionButton icon="icon-delete" @click="deleteStack(stack)">
+				<NcActionButton :close-after-click="true" icon="icon-delete" @click="deleteStack(stack)">
 					{{ t('deck', 'Delete list') }}
 				</NcActionButton>
 			</NcActions>
@@ -130,6 +136,10 @@
 				</form>
 			</div>
 		</transition>
+
+		<StackAutomationSettings :show="showAutomationSettings"
+			:stack-id="stack.id"
+			@close="showAutomationSettings = false" />
 	</div>
 </template>
 
@@ -139,10 +149,12 @@ import { mapGetters, mapState } from 'vuex'
 import { Container, Draggable } from 'vue-smooth-dnd'
 import ArchiveIcon from 'vue-material-design-icons/ArchiveOutline.vue'
 import CardPlusOutline from 'vue-material-design-icons/CardPlusOutline.vue'
+import CogIcon from 'vue-material-design-icons/Cog.vue'
 import { NcActions, NcActionButton, NcModal } from '@nextcloud/vue'
 import { showError, showUndo } from '@nextcloud/dialogs'
 
 import CardItem from '../cards/CardItem.vue'
+import StackAutomationSettings from './StackAutomationSettings.vue'
 
 import '@nextcloud/dialogs/style.css'
 
@@ -157,6 +169,8 @@ export default {
 		NcModal,
 		ArchiveIcon,
 		CardPlusOutline,
+		CogIcon,
+		StackAutomationSettings,
 	},
 	directives: {
 		ClickOutside,
@@ -181,6 +195,7 @@ export default {
 			stateCardCreating: false,
 			animate: false,
 			modalArchivAllCardsShow: false,
+			showAutomationSettings: false,
 			stackTransfer: {
 				total: 0,
 				current: null,

--- a/src/components/board/StackAutomationItem.vue
+++ b/src/components/board/StackAutomationItem.vue
@@ -1,0 +1,186 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="automation-item">
+		<div class="automation-content">
+			<span v-if="showStackName" class="stack-name">{{ stackName }}</span>
+			<span class="event-badge">{{ eventLabel }}</span>
+			<span class="arrow">→</span>
+			<span class="action-description">
+				{{ actionDescription }}
+				<ul v-if="labelNames.length > 0" class="labels">
+					<li v-for="label in labelNames" :key="label.id" :style="labelStyle(label)">
+						<span>{{ label.title }}</span>
+					</li>
+				</ul>
+			</span>
+		</div>
+		<div class="automation-actions">
+			<NcActions :force-menu="true">
+				<NcActionButton :close-after-click="true" icon="icon-rename" @click="$emit('edit', automation)">
+					{{ t('deck', 'Edit') }}
+				</NcActionButton>
+				<NcActionButton :close-after-click="true" @click="$emit('clone', automation)">
+					{{ t('deck', 'Clone') }}
+				</NcActionButton>
+				<NcActionButton :close-after-click="true" icon="icon-delete" @click="$emit('delete', automation.id)">
+					{{ t('deck', 'Delete') }}
+				</NcActionButton>
+			</NcActions>
+		</div>
+	</div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import { NcActions, NcActionButton } from '@nextcloud/vue'
+import labelStyle from '../../mixins/labelStyle.js'
+
+export default {
+	name: 'StackAutomationItem',
+
+	components: {
+		NcActions,
+		NcActionButton,
+	},
+
+	mixins: [labelStyle],
+
+	props: {
+		automation: {
+			type: Object,
+			required: true,
+		},
+		stackId: {
+			type: Number,
+			required: false,
+			default: null,
+		},
+		showStackName: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	computed: {
+		...mapGetters(['currentBoardLabels', 'stackById']),
+
+		stackName() {
+			if (!this.showStackName || !this.automation.stackId) {
+				return ''
+			}
+			const stack = this.stackById(this.automation.stackId)
+			return stack?.title || this.t('deck', 'Unknown stack')
+		},
+
+		eventLabel() {
+			const eventLabels = {
+				create: this.t('deck', 'Card created'),
+				enter: this.t('deck', 'Card enters'),
+				exit: this.t('deck', 'Card exits'),
+				delete: this.t('deck', 'Card deleted'),
+			}
+			return eventLabels[this.automation.event] || this.automation.event
+		},
+
+		labelNames() {
+			const actionType = this.automation.actionType
+			const config = this.automation.actionConfig || {}
+
+			if ((actionType === 'add_label' || actionType === 'remove_label') && config.labelIds) {
+				return this.currentBoardLabels.filter(label => config.labelIds.includes(label.id))
+			}
+			return []
+		},
+
+		actionDescription() {
+			const actionType = this.automation.actionType
+			const config = this.automation.actionConfig || {}
+
+			if (actionType === 'add_label') {
+				const count = config.labelIds?.length || 0
+				return count === 1
+					? this.t('deck', 'Add tag:')
+					: this.t('deck', 'Add tags:')
+			}
+
+			if (actionType === 'remove_label') {
+				const count = config.labelIds?.length || 0
+				return count === 1
+					? this.t('deck', 'Remove tag:')
+					: this.t('deck', 'Remove tags:')
+			}
+
+			const descriptions = {
+				set_done: this.t('deck', 'Mark as done'),
+				remove_done: this.t('deck', 'Unmark as done'),
+				archive: this.t('deck', 'Archive card'),
+				webhook: this.t('deck', 'Call webhook: {url}', { url: config.url }),
+			}
+
+			return descriptions[actionType] || actionType
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../../css/labels';
+
+.automation-item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 12px;
+	margin-bottom: 8px;
+	background: var(--color-background-hover);
+	border-radius: var(--border-radius);
+
+	.automation-content {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		flex: 1;
+
+		.stack-name {
+			display: inline-block;
+			padding: 4px 12px;
+			background: var(--color-background-dark);
+			color: var(--color-main-text);
+			border-radius: 12px;
+			font-size: 12px;
+			font-weight: 600;
+			margin-right: 4px;
+		}
+
+		.event-badge {
+			display: inline-block;
+			padding: 4px 12px;
+			background: var(--color-primary-element);
+			color: var(--color-primary-element-text);
+			border-radius: 12px;
+			font-size: 12px;
+			font-weight: 500;
+		}
+
+		.arrow {
+			color: var(--color-text-maxcontrast);
+		}
+
+		.action-description {
+			flex: 1;
+			display: flex;
+			align-items: center;
+			gap: 8px;
+			flex-wrap: wrap;
+		}
+	}
+
+	.automation-actions {
+		margin-left: 12px;
+	}
+}
+</style>

--- a/src/components/board/StackAutomationSettings.vue
+++ b/src/components/board/StackAutomationSettings.vue
@@ -1,0 +1,401 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcModal v-if="show"
+		:name="t('deck', 'Stack automations')"
+		@close="$emit('close')">
+		<div class="stack-automation-settings">
+			<p class="automation-description">
+				{{ t('deck', 'Configure actions that are automatically executed when a specific event is triggered.') }}
+			</p>
+
+			<div v-if="automations.length > 0" class="automations-list">
+				<StackAutomationItem v-for="automation in automations"
+					:key="automation.id"
+					:automation="automation"
+					:stack-id="stackId"
+					@edit="editAutomation"
+					@clone="cloneAutomation"
+					@delete="deleteAutomation" />
+			</div>
+
+			<div v-else class="empty-content">
+				<p>{{ t('deck', 'No automations configured yet.') }}</p>
+			</div>
+
+			<NcButton class="add-automation-button"
+				type="primary"
+				@click="showAddForm = true">
+				<template #icon>
+					<Plus :size="20" />
+				</template>
+				{{ t('deck', 'Add automation') }}
+			</NcButton>
+
+			<!-- Add/Edit automation form -->
+			<div v-if="showAddForm" class="automation-form">
+				<h3>{{ editingAutomation ? t('deck', 'Edit automation') : t('deck', 'Add automation') }}</h3>
+
+				<NcSelect v-model="formEvent"
+					:options="eventOptions"
+					:placeholder="t('deck', 'Select event')"
+					label="label"
+					track-by="value" />
+
+				<NcSelect v-model="formActionType"
+					:options="actionTypeOptions"
+					:placeholder="t('deck', 'Select action')"
+					label="label"
+					track-by="value" />
+
+				<!-- Action-specific configuration -->
+				<div v-if="formActionType" class="action-config">
+					<template v-if="formActionType.value === 'add_label' || formActionType.value === 'remove_label'">
+						<TagSelector
+							v-model="selectedLabels"
+							:labels="boardLabels" />
+					</template>
+
+					<template v-if="formActionType.value === 'webhook'">
+						<input v-model="webhookUrl"
+							type="url"
+							:placeholder="t('deck', 'Webhook URL')"
+							class="webhook-input">
+						<NcSelect v-model="webhookMethod"
+							:options="['GET', 'POST']"
+							:placeholder="t('deck', 'HTTP Method')" />
+					</template>
+				</div>
+
+				<div class="form-actions">
+					<NcButton @click="cancelForm">
+						{{ t('deck', 'Cancel') }}
+					</NcButton>
+					<NcButton type="primary"
+						:disabled="!isFormValid"
+						@click="saveAutomation">
+						{{ editingAutomation ? t('deck', 'Update') : t('deck', 'Create') }}
+					</NcButton>
+				</div>
+			</div>
+		</div>
+	</NcModal>
+</template>
+
+<script>
+import { NcModal } from '@nextcloud/vue'
+import { NcButton } from '@nextcloud/vue'
+import { NcSelect } from '@nextcloud/vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
+import StackAutomationItem from './StackAutomationItem.vue'
+import TagSelector from '../card/TagSelector.vue'
+import { mapGetters } from 'vuex'
+
+export default {
+	name: 'StackAutomationSettings',
+
+	components: {
+		NcModal,
+		NcButton,
+		NcSelect,
+		Plus,
+		StackAutomationItem,
+		TagSelector,
+	},
+
+	props: {
+		show: {
+			type: Boolean,
+			default: false,
+		},
+		stackId: {
+			type: Number,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			showAddForm: false,
+			editingAutomation: null,
+			formEvent: null,
+			formActionType: null,
+			selectedLabels: [],
+			webhookUrl: '',
+			webhookMethod: 'POST',
+		}
+	},
+
+	computed: {
+		...mapGetters([
+			'currentBoardLabels',
+		]),
+
+		automations() {
+			return this.$store.getters.automationsByStack(this.stackId)
+		},
+
+		boardLabels() {
+			return this.currentBoardLabels
+		},
+
+		eventOptions() {
+			return [
+				{ value: 'create', label: this.t('deck', 'Card created') },
+				{ value: 'enter', label: this.t('deck', 'Card enters stack') },
+				{ value: 'exit', label: this.t('deck', 'Card exits stack') },
+				{ value: 'delete', label: this.t('deck', 'Card deleted') },
+			]
+		},
+
+		actionTypeOptions() {
+			return [
+				{ value: 'add_label', label: this.t('deck', 'Add tag') },
+				{ value: 'remove_label', label: this.t('deck', 'Remove tag') },
+				{ value: 'set_done', label: this.t('deck', 'Mark as done') },
+				{ value: 'remove_done', label: this.t('deck', 'Unmark as done') },
+				{ value: 'archive', label: this.t('deck', 'Archive card') },
+				{ value: 'webhook', label: this.t('deck', 'Call webhook') },
+			]
+		},
+
+		isFormValid() {
+			if (!this.formEvent || !this.formActionType) {
+				return false
+			}
+
+			const actionType = this.formActionType.value
+			if ((actionType === 'add_label' || actionType === 'remove_label') && this.selectedLabels.length === 0) {
+				return false
+			}
+
+			if (actionType === 'webhook' && !this.webhookUrl) {
+				return false
+			}
+
+			return true
+		},
+	},
+
+	watch: {
+		show(newVal) {
+			if (newVal) {
+				this.loadAutomations()
+			}
+		},
+
+		formActionType(newValue, oldValue) {
+			// Preserve tags when switching between add_label and remove_label
+			const labelActions = ['add_label', 'remove_label']
+			const bothAreLabelActions = labelActions.includes(newValue?.value) && labelActions.includes(oldValue?.value)
+			const isLabelAction = labelActions.includes(newValue?.value)
+			
+			// Don't reset selectedLabels if:
+			// 1. Both old and new are label actions (switching between add/remove)
+			// 2. oldValue is null and newValue is a label action (initial edit load)
+			if (!bothAreLabelActions && !(oldValue === null && isLabelAction)) {
+				// Reset action-specific config when switching to a different action type
+				this.selectedLabels = []
+			}
+			
+			// Always reset webhook config when not switching to webhook
+			if (newValue?.value !== 'webhook') {
+				this.webhookUrl = ''
+				this.webhookMethod = 'POST'
+			}
+		},
+	},
+
+	methods: {
+		async loadAutomations() {
+			try {
+				await this.$store.dispatch('loadStackAutomations', this.stackId)
+			} catch (error) {
+				console.error('Failed to load automations', error)
+			}
+		},
+
+		editAutomation(automation) {
+			this.editingAutomation = automation
+			this.showAddForm = true
+
+			// Find the event option
+			const eventOption = this.eventOptions.find(opt => opt.value === automation.event)
+			this.formEvent = eventOption
+
+			// Find the action type option
+			const actionTypeOption = this.actionTypeOptions.find(opt => opt.value === automation.actionType)
+			this.formActionType = actionTypeOption
+
+			// Load config based on action type
+			const config = automation.actionConfig || {}
+			if (automation.actionType === 'add_label' || automation.actionType === 'remove_label') {
+				// Map labelIds to full label objects
+				if (config.labelIds) {
+					this.selectedLabels = this.currentBoardLabels.filter(label =>
+						config.labelIds.includes(label.id)
+					)
+				}
+			} else if (automation.actionType === 'webhook') {
+				this.webhookUrl = config.url || ''
+				this.webhookMethod = config.method || 'POST'
+			}
+		},
+
+		cloneAutomation(automation) {
+			// Reset editing automation so it creates a new one
+			this.editingAutomation = null
+			this.showAddForm = true
+
+			// Find the event option
+			const eventOption = this.eventOptions.find(opt => opt.value === automation.event)
+			this.formEvent = eventOption
+
+			// Find the action type option
+			const actionTypeOption = this.actionTypeOptions.find(opt => opt.value === automation.actionType)
+			this.formActionType = actionTypeOption
+
+			// Load config based on action type
+			const config = automation.actionConfig || {}
+			if (automation.actionType === 'add_label' || automation.actionType === 'remove_label') {
+				// Map labelIds to full label objects
+				if (config.labelIds) {
+					this.selectedLabels = this.currentBoardLabels.filter(label =>
+						config.labelIds.includes(label.id)
+					)
+				}
+			} else if (automation.actionType === 'webhook') {
+				this.webhookUrl = config.url || ''
+				this.webhookMethod = config.method || 'POST'
+			}
+		},
+
+		async saveAutomation() {
+			const config = this.buildConfig()
+
+			try {
+				if (this.editingAutomation) {
+					await this.$store.dispatch('updateStackAutomation', {
+						stackId: this.stackId,
+						id: this.editingAutomation.id,
+						event: this.formEvent.value,
+						actionType: this.formActionType.value,
+						config,
+						order: this.editingAutomation.order,
+					})
+				} else {
+					await this.$store.dispatch('createStackAutomation', {
+						stackId: this.stackId,
+						event: this.formEvent.value,
+						actionType: this.formActionType.value,
+						config,
+						order: this.automations.length,
+					})
+				}
+
+				this.cancelForm()
+			} catch (error) {
+				console.error('Failed to save automation', error)
+			}
+		},
+
+		buildConfig() {
+			const actionType = this.formActionType.value
+
+			if (actionType === 'add_label' || actionType === 'remove_label') {
+				return { labelIds: this.selectedLabels.map(label => label.id) }
+			}
+
+			if (actionType === 'webhook') {
+				return {
+					url: this.webhookUrl,
+					method: this.webhookMethod,
+				}
+			}
+
+			return {}
+		},
+
+		async deleteAutomation(automationId) {
+			try {
+				await this.$store.dispatch('deleteStackAutomation', {
+					stackId: this.stackId,
+					id: automationId,
+				})
+			} catch (error) {
+				console.error('Failed to delete automation', error)
+			}
+		},
+
+		cancelForm() {
+			this.showAddForm = false
+			this.editingAutomation = null
+			this.formEvent = null
+			this.formActionType = null
+			this.selectedLabels = []
+			this.webhookUrl = ''
+			this.webhookMethod = 'POST'
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.stack-automation-settings {
+	padding: 20px;
+	min-height: 400px;
+
+	.automation-description {
+		margin-bottom: 20px;
+		color: var(--color-text-maxcontrast);
+	}
+
+	.automations-list {
+		margin-bottom: 20px;
+	}
+
+	.empty-content {
+		text-align: center;
+		padding: 40px 0;
+		color: var(--color-text-maxcontrast);
+	}
+
+	.add-automation-button {
+		margin-bottom: 20px;
+	}
+
+	.automation-form {
+		border-top: 1px solid var(--color-border);
+		padding-top: 20px;
+		margin-top: 20px;
+
+		h3 {
+			margin-bottom: 16px;
+		}
+
+		> * {
+			margin-bottom: 12px;
+		}
+
+		.action-config {
+			margin-top: 12px;
+
+			.webhook-input {
+				width: 100%;
+				padding: 8px;
+				margin-bottom: 8px;
+			}
+		}
+
+		.form-actions {
+			display: flex;
+			gap: 8px;
+			justify-content: flex-end;
+			margin-top: 20px;
+		}
+	}
+}
+</style>

--- a/src/services/StackAutomationApi.js
+++ b/src/services/StackAutomationApi.js
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+export class StackAutomationApi {
+	url(url) {
+		url = `/apps/deck${url}`
+		return generateUrl(url)
+	}
+
+	loadAutomations(stackId) {
+		return axios.get(this.url(`/stacks/${stackId}/automations`))
+			.then(
+				(response) => {
+					return Promise.resolve(response.data)
+				},
+				(err) => {
+					return Promise.reject(err)
+				},
+			)
+			.catch((err) => {
+				return Promise.reject(err)
+			})
+	}
+
+	createAutomation(stackId, event, actionType, config, order = 0) {
+		return axios.post(this.url(`/stacks/${stackId}/automations`), {
+			event,
+			actionType,
+			config,
+			order,
+		})
+			.then(
+				(response) => {
+					return Promise.resolve(response.data)
+				},
+				(err) => {
+					return Promise.reject(err)
+				},
+			)
+			.catch((err) => {
+				return Promise.reject(err)
+			})
+	}
+
+	updateAutomation(id, event, actionType, config, order) {
+		return axios.put(this.url(`/automations/${id}`), {
+			event,
+			actionType,
+			config,
+			order,
+		})
+			.then(
+				(response) => {
+					return Promise.resolve(response.data)
+				},
+				(err) => {
+					return Promise.reject(err)
+				},
+			)
+			.catch((err) => {
+				return Promise.reject(err)
+			})
+	}
+
+	deleteAutomation(id) {
+		return axios.delete(this.url(`/automations/${id}`))
+			.then(
+				(response) => {
+					return Promise.resolve(response.data)
+				},
+				(err) => {
+					return Promise.reject(err)
+				},
+			)
+			.catch((err) => {
+				return Promise.reject(err)
+			})
+	}
+}

--- a/src/store/card.js
+++ b/src/store/card.js
@@ -216,8 +216,8 @@ export default function cardModuleFactory() {
 				for (const newCard of cards) {
 					const existingIndex = state.cards.findIndex(_card => _card.id === newCard.id)
 					if (existingIndex !== -1) {
-						Vue.set(state.cards[existingIndex], 'order', newCard.order)
-						Vue.set(state.cards[existingIndex], 'stackId', newCard.stackId)
+						// Merge all properties from server response (includes labels from automations)
+						Vue.set(state.cards, existingIndex, Object.assign({}, state.cards[existingIndex], newCard))
 					}
 				}
 			},

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -13,6 +13,7 @@ import { generateOcsUrl, generateUrl } from '@nextcloud/router'
 import { BoardApi } from '../services/BoardApi.js'
 import actions from './actions.js'
 import stackModuleFactory from './stack.js'
+import stackAutomationModuleFactory from './stackAutomation.js'
 import cardModuleFactory from './card.js'
 import comment from './comment.js'
 import trashbin from './trashbin.js'
@@ -34,6 +35,7 @@ export default function storeFactory() {
 		modules: {
 			actions,
 			stack: stackModuleFactory(),
+			stackAutomation: stackAutomationModuleFactory(),
 			card: cardModuleFactory(),
 			comment,
 			trashbin,

--- a/src/store/stackAutomation.js
+++ b/src/store/stackAutomation.js
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import Vue from 'vue'
+import { StackAutomationApi } from '../services/StackAutomationApi.js'
+
+const apiClient = new StackAutomationApi()
+
+export default function stackAutomationModuleFactory() {
+	return {
+		state: {
+			automations: {},
+		},
+		getters: {
+			automationsByStack: state => (stackId) => {
+				return state.automations[stackId] || []
+			},
+		},
+		mutations: {
+			setAutomations(state, { stackId, automations }) {
+				Vue.set(state.automations, stackId, automations)
+			},
+			addAutomation(state, { stackId, automation }) {
+				if (!state.automations[stackId]) {
+					Vue.set(state.automations, stackId, [])
+				}
+				state.automations[stackId].push(automation)
+			},
+			updateAutomation(state, { stackId, automation }) {
+				const automations = state.automations[stackId]
+				if (automations) {
+					const index = automations.findIndex(a => a.id === automation.id)
+					if (index !== -1) {
+						Vue.set(automations, index, automation)
+					}
+				}
+			},
+			deleteAutomation(state, { stackId, automationId }) {
+				const automations = state.automations[stackId]
+				if (automations) {
+					const index = automations.findIndex(a => a.id === automationId)
+					if (index !== -1) {
+						automations.splice(index, 1)
+					}
+				}
+			},
+		},
+		actions: {
+			async loadStackAutomations({ commit }, stackId) {
+				try {
+					const automations = await apiClient.loadAutomations(stackId)
+					commit('setAutomations', { stackId, automations })
+					return automations
+				} catch (error) {
+					console.error('Failed to load automations', error)
+					throw error
+				}
+			},
+			async createStackAutomation({ commit }, { stackId, event, actionType, config, order }) {
+				try {
+					const automation = await apiClient.createAutomation(stackId, event, actionType, config, order)
+					commit('addAutomation', { stackId, automation })
+					return automation
+				} catch (error) {
+					console.error('Failed to create automation', error)
+					throw error
+				}
+			},
+			async updateStackAutomation({ commit }, { stackId, id, event, actionType, config, order }) {
+				try {
+					const automation = await apiClient.updateAutomation(id, event, actionType, config, order)
+					commit('updateAutomation', { stackId, automation })
+					return automation
+				} catch (error) {
+					console.error('Failed to update automation', error)
+					throw error
+				}
+			},
+			async deleteStackAutomation({ commit }, { stackId, id }) {
+				try {
+					await apiClient.deleteAutomation(id)
+					commit('deleteAutomation', { stackId, automationId: id })
+				} catch (error) {
+					console.error('Failed to delete automation', error)
+					throw error
+				}
+			},
+		},
+	}
+}


### PR DESCRIPTION
### Summary

This commit adds support for running specific actions when a card is created/deleted in a stack or enters/exits a stack.

Usecase 1:

I'm using deck to track my personal work and I have two stacks where I create new cards: "Nice-to-do" and "Need-to-do" before this commit I added the labels manually, so that I could track that that I always have enough work that I like to do and do enough work that I have to do. With this patch, I'm giving the user an option to automatically add tags on creation.

I can come up with more usecases, especially if I wanna track what happened to a card in a non-linear way, this tool is gold.


* Target version: main

### TODO

- [ ] Unit tests
- [ ] Documentation

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
