### PR TITLE
ci(behat): Make comments readable on GitHub dark mode

### DIFF
--- a/tests/integration/config/behat.yml
+++ b/tests/integration/config/behat.yml
@@ -1,4 +1,8 @@
 default:
+  formatters:
+    pretty:
+      output_styles:
+        comment: [ 'bright-blue' ]
   suites:
     test:
       paths:


### PR DESCRIPTION
## Deck before
<img width="1336" height="258" alt="grafik" src="https://github.com/user-attachments/assets/2db332d3-9ed7-4da4-bd8c-8b9a047bc6b3" />

## Deck after
<img width="1336" height="258" alt="grafik" src="https://github.com/user-attachments/assets/2d723b4c-c0bc-4247-9adf-0d1ddea95bb1" />

