### PR TITLE
[stable32] do not re-install phpunit in integration ci

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -63,7 +63,6 @@ jobs:
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-          cd build/integration && composer require --dev phpunit/phpunit:~9
 
       - name: Checkout app
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
ci for integration tests couldn't run before
comparison for a test run before: https://github.com/nextcloud/deck/actions/runs/22556727299/job/65335384451

phpunit is already installed in run.sh: https://github.com/nextcloud/server/blob/stable32/build/integration/run.sh#L41
so I don't know why this line would even be required tbh.