### PR TITLE
docs: Adding a link to third party native client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Deck is a kanban style organization tool aimed at personal planning and project 
 - [mail2deck](https://github.com/newroco/mail2deck) - Provides an "email in" solution
 - [A-deck](https://github.com/leoossa/A-deck) - Chrome Extension that allows to create new card in selected stack based on current tab
 - [QOwnNotes](https://github.com/pbek/QOwnNotes) - Quickly creates cards and links to them in Markdown notes
+- [Nextcloud Deck macOS](https://github.com/unicornops/nextcloud-deck-macos) - Native macOS application for Nextcloud Deck
 
 ## Installation/Update
 


### PR DESCRIPTION

* Target version: main

### Summary
Adding a link to my third party native macOS client for Nextcloud Deck
released under GPLv3 and using the Deck API. Tested and working with the
latest version of Nextcloud and Deck on my own instance.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
