### PR TITLE
Remove `dragDisabled` class to prevent accidential text selection when dragging a card

### DIFF
--- a/src/components/cards/CardItem.vue
+++ b/src/components/cards/CardItem.vue
@@ -20,7 +20,7 @@
 			<CardCover v-if="showCardCover" :card-id="card.id" />
 			<div class="card-upper">
 				<h4 v-if="editingTitle === 0" key="title-view" dir="auto">
-					<span class="dragDisabled" contenteditable="false">{{ displayTitle }}</span>
+					<span contenteditable="false">{{ displayTitle }}</span>
 				</h4>
 				<h4 v-if="editingTitle >= 1"
 					key="title-edit"


### PR DESCRIPTION
* Resolves: #7279 #7514
* Target version: main

### Summary

The card title could be selected with the cursor, which often caused accidental text selection when trying to drag a card. This PR removes the `dragDisabled` class from the card title so that card is dragged instead of text selected.

Especially small cards with only title text and little 'draggable padding' suffered from the text selection issue (see screencast below).

Before:

https://github.com/user-attachments/assets/b4398024-d520-4281-8d5d-4c41889f1cc7

After:

https://github.com/user-attachments/assets/bbcd0db2-a5b4-4f0f-a76b-964af4e0d592
