### PR TITLE
fix(navigation): fix Enter/Escape key behavior in board edit form

### DIFF
--- a/src/components/navigation/AppNavigationBoard.vue
+++ b/src/components/navigation/AppNavigationBoard.vue
@@ -133,7 +133,7 @@
 			<NcColorPicker v-model="editColor" class="app-navigation-entry-bullet-wrapper">
 				<button :style="{ backgroundColor: getColor }" class="color0 icon-colorpicker app-navigation-entry-bullet" />
 			</NcColorPicker>
-			<form @submit.prevent.stop="applyEdit">
+			<form @submit.prevent.stop="applyEdit" @keyup.esc="cancelEdit">
 				<NcTextField ref="inputField"
 					:disable="loading"
 					:value.sync="editTitle"
@@ -142,7 +142,7 @@
 					required />
 				<NcButton type="tertiary"
 					:disabled="loading"
-					native-type="submit"
+					native-type="button"
 					:title="t('deck', 'Cancel edit')"
 					@click.stop.prevent="cancelEdit">
 					<template #icon>


### PR DESCRIPTION
The Cancel button had `native-type="submit"`, making it the first submit button in the form. Due to HTML implicit form submission, pressing Enter in the text field activated the Cancel button instead of saving changes.

- Change Cancel button `native-type` from `"submit"` to `"button"` so that the Save button becomes the form's implicit submit target
- Add `@keyup.esc` handler on the form to cancel editing on Escape

* Resolves: 
#6704
#7105 
* Target version: main

### Summary

When editing a board name in the sidebar navigation, pressing Enter discards changes instead of saving them, and pressing Escape does nothing. This is counter-intuitive behavior (and annoying tbh).

The root cause is that the Cancel button had `native-type="submit"`, making it the first submit button in the `<form>`. Per the [HTML spec for implicit submission](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission), pressing Enter in a text input activates the form's first submit button — which was Cancel, not Save.

| Key | Before | After |
|-----|--------|-------|
| Enter | Cancels editing (discards changes) | Saves the board |
| Escape | Does nothing | Cancels editing |

### TODO

- [x] Fix Cancel button `native-type` from `"submit"` to `"button"`
- [x] Add `@keyup.esc` handler to cancel editing on Escape

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required