### PR TITLE
fix(notifications): don't notify users about their own actions

### DIFF
--- a/lib/Activity/DeckProvider.php
+++ b/lib/Activity/DeckProvider.php
@@ -73,7 +73,6 @@ class DeckProvider implements IProvider {
 
 		$subjectIdentifier = $event->getSubject();
 		$subjectParams = $event->getSubjectParameters();
-		$ownActivity = ($event->getAuthor() === $this->userId);
 
 		/**
 		 * Map stored parameter objects to rich string types
@@ -85,6 +84,7 @@ class DeckProvider implements IProvider {
 			$author = $subjectParams['author'];
 			unset($subjectParams['author']);
 		}
+		$ownActivity = ($author === $this->userId);
 		$user = $this->userManager->get($author);
 		$params = [];
 		if ($user !== null) {

--- a/lib/Notification/NotificationHelper.php
+++ b/lib/Notification/NotificationHelper.php
@@ -174,7 +174,7 @@ class NotificationHelper {
 			$notification = $this->generateBoardShared($board, $acl->getParticipant());
 			if ($markAsRead) {
 				$this->notificationManager->markProcessed($notification);
-			} else {
+			} elseif ($acl->getParticipant() !== $this->currentUser) {
 				$notification->setDateTime(new DateTime());
 				$this->notificationManager->notify($notification);
 			}
@@ -201,6 +201,9 @@ class NotificationHelper {
 
 	public function sendMention(IComment $comment): void {
 		foreach ($comment->getMentions() as $mention) {
+			if ((string)$mention['id'] === $this->currentUser) {
+				continue;
+			}
 			$card = $this->cardMapper->find($comment->getObjectId());
 			$boardId = $this->cardMapper->findBoardId($card->getId());
 			$notification = $this->notificationManager->createNotification();


### PR DESCRIPTION
Users were receiving notifications for Action and incorrectly rendered activity entries they performed themselves, such as commenting on cards or sharing boards. The causes:

**1. NotificationHelper:** `sendMention()` and `sendBoardShared()` did not filter out the acting user from notification recipients.

- `sendMention`: skip mentions where the mentioned user is the comment author (`currentUser`)
- `sendBoardShared` (user type): only call `notify()` when participant differs from `currentUser`; `markProcessed` still runs unconditionally to clean up any pre-existing stale notifications on unshare

**2. DeckProvider:** `$ownActivity` was computed from `$event->getAuthor()` *before* the real author was resolved. For comment events, `ActivityManager` overrides the author to `DECK_NOAUTHOR_COMMENT_SYSTEM_ENFORCED`, so `$ownActivity` was always `false` for comments. This caused activity entries to show "{user} commented" instead of "You commented". Moved the check after the author fallback resolution.

* Resolves:
#6955
#4303
#4304
#4305
#2068
#2672 
#5437 
#7102 
#2310
* Target version: main

### Summary

Three fixes:

1. **`sendMention()`**: Skip the mention when `$mention['id'] === $this->currentUser`.
2. **`sendBoardShared()` (user type)**: Replace `else` with `elseif ($acl->getParticipant() !== $this->currentUser)` so that `notify()` is suppressed for the actor, while `markProcessed()` (used on unshare) still runs to clean up stale notifications.
3. **`DeckProvider::parse()`**: Move `$ownActivity` computation after the author fallback resolution so it compares against the real user ID, not `DECK_NOAUTHOR_COMMENT_SYSTEM_ENFORCED`.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required