### PR TITLE
[stable33] chore: remove elzody as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # App maintainers
-* @luka-nextcloud @grnd-alt @elzody
+* @luka-nextcloud @grnd-alt


### PR DESCRIPTION
This change removes me as a code owner since I am no longer a member of the team responsible for the Deck app.
_Manual backport of https://github.com/nextcloud/deck/pull/7828_