### PR TITLE
fix: user may be null

### DIFF
--- a/lib/Db/BoardMapper.php
+++ b/lib/Db/BoardMapper.php
@@ -105,8 +105,12 @@ class BoardMapper extends QBMapper implements IPermissionMapper {
 		));
 
 		// Shared to user groups of the user
-		$groupIds = $this->groupManager->getUserGroupIds($this->userManager->get($userId));
-		if (count($groupIds) !== 0) {
+		$user = $this->userManager->get($userId);
+		$groupIds = null;
+		if ($user !== null) {
+			$groupIds = $this->groupManager->getUserGroupIds($user);
+		}
+		if ($groupIds !== null && count($groupIds) !== 0) {
 			$qb->orWhere($qb->expr()->andX(
 				$qb->expr()->eq('acl.type', $qb->createNamedParameter(Acl::PERMISSION_TYPE_GROUP, IQueryBuilder::PARAM_INT)),
 				$qb->expr()->in('acl.participant', $qb->createNamedParameter($groupIds, IQueryBuilder::PARAM_STR_ARRAY)),


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
Found in my logs during tests:

```
"CustomMessage":"OC\\Group\\Manager::getUserGroupIds(): Argument #1 ($user) must be of type OCP\\IUser, null given, called in /var/www/html/apps-extra/deck/lib/Db/BoardMapper.php on line 108 in file '/var/www/html/lib/private/Group/Manager.php' line 352"
```

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
