### PR TITLE
fix: hide upload button if user has no quota

### DIFF
--- a/src/components/card/AttachmentList.vue
+++ b/src/components/card/AttachmentList.vue
@@ -6,7 +6,7 @@
 <template>
 	<AttachmentDragAndDrop :card-id="cardId" class="drop-upload--sidebar">
 		<div v-if="!isReadOnly" class="button-group">
-			<NcButton class="icon-upload" @click="uploadNewFile()">
+			<NcButton v-if="canUploadLocalFiles" class="icon-upload" @click="uploadNewFile()">
 				{{ t('deck', 'Upload new files') }}
 			</NcButton>
 			<NcButton class="icon-folder" @click="shareFromFiles()">
@@ -141,6 +141,10 @@ export default {
 		}
 	},
 	computed: {
+		canUploadLocalFiles() {
+			const storageStats = loadState('files', 'storageStats', { quota: -1 })
+			return storageStats.quota !== 0
+		},
 		attachments() {
 			// FIXME sort propertly by last modified / deleted at
 			return [...this.$store.getters.attachmentsByCard(this.cardId)].filter(attachment => attachment.deletedAt >= 0).sort((a, b) => b.id - a.id)


### PR DESCRIPTION
### Summary

If user has no quota, don't show the option as it will only lead to an error.
`0 B` quota can be defined exactly to restrict uploads.

Similar to https://github.com/nextcloud/server/blob/0a6831085994b9d388fb79805df8fed2a5597abe/apps/files_sharing/src/files_views/shares.ts#L62-L64

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
