### PR TITLE
#7588: Archived Cards not shown when searching in specific deck

### DIFF
--- a/src/components/search/GlobalSearchResults.vue
+++ b/src/components/search/GlobalSearchResults.vue
@@ -87,17 +87,18 @@ export default {
 			searchQuery: state => state.searchQuery,
 		}),
 		filteredResults() {
-            const sortFn = (a, b) => a.archived - b.archived || b.lastModified - a.lastModified
-            if (this.$route.params.id) {
-                return this.results.filter((result) => {
-                    if (result.relatedBoard.id.toString() === this.$route.params.id.toString()) {
-                        return result.archived
-                    }
-                    return true
-                }).sort(sortFn)
-            }
-            return [...this.results].sort(sortFn)
-        },
+			const sortFn = (a, b) => a.archived - b.archived || b.lastModified - a.lastModified
+			if (this.$route.params.id) {
+				return this.results.filter((result) => {
+					// Only show cards from the current board if they are archived; show all cards from other boards
+					if (result.relatedBoard.id.toString() === this.$route.params.id.toString()) {
+						return result.archived
+					}
+					return true
+				}).sort(sortFn)
+			}
+			return [...this.results].sort(sortFn)
+		},
 		queryStringArgs() {
 			return {
 				searchQuery: this.searchQuery,


### PR DESCRIPTION
* Resolves: [#7588](https://github.com/nextcloud/deck/issues/7588)
* Target version: main

### Summary
If user inside Board A search for keyword 'Card', if Board A has two cards of Card A and Card B (which is archived), will not be shown in search result.

### TODO
Updated the login that inside Board A when search for keyword 'Card', the archived result (Card B) show to the user.
### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
