### PR TITLE
Submit changes to board color and name on enter key press

### DIFF
--- a/src/components/navigation/AppNavigationBoard.vue
+++ b/src/components/navigation/AppNavigationBoard.vue
@@ -142,7 +142,7 @@
 					required />
 				<NcButton type="tertiary"
 					:disabled="loading"
-					native-type="submit"
+					native-type="button"
 					:title="t('deck', 'Cancel edit')"
 					@click.stop.prevent="cancelEdit">
 					<template #icon>


### PR DESCRIPTION
* Resolves: #7425, #6704
* Target version: main

### Summary
The form for changing the board color and name has 2 buttons, one to cancel the changes and one to save them. Because both buttons are of `native-type="submit"` and the cancel button comes first, color and name changes are discarded when the input field is submitted via enter key.

> Per the HTML spec, when you press Enter in a text field, the browser implicitly submits the form by firing a synthetic click event on the form's first submit button.

This PR changes the button type of the button with the cancel action to `button` instead of `submit`. Now, when the changes are submitted, e.g. via enter key press, the changes are getting saved correctly.

https://github.com/user-attachments/assets/cd2d8fb7-7127-457a-8ed9-c9a566cb8a5e