### PR TITLE
fix(session): Add null check for boardId in createSession

### DIFF
--- a/src/components/board/Board.vue
+++ b/src/components/board/Board.vue
@@ -163,14 +163,14 @@ export default {
 		},
 	},
 	created() {
-		this.session = createSession(this.id)
+		// Session is created in fetchData() after loadBoardById succeeds
 		this.fetchData()
 		this.$root.$on('open-card', (cardId) => {
 			this.localModal = cardId
 		})
 	},
 	beforeDestroy() {
-		this.session.close()
+		this.session?.close()
 	},
 	methods: {
 		async fetchData() {

--- a/src/sessions.js
+++ b/src/sessions.js
@@ -73,7 +73,7 @@ export function isNotifyPushEnabled() {
  */
 export function createSession(boardId) {
 
-	if (!isNotifyPushEnabled()) {
+	if (!boardId || !isNotifyPushEnabled()) {
 		// return a dummy object
 		return {
 			async close() {},
@@ -107,7 +107,7 @@ export function createSession(boardId) {
 			syncRunning = true
 			await sessionApi.syncSession(boardId, await tokenPromise)
 		} catch (err) {
-			if (err.response.status === 404) {
+			if (err.response?.status === 404) {
 				// session probably expired, let's
 				// create a fresh session
 				create()


### PR DESCRIPTION
### Summary

> Exception
OCA\Deck\Controller\SessionController::create(): Argument #1 ($boardId) must be of type int, null given

Remove `createSession()` from` created()` entirely and move the single call site to `fetchData()`, after `loadBoardById` has successfully resolved — guaranteeing `this.id` is a valid integer.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
