### PR TITLE
fix: show unknown federated users in search

### DIFF
--- a/src/components/board/SharingTabSidebar.vue
+++ b/src/components/board/SharingTabSidebar.vue
@@ -138,7 +138,7 @@ export default {
 					...item,
 					displayName: item.displayname || item.name || item.label || item.id,
 					user: item.id,
-					subname: item.shareWithDisplayNameUnique || item.subline, // NcSelectUser does its own pattern matching to filter things out
+					subname: item.shareWithDisplayNameUnique || item.subline || item.id, // NcSelectUser does its own pattern matching to filter things out
 				}
 				return res
 			}).slice(0, 10)
@@ -147,7 +147,6 @@ export default {
 		unallocatedSharees() {
 			return this.sharees.filter((sharee) => {
 				const foundIndex = this.board.acl.findIndex((acl) => {
-					console.debug()
 					if (acl.participant.uid === sharee.id && acl.type === SOURCE_TO_SHARE_TYPE[sharee.source]) {
 						return true
 					}

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -433,7 +433,7 @@ export default function storeFactory() {
 				const params = {
 					search: query,
 					itemType: 'deck',
-					shareTypes: [0, 1, 4, 6, 7],
+					shareTypes: [0, 1, 6, 7],
 					limit: 20,
 				}
 


### PR DESCRIPTION
This makes federated users that are not in the address book shown in the search results.
for local testing share to \<userid\>@http://otherinstance.local