### PR TITLE
feat(board): A board can be pinned as default board

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -411,6 +411,8 @@ OC.L10N.register(
     "Save" : "Speichern",
     "Today" : "Heute",
     "Tomorrow" : "Morgen",
-    "No due" : "Kein Fälligkeitsdatum"
+    "No due" : "Kein Fälligkeitsdatum",
+    "Set as default board" : "Als Standard-Board festlegen",
+    "Remove as default board" : "Als Standard-Board entfernen"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -409,6 +409,8 @@
     "Save" : "Speichern",
     "Today" : "Heute",
     "Tomorrow" : "Morgen",
-    "No due" : "Kein Fälligkeitsdatum"
+    "No due" : "Kein Fälligkeitsdatum",
+    "Set as default board" : "Als Standard-Board festlegen",
+    "Remove as default board" : "Als Standard-Board entfernen"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -411,6 +411,8 @@ OC.L10N.register(
     "Save" : "Speichern",
     "Today" : "Heute",
     "Tomorrow" : "Morgen",
-    "No due" : "Kein Fälligkeitsdatum"
+    "No due" : "Kein Fälligkeitsdatum",
+    "Set as default board" : "Als Standard-Board festlegen",
+    "Remove as default board" : "Als Standard-Board entfernen"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -409,6 +409,8 @@
     "Save" : "Speichern",
     "Today" : "Heute",
     "Tomorrow" : "Morgen",
-    "No due" : "Kein Fälligkeitsdatum"
+    "No due" : "Kein Fälligkeitsdatum",
+    "Set as default board" : "Als Standard-Board festlegen",
+    "Remove as default board" : "Als Standard-Board entfernen"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/en_GB.js
+++ b/l10n/en_GB.js
@@ -411,6 +411,8 @@ OC.L10N.register(
     "Save" : "Save",
     "Today" : "Today",
     "Tomorrow" : "Tomorrow",
-    "No due" : "No due"
+    "No due" : "No due",
+    "Set as default board" : "Set as default board",
+    "Remove as default board" : "Remove as default board"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -409,6 +409,8 @@
     "Save" : "Save",
     "Today" : "Today",
     "Tomorrow" : "Tomorrow",
-    "No due" : "No due"
+    "No due" : "No due",
+    "Set as default board" : "Set as default board",
+    "Remove as default board" : "Remove as default board"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/src/components/navigation/AppNavigationBoard.vue
+++ b/src/components/navigation/AppNavigationBoard.vue
@@ -72,6 +72,13 @@
 					<NcActionButton v-if="!board.archived && board.acl?.length === 0" :icon="board.settings['notify-due'] === 'off' ? 'icon-sound' : 'icon-sound-off'" @click="board.settings['notify-due'] === 'off' ? updateSetting('notify-due', 'all') : updateSetting('notify-due', 'off')">
 						{{ board.settings['notify-due'] === 'off' ? t('deck', 'Turn on due date reminders') : t('deck', 'Turn off due date reminders') }}
 					</NcActionButton>
+					<NcActionButton :close-after-click="true" @click="toggleDefaultBoard">
+						<template #icon>
+							<PinOffIcon v-if="isDefaultBoard" :size="20" decorative />
+							<PinIcon v-else :size="20" decorative />
+						</template>
+						{{ isDefaultBoard ? t('deck', 'Remove as default board') : t('deck', 'Set as default board') }}
+					</NcActionButton>
 				</template>
 
 				<!-- Due date reminder settings -->
@@ -172,6 +179,8 @@ import LeaveIcon from 'vue-material-design-icons/ExitRun.vue'
 import AccountIcon from 'vue-material-design-icons/AccountOutline.vue'
 import CloseIcon from 'vue-material-design-icons/Close.vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
+import PinIcon from 'vue-material-design-icons/Pin.vue'
+import PinOffIcon from 'vue-material-design-icons/PinOff.vue'
 
 import { loadState } from '@nextcloud/initial-state'
 import { emit } from '@nextcloud/event-bus'
@@ -198,6 +207,8 @@ export default {
 		CloneIcon,
 		CloseIcon,
 		CheckIcon,
+		PinIcon,
+		PinOffIcon,
 		LeaveIcon,
 		BoardCloneModal,
 		BoardExportModal,
@@ -231,6 +242,7 @@ export default {
 			cloneModalOpen: false,
 			exportModalOpen: false,
 			currentUser: getCurrentUser(),
+			defaultBoardId: localStorage.getItem('deck.defaultBoardId'),
 		}
 	},
 	computed: {
@@ -275,6 +287,9 @@ export default {
 			}
 			return ''
 		},
+		isDefaultBoard() {
+			return this.defaultBoardId === String(this.board.id)
+		},
 	},
 	watch: {},
 	mounted() {
@@ -282,6 +297,15 @@ export default {
 		this.popupItem = this.$el
 	},
 	methods: {
+		toggleDefaultBoard() {
+			if (this.isDefaultBoard) {
+				localStorage.removeItem('deck.defaultBoardId')
+				this.defaultBoardId = null
+			} else {
+				localStorage.setItem('deck.defaultBoardId', String(this.board.id))
+				this.defaultBoardId = String(this.board.id)
+			}
+		},
 		unDelete() {
 			clearTimeout(this.undoTimeoutHandle)
 			this.boardApi.unDeleteBoard(this.board)

--- a/src/router.js
+++ b/src/router.js
@@ -155,6 +155,14 @@ router.beforeEach((to, from, next) => {
 		next(path)
 		return
 	}
+	// Redirect to the pinned default board if set and navigating to the main route
+	if (to.name === 'main') {
+		const defaultBoardId = localStorage.getItem('deck.defaultBoardId')
+		if (defaultBoardId) {
+			next({ name: 'board', params: { id: parseInt(defaultBoardId, 10) } })
+			return
+		}
+	}
 	next()
 })
 


### PR DESCRIPTION
Adds a "Set as default board" option to the board context menu.

Opening Deck always navigated to the "Upcoming cards" overview, which is empty for teams that don't use due dates. With this change, any board can be pinned as the landing page: right-click it in the sidebar and choose **Set as default board**. The next time Deck is opened, it goes straight there. Choosing **Remove as default board** restores the normal overview.

The preference is stored in **localStorage** (key `deck.defaultBoardId`) with no server-side changes needed. The selection is wired through the Vuex store so that all board items in the sidebar stay in sync - pinning a new board immediately unpins the previous one everywhere.


* Resolves: #7658
* Target version: main

### Open questions
English and German translations are available in this PR.
Will translation to missing languages be added by the Transifex pipeline automatically? 

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
