### PR TITLE
perf: Replace getById call with getFirstNodeById

### DIFF
--- a/lib/Service/FilesAppService.php
+++ b/lib/Service/FilesAppService.php
@@ -140,11 +140,10 @@ class FilesAppService implements IAttachmentService, ICustomAttachmentService {
 	public function extendData(Attachment $attachment) {
 		$userFolder = $this->rootFolder->getUserFolder($this->userId);
 		$share = $this->getShareForAttachment($attachment);
-		$files = $userFolder->getById($share->getNode()->getId());
-		if (count($files) === 0) {
+		$file = $userFolder->getFirstNodeById($share->getNode()->getId());
+		if ($file === null) {
 			return $attachment;
 		}
-		$file = array_shift($files);
 		$attachment->setExtendedData([
 			'path' => $userFolder->getRelativePath($file->getPath()),
 			'fileid' => $file->getId(),


### PR DESCRIPTION
We only need the first node anyway and using getFirstNodeById is faster.


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
