### PR TITLE
feat: board and card import from CSV / JSON

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -31,6 +31,7 @@ return [
 		['name' => 'board#transferOwner', 'url' => '/boards/{boardId}/transferOwner', 'verb' => 'PUT'],
 		['name' => 'board#export', 'url' => '/boards/{boardId}/export', 'verb' => 'GET'],
 		['name' => 'board#import', 'url' => '/boards/import', 'verb' => 'POST'],
+		['name' => 'board#importCsv', 'url' => '/boards/{boardId}/importCsv', 'verb' => 'POST'],
 
 		// stacks
 		['name' => 'stack#index', 'url' => '/stacks/{boardId}', 'verb' => 'GET'],

--- a/cypress/e2e/boardFeatures.js
+++ b/cypress/e2e/boardFeatures.js
@@ -266,18 +266,28 @@ describe('Board import', function() {
 	})
 
 	it('Imports a board from JSON', function() {
-		cy.get('#app-navigation-vue .app-navigation__list .app-navigation-entry:contains("Import board")')
-			.should('be.visible')
+		// Open settings dialog
+		cy.get('#app-navigation-vue').contains('Deck settings').click()
+
+		// Click "Import from device" in the Import section
+		cy.get('.app-settings-section').contains('button', 'Import from device')
 			.click()
 
 		// Upload a JSON file
-		cy.get('input[type="file"]')
+		cy.get('.app-settings-section input[type="file"]')
 			.selectFile([
 				{
 					contents: 'cypress/fixtures/import-board.json',
 					fileName: 'import-board.json',
 				},
 			], { force: true })
+
+		// Wait for import to finish and close the import result modal
+		cy.get('.csv-import-modal__result', { timeout: 30000 }).should('be.visible')
+		cy.get('.dialog__actions').contains('button', 'Close').click()
+
+		// Close the settings dialog
+		cy.get('body').type('{esc}')
 
 		cy.get('.app-navigation__list .app-navigation-entry:contains("Imported board")')
 			.should('be.visible')

--- a/lib/Controller/AttachmentOcsController.php
+++ b/lib/Controller/AttachmentOcsController.php
@@ -11,7 +11,9 @@ namespace OCA\Deck\Controller;
 use OCA\Deck\NotImplementedException;
 use OCA\Deck\Service\AttachmentService;
 use OCA\Deck\Service\BoardService;
+use OCP\AppFramework\Http\Attribute\CORS;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
 use OCP\IRequest;
@@ -36,6 +38,8 @@ class AttachmentOcsController extends OCSController {
 	}
 
 	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function getAll(int $cardId, ?int $boardId = null): DataResponse {
 		$this->ensureLocalBoard($boardId);
 		$attachment = $this->attachmentService->findAll($cardId, true);
@@ -43,6 +47,8 @@ class AttachmentOcsController extends OCSController {
 	}
 
 	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function create(int $cardId, string $type, string $data = '', ?int $boardId = null): DataResponse {
 		$this->ensureLocalBoard($boardId);
 		$attachment = $this->attachmentService->create($cardId, $type, $data);
@@ -50,6 +56,8 @@ class AttachmentOcsController extends OCSController {
 	}
 
 	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function update(int $cardId, int $attachmentId, string $data, string $type = 'file', ?int $boardId = null): DataResponse {
 		$this->ensureLocalBoard($boardId);
 		$attachment = $this->attachmentService->update($cardId, $attachmentId, $data, $type);
@@ -57,6 +65,8 @@ class AttachmentOcsController extends OCSController {
 	}
 
 	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function delete(int $cardId, int $attachmentId, string $type = 'file', ?int $boardId = null): DataResponse {
 		$this->ensureLocalBoard($boardId);
 		$attachment = $this->attachmentService->delete($cardId, $attachmentId, $type);
@@ -64,6 +74,8 @@ class AttachmentOcsController extends OCSController {
 	}
 
 	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function restore(int $cardId, int $attachmentId, string $type = 'file', ?int $boardId = null): DataResponse {
 		$this->ensureLocalBoard($boardId);
 		$attachment = $this->attachmentService->restore($cardId, $attachmentId, $type);

--- a/lib/Controller/BoardController.php
+++ b/lib/Controller/BoardController.php
@@ -11,6 +11,7 @@ use OCA\Deck\Db\Acl;
 use OCA\Deck\Db\Board;
 use OCA\Deck\NoPermissionException;
 use OCA\Deck\Service\BoardService;
+use OCA\Deck\Service\CsvImportService;
 use OCA\Deck\Service\ExternalBoardService;
 use OCA\Deck\Service\Importer\BoardImportService;
 use OCA\Deck\Service\PermissionService;
@@ -29,6 +30,7 @@ class BoardController extends ApiController {
 		private ExternalBoardService $externalBoardService,
 		private PermissionService $permissionService,
 		private BoardImportService $boardImportService,
+		private CsvImportService $csvImportService,
 		private IL10N $l10n,
 		private $userId,
 	) {
@@ -168,8 +170,9 @@ class BoardController extends ApiController {
 		if (!empty($file) && array_key_exists('error', $file) && $file['error'] !== UPLOAD_ERR_OK) {
 			$error = $phpFileUploadErrors[$file['error']];
 		}
-		if (!empty($file) && $file['error'] === UPLOAD_ERR_OK && !in_array($file['type'], ['application/json', 'text/plain'], true)) {
-			$error = $this->l10n->t('Invalid file type. Only JSON files are allowed.');
+		$isCsv = $this->isCsvFile($file);
+		if (!empty($file) && $file['error'] === UPLOAD_ERR_OK && !$isCsv && !in_array($file['type'], ['application/json', 'text/plain'], true)) {
+			$error = $this->l10n->t('Invalid file type. Only JSON and CSV files are allowed.');
 		}
 		if ($error !== null) {
 			return new DataResponse([
@@ -180,20 +183,45 @@ class BoardController extends ApiController {
 
 		try {
 			$fileContent = file_get_contents($file['tmp_name']);
-			$this->boardImportService->setSystem('DeckJson');
-			$config = new \stdClass();
-			$config->owner = $this->userId;
-			$this->boardImportService->setConfigInstance($config);
-			$this->boardImportService->setData(json_decode($fileContent));
+
+			if ($isCsv) {
+				$boardTitle = pathinfo($file['name'] ?? 'Imported Board', PATHINFO_FILENAME) ?: 'Imported Board';
+				$this->boardImportService->setSystem('DeckCsv');
+				$config = new \stdClass();
+				$config->owner = $this->userId;
+				$config->boardTitle = $boardTitle;
+				$this->boardImportService->setConfigInstance($config);
+				$data = new \stdClass();
+				$data->rawCsvContent = $fileContent;
+				$data->title = $boardTitle;
+				$this->boardImportService->setData($data);
+			} else {
+				$this->boardImportService->setSystem('DeckJson');
+				$config = new \stdClass();
+				$config->owner = $this->userId;
+				$this->boardImportService->setConfigInstance($config);
+				$this->boardImportService->setData(json_decode($fileContent));
+			}
+
+			$importErrors = [];
+			$this->boardImportService->registerErrorCollector(function (string $message) use (&$importErrors) {
+				$importErrors[] = $message;
+			});
+
 			$this->boardImportService->import();
 			$importedBoard = $this->boardImportService->getBoard();
 			$board = $this->boardService->find($importedBoard->getId());
 
-			return new DataResponse($board, Http::STATUS_OK);
+			return new DataResponse([
+				'board' => $board,
+				'import' => [
+					'errors' => $importErrors,
+				],
+			], Http::STATUS_OK);
 		} catch (\TypeError $e) {
 			return new DataResponse([
 				'status' => 'error',
-				'message' => $this->l10n->t('Invalid JSON data'),
+				'message' => $this->l10n->t('Invalid import data'),
 			], Http::STATUS_BAD_REQUEST);
 		} catch (\Exception $e) {
 			return new DataResponse([
@@ -201,5 +229,66 @@ class BoardController extends ApiController {
 				'message' => $this->l10n->t('Failed to import board'),
 			], Http::STATUS_BAD_REQUEST);
 		}
+	}
+
+	/**
+	 * @NoAdminRequired
+	 */
+	public function importCsv(int $boardId): DataResponse {
+		$file = $this->request->getUploadedFile('file');
+		$error = null;
+		$phpFileUploadErrors = [
+			UPLOAD_ERR_OK => $this->l10n->t('The file was uploaded'),
+			UPLOAD_ERR_INI_SIZE => $this->l10n->t('The uploaded file exceeds the upload_max_filesize directive in php.ini'),
+			UPLOAD_ERR_FORM_SIZE => $this->l10n->t('The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form'),
+			UPLOAD_ERR_PARTIAL => $this->l10n->t('The file was only partially uploaded'),
+			UPLOAD_ERR_NO_FILE => $this->l10n->t('No file was uploaded'),
+			UPLOAD_ERR_NO_TMP_DIR => $this->l10n->t('Missing a temporary folder'),
+			UPLOAD_ERR_CANT_WRITE => $this->l10n->t('Could not write file to disk'),
+			UPLOAD_ERR_EXTENSION => $this->l10n->t('A PHP extension stopped the file upload'),
+		];
+
+		if (empty($file)) {
+			$error = $this->l10n->t('No file uploaded or file size exceeds maximum of %s', [\OCP\Util::humanFileSize(\OCP\Util::uploadLimit())]);
+		}
+		if (!empty($file) && array_key_exists('error', $file) && $file['error'] !== UPLOAD_ERR_OK) {
+			$error = $phpFileUploadErrors[$file['error']];
+		}
+		if (!empty($file) && $file['error'] === UPLOAD_ERR_OK && !$this->isCsvFile($file)) {
+			$error = $this->l10n->t('Invalid file type. Only CSV files are allowed.');
+		}
+		if ($error !== null) {
+			return new DataResponse([
+				'status' => 'error',
+				'message' => $error,
+			], Http::STATUS_BAD_REQUEST);
+		}
+
+		try {
+			$fileContent = file_get_contents($file['tmp_name']);
+			$importResult = $this->csvImportService->importToBoard($boardId, $fileContent, $this->userId);
+			$board = $this->boardService->find($boardId);
+
+			return new DataResponse([
+				'board' => $board,
+				'import' => $importResult,
+			], Http::STATUS_OK);
+		} catch (\Exception $e) {
+			return new DataResponse([
+				'status' => 'error',
+				'message' => $this->l10n->t('Failed to import cards from CSV'),
+			], Http::STATUS_BAD_REQUEST);
+		}
+	}
+
+	private function isCsvFile(?array $file): bool {
+		if (empty($file)) {
+			return false;
+		}
+		if (in_array($file['type'] ?? '', ['text/csv', 'application/csv'], true)) {
+			return true;
+		}
+		$name = $file['name'] ?? '';
+		return str_ends_with(strtolower($name), '.csv');
 	}
 }

--- a/lib/Controller/BoardOcsController.php
+++ b/lib/Controller/BoardOcsController.php
@@ -10,7 +10,9 @@ namespace OCA\Deck\Controller;
 use OCA\Deck\Service\BoardService;
 use OCA\Deck\Service\ExternalBoardService;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\Attribute\RequestHeader;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
 use OCP\IRequest;
@@ -36,6 +38,8 @@ class BoardOcsController extends OCSController {
 
 	#[NoAdminRequired]
 	#[PublicPage]
+	#[NoCSRFRequired]
+	#[RequestHeader(name: 'x-nextcloud-federation', description: 'Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request', indirect: true)]
 	public function read(int $boardId): DataResponse {
 		$localBoard = $this->boardService->find($boardId, true, true);
 		if ($localBoard->getExternalId() !== null) {
@@ -45,16 +49,19 @@ class BoardOcsController extends OCSController {
 	}
 
 	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function create(string $title, string $color): DataResponse {
 		return new DataResponse($this->boardService->create($title, $this->userId, $color));
 	}
 
 	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function addAcl(int $boardId, int $type, string $participant, bool $permissionEdit, bool $permissionShare, bool $permissionManage, ?string $remote = null): DataResponse {
 		return new DataResponse($this->boardService->addAcl($boardId, $type, $participant, $permissionEdit, $permissionShare, $permissionManage));
 	}
 
 	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function updateAcl(int $id, bool $permissionEdit, bool $permissionShare, bool $permissionManage): DataResponse {
 		return new DataResponse($this->boardService->updateAcl($id, $permissionEdit, $permissionShare, $permissionManage));
 	}

--- a/lib/Controller/CardOcsController.php
+++ b/lib/Controller/CardOcsController.php
@@ -14,7 +14,9 @@ use OCA\Deck\Service\CardService;
 use OCA\Deck\Service\ExternalBoardService;
 use OCA\Deck\Service\StackService;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\Attribute\RequestHeader;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
 use OCP\IRequest;
@@ -35,6 +37,8 @@ class CardOcsController extends OCSController {
 
 	#[NoAdminRequired]
 	#[PublicPage]
+	#[NoCSRFRequired]
+	#[RequestHeader(name: 'x-nextcloud-federation', description: 'Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request', indirect: true)]
 	public function create(string $title, int $stackId, ?int $boardId = null, ?string $type = 'plain', ?string $owner = null, ?int $order = 999, ?string $description = '', $duedate = null, $startdate = null, ?array $labels = [], ?array $users = []) {
 		if ($boardId) {
 			$board = $this->boardService->find($boardId, false);
@@ -63,6 +67,7 @@ class CardOcsController extends OCSController {
 
 	#[NoAdminRequired]
 	#[PublicPage]
+	#[NoCSRFRequired]
 	public function assignLabel(?int $boardId, int $cardId, int $labelId): DataResponse {
 		if ($boardId) {
 			$board = $this->boardService->find($boardId, false);
@@ -76,6 +81,7 @@ class CardOcsController extends OCSController {
 
 	#[NoAdminRequired]
 	#[PublicPage]
+	#[NoCSRFRequired]
 	public function assignUser(?int $boardId, int $cardId, string $userId, int $type = 0): DataResponse {
 		if ($boardId) {
 			$localBoard = $this->boardService->find($boardId, false);
@@ -88,6 +94,7 @@ class CardOcsController extends OCSController {
 
 	#[NoAdminRequired]
 	#[PublicPage]
+	#[NoCSRFRequired]
 	public function unAssignUser(?int $boardId, int $cardId, string $userId, int $type = 0): DataResponse {
 		if ($boardId) {
 			$localBoard = $this->boardService->find($boardId, false);
@@ -100,6 +107,7 @@ class CardOcsController extends OCSController {
 
 	#[NoAdminRequired]
 	#[PublicPage]
+	#[NoCSRFRequired]
 	public function removeLabel(?int $boardId, int $cardId, int $labelId): DataResponse {
 		if ($boardId) {
 			$board = $this->boardService->find($boardId, false);
@@ -113,6 +121,8 @@ class CardOcsController extends OCSController {
 
 	#[NoAdminRequired]
 	#[PublicPage]
+	#[NoCSRFRequired]
+	#[RequestHeader(name: 'x-nextcloud-federation', description: 'Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request', indirect: true)]
 	public function update(int $id, string $title, int $stackId, string $type, int $order, string $description, $duedate, $deletedAt, int $boardId, array|string|null $owner = null, $archived = null, $startdate = null): DataResponse {
 		$done = array_key_exists('done', $this->request->getParams())
 			? new OptionalNullableValue($this->request->getParam('done', null))
@@ -160,6 +170,7 @@ class CardOcsController extends OCSController {
 
 	#[NoAdminRequired]
 	#[PublicPage]
+	#[NoCSRFRequired]
 	public function reorder(int $cardId, int $stackId, int $order, ?int $boardId): DataResponse {
 		if ($boardId) {
 			$board = $this->boardService->find($boardId, false);

--- a/lib/Controller/StackOcsController.php
+++ b/lib/Controller/StackOcsController.php
@@ -11,7 +11,9 @@ use OCA\Deck\Service\BoardService;
 use OCA\Deck\Service\ExternalBoardService;
 use OCA\Deck\Service\StackService;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\Attribute\RequestHeader;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
 use OCP\IRequest;
@@ -29,6 +31,8 @@ class StackOcsController extends OCSController {
 
 	#[NoAdminRequired]
 	#[PublicPage]
+	#[NoCSRFRequired]
+	#[RequestHeader(name: 'x-nextcloud-federation', description: 'Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request', indirect: true)]
 	public function index(int $boardId): DataResponse {
 		$localBoard = $this->boardService->find($boardId, true, true);
 		if ($localBoard->getExternalId() !== null) {
@@ -40,6 +44,8 @@ class StackOcsController extends OCSController {
 
 	#[NoAdminRequired]
 	#[PublicPage]
+	#[NoCSRFRequired]
+	#[RequestHeader(name: 'x-nextcloud-federation', description: 'Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request', indirect: true)]
 	public function create(string $title, int $boardId, int $order = 0):DataResponse {
 		$board = $this->boardService->find($boardId, false);
 		if ($board->getExternalId()) {
@@ -53,6 +59,8 @@ class StackOcsController extends OCSController {
 
 	#[NoAdminRequired]
 	#[PublicPage]
+	#[NoCSRFRequired]
+	#[RequestHeader(name: 'x-nextcloud-federation', description: 'Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request', indirect: true)]
 	public function setDoneStack(int $stackId, int $boardId, bool $isDone): DataResponse {
 		$board = $this->boardService->find($boardId, false);
 		if ($board->getExternalId()) {
@@ -65,6 +73,8 @@ class StackOcsController extends OCSController {
 
 	#[NoAdminRequired]
 	#[PublicPage]
+	#[NoCSRFRequired]
+	#[RequestHeader(name: 'x-nextcloud-federation', description: 'Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request', indirect: true)]
 	public function delete(int $stackId, ?int $boardId = null):DataResponse {
 		if ($boardId) {
 			$board = $this->boardService->find($boardId, false);
@@ -80,6 +90,8 @@ class StackOcsController extends OCSController {
 
 	#[NoAdminRequired]
 	#[PublicPage]
+	#[NoCSRFRequired]
+	#[RequestHeader(name: 'x-nextcloud-federation', description: 'Set to 1 when the request is performed by another Nextcloud Server to indicate a federation request', indirect: true)]
 	public function reorder(int $stackId, int $order, ?int $boardId):DataResponse {
 		if ($boardId !== null) {
 			$board = $this->boardService->find($boardId, false);

--- a/lib/Service/CsvImportService.php
+++ b/lib/Service/CsvImportService.php
@@ -1,0 +1,379 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Service;
+
+use OCA\Deck\Db\Acl;
+use OCA\Deck\Db\AclMapper;
+use OCA\Deck\Db\Assignment;
+use OCA\Deck\Db\AssignmentMapper;
+use OCA\Deck\Db\Card;
+use OCA\Deck\Db\CardMapper;
+use OCA\Deck\Db\Label;
+use OCA\Deck\Db\LabelMapper;
+use OCA\Deck\Db\Stack;
+use OCA\Deck\Db\StackMapper;
+use OCA\Deck\Service\Importer\CsvParser;
+use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
+
+class CsvImportService {
+
+	private const DEFAULT_LABEL_COLORS = [
+		'CC317C', '317CCC', '2EA07B', 'F4A331',
+		'9C31CC', 'CC3131', '31CC7C', '3131CC',
+		'CC7C31', '7C31CC',
+	];
+
+	public function __construct(
+		private CsvParser $csvParser,
+		private StackMapper $stackMapper,
+		private CardMapper $cardMapper,
+		private LabelMapper $labelMapper,
+		private AssignmentMapper $assignmentMapper,
+		private AclMapper $aclMapper,
+		private IUserManager $userManager,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Import cards from CSV content into an existing board.
+	 *
+	 * @return array{imported: int, updated: int, total: int, stacksCreated: int, labelsCreated: int, errors: string[]}
+	 */
+	public function importToBoard(int $boardId, string $csvContent, string $userId): array {
+		$rows = $this->csvParser->parse($csvContent);
+		if (empty($rows)) {
+			return ['imported' => 0, 'updated' => 0, 'total' => 0, 'stacksCreated' => 0, 'labelsCreated' => 0, 'errors' => []];
+		}
+
+		$existingStacks = $this->stackMapper->findAll($boardId);
+		$stackMap = [];
+		$maxStackOrder = 0;
+		foreach ($existingStacks as $stack) {
+			$stackMap[mb_strtolower($stack->getTitle())] = $stack;
+			$maxStackOrder = max($maxStackOrder, $stack->getOrder() + 1);
+		}
+
+		$existingLabels = $this->labelMapper->findAll($boardId);
+		$labelMap = [];
+		foreach ($existingLabels as $label) {
+			$labelMap[mb_strtolower($label->getTitle())] = $label;
+		}
+
+		// Share the board with all assigned users before creating cards
+		$this->shareBoardWithAssignedUsers($boardId, $rows, $userId);
+
+		$stacksCreated = 0;
+		$labelsCreated = 0;
+		$colorIndex = 0;
+		$imported = 0;
+		$updated = 0;
+		$total = count($rows);
+		$errors = [];
+		$orderPerStack = [];
+
+		foreach ($rows as $row) {
+			$stackName = $row['stackName'] ?? '';
+			if ($stackName === '') {
+				$stackName = 'Imported';
+			}
+			$stackKey = mb_strtolower($stackName);
+
+			if (!isset($stackMap[$stackKey])) {
+				$stack = new Stack();
+				$stack->setTitle($stackName);
+				$stack->setBoardId($boardId);
+				$stack->setOrder($maxStackOrder++);
+				$stack->setLastModified(time());
+				$this->stackMapper->insert($stack);
+				$stackMap[$stackKey] = $stack;
+				$stacksCreated++;
+			}
+
+			$stackId = $stackMap[$stackKey]->getId();
+			if (!isset($orderPerStack[$stackId])) {
+				$orderPerStack[$stackId] = 0;
+			}
+
+			$cardTitle = $row['title'] ?? '';
+			$cardId = $row['id'] ?? null;
+			$isUpdate = false;
+
+			try {
+				if ($cardId !== null) {
+					// Verify the card exists and belongs to this board
+					$existingBoardId = $this->cardMapper->findBoardId($cardId);
+					if ($existingBoardId === null) {
+						$errors[] = 'Card ID ' . $cardId . ' ("' . $cardTitle . '") not found, creating as new card';
+						$cardId = null;
+					} elseif ($existingBoardId !== $boardId) {
+						$errors[] = 'Card ID ' . $cardId . ' ("' . $cardTitle . '") belongs to a different board, creating as new card';
+						$cardId = null;
+					}
+				}
+
+				if ($cardId !== null) {
+					// Update existing card
+					$card = $this->cardMapper->find($cardId, false);
+					$card->setTitle($cardTitle);
+					$card->setDescription($row['description'] ?? '');
+					$card->setStackId($stackId);
+					$card->setDuedate($row['duedate']);
+
+					$createdAt = $row['createdAt'] ? $row['createdAt']->getTimestamp() : null;
+					$lastModified = $row['lastModified'] ? $row['lastModified']->getTimestamp() : null;
+					if ($createdAt !== null) {
+						$card->setCreatedAt($createdAt);
+					}
+					if ($lastModified !== null) {
+						$card->setLastModified($lastModified);
+					}
+
+					$this->cardMapper->update($card, false);
+					$isUpdate = true;
+				} else {
+					// Create new card
+					$card = new Card();
+					$card->setTitle($cardTitle);
+					$card->setDescription($row['description'] ?? '');
+					$card->setStackId($stackId);
+					$card->setType('plain');
+					$card->setOrder($orderPerStack[$stackId]++);
+					$card->setOwner($userId);
+					$card->setDuedate($row['duedate']);
+
+					$createdAt = $row['createdAt'] ? $row['createdAt']->getTimestamp() : null;
+					$lastModified = $row['lastModified'] ? $row['lastModified']->getTimestamp() : null;
+
+					$this->cardMapper->insert($card);
+
+					$updateDate = false;
+					if ($createdAt !== null && $createdAt !== $card->getCreatedAt()) {
+						$card->setCreatedAt($createdAt);
+						$updateDate = true;
+					}
+					if ($lastModified !== null && $lastModified !== $card->getLastModified()) {
+						$card->setLastModified($lastModified);
+						$updateDate = true;
+					}
+					if ($updateDate) {
+						$this->cardMapper->update($card, false);
+					}
+				}
+			} catch (\Exception $e) {
+				$errors[] = 'Failed to import card "' . $cardTitle . '": ' . $e->getMessage();
+				$this->logger->warning('Failed to import card "' . $cardTitle . '"', ['exception' => $e]);
+				continue;
+			}
+
+			// Sync labels
+			$this->syncCardLabels($card, $row['tags'], $boardId, $labelMap, $colorIndex, $labelsCreated, $isUpdate, $errors, $cardTitle);
+
+			// Sync user assignments
+			$this->syncCardAssignments($card, $row['assignedUsers'], $isUpdate, $errors, $cardTitle);
+
+			if ($isUpdate) {
+				$updated++;
+			} else {
+				$imported++;
+			}
+		}
+
+		return [
+			'imported' => $imported,
+			'updated' => $updated,
+			'total' => $total,
+			'stacksCreated' => $stacksCreated,
+			'labelsCreated' => $labelsCreated,
+			'errors' => $errors,
+		];
+	}
+
+	/**
+	 * Sync labels on a card: for updates, remove labels not in CSV and add missing ones.
+	 */
+	private function syncCardLabels(
+		Card $card,
+		array $tags,
+		int $boardId,
+		array &$labelMap,
+		int &$colorIndex,
+		int &$labelsCreated,
+		bool $isUpdate,
+		array &$errors,
+		string $cardTitle,
+	): void {
+		// Build the desired label set
+		$desiredLabelIds = [];
+		foreach ($tags as $tag) {
+			$tagKey = mb_strtolower($tag);
+			if (!isset($labelMap[$tagKey])) {
+				$label = new Label();
+				$label->setTitle($tag);
+				$index = abs($colorIndex) % count(self::DEFAULT_LABEL_COLORS);
+				$label->setColor(self::DEFAULT_LABEL_COLORS[$index]);
+				$label->setBoardId($boardId);
+				$label->setLastModified(time());
+				$this->labelMapper->insert($label);
+				$labelMap[$tagKey] = $label;
+				$colorIndex++;
+				$labelsCreated++;
+			}
+			$desiredLabelIds[$labelMap[$tagKey]->getId()] = $tag;
+		}
+
+		// For updates, remove labels that are no longer in the CSV
+		if ($isUpdate) {
+			$currentLabels = $this->labelMapper->findAssignedLabelsForCard($card->getId());
+			foreach ($currentLabels as $currentLabel) {
+				if (!isset($desiredLabelIds[$currentLabel->getId()])) {
+					try {
+						$this->cardMapper->removeLabel($card->getId(), $currentLabel->getId());
+					} catch (\Exception $e) {
+						$errors[] = 'Failed to remove label "' . $currentLabel->getTitle() . '" from card "' . $cardTitle . '"';
+					}
+				}
+			}
+			// Only add labels that aren't already assigned
+			$currentLabelIds = array_map(fn ($l) => $l->getId(), $currentLabels);
+			foreach ($desiredLabelIds as $labelId => $tag) {
+				if (!in_array($labelId, $currentLabelIds, true)) {
+					try {
+						$this->cardMapper->assignLabel($card->getId(), $labelId);
+					} catch (\Exception $e) {
+						$errors[] = 'Failed to assign label "' . $tag . '" to card "' . $cardTitle . '"';
+					}
+				}
+			}
+		} else {
+			foreach ($desiredLabelIds as $labelId => $tag) {
+				try {
+					$this->cardMapper->assignLabel($card->getId(), $labelId);
+				} catch (\Exception $e) {
+					$errors[] = 'Failed to assign label "' . $tag . '" to card "' . $cardTitle . '"';
+					$this->logger->warning('Failed to assign label "' . $tag . '" to card "' . $cardTitle . '"', ['exception' => $e]);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Sync user assignments on a card: for updates, remove users not in CSV and add missing ones.
+	 */
+	private function syncCardAssignments(
+		Card $card,
+		array $assignedUsers,
+		bool $isUpdate,
+		array &$errors,
+		string $cardTitle,
+	): void {
+		// Resolve display names to UIDs
+		$desiredUids = [];
+		foreach ($assignedUsers as $displayName) {
+			$users = $this->userManager->searchDisplayName($displayName, 1);
+			if (empty($users)) {
+				$errors[] = 'User "' . $displayName . '" not found for card "' . $cardTitle . '"';
+				continue;
+			}
+			$user = reset($users);
+			$desiredUids[$user->getUID()] = $displayName;
+		}
+
+		if ($isUpdate) {
+			$currentAssignments = $this->assignmentMapper->findAll($card->getId());
+			$currentUids = [];
+			foreach ($currentAssignments as $assignment) {
+				$currentUids[$assignment->getParticipant()] = $assignment;
+			}
+
+			// Remove assignments not in CSV
+			foreach ($currentUids as $uid => $assignment) {
+				if (!isset($desiredUids[$uid])) {
+					try {
+						$this->assignmentMapper->delete($assignment);
+					} catch (\Exception $e) {
+						$errors[] = 'Failed to remove user "' . $uid . '" from card "' . $cardTitle . '"';
+					}
+				}
+			}
+
+			// Add missing assignments
+			foreach ($desiredUids as $uid => $displayName) {
+				if (!isset($currentUids[$uid])) {
+					try {
+						$assignment = new Assignment();
+						$assignment->setCardId($card->getId());
+						$assignment->setParticipant($uid);
+						$assignment->setType(Assignment::TYPE_USER);
+						$this->assignmentMapper->insert($assignment);
+					} catch (\Exception $e) {
+						$errors[] = 'Failed to assign user "' . $displayName . '" to card "' . $cardTitle . '"';
+					}
+				}
+			}
+		} else {
+			foreach ($desiredUids as $uid => $displayName) {
+				try {
+					$assignment = new Assignment();
+					$assignment->setCardId($card->getId());
+					$assignment->setParticipant($uid);
+					$assignment->setType(Assignment::TYPE_USER);
+					$this->assignmentMapper->insert($assignment);
+				} catch (\Exception $e) {
+					$errors[] = 'Failed to assign user "' . $displayName . '" to card "' . $cardTitle . '"';
+					$this->logger->warning('Failed to assign user "' . $displayName . '" to card "' . $cardTitle . '"', ['exception' => $e]);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Share the board with all users referenced in the CSV before assigning them to cards.
+	 *
+	 * @param array<int, array<string, mixed>> $rows
+	 */
+	private function shareBoardWithAssignedUsers(int $boardId, array $rows, string $ownerUid): void {
+		$existingAcls = $this->aclMapper->findAll($boardId);
+		$sharedUsers = [];
+		foreach ($existingAcls as $acl) {
+			if ($acl->getType() === Acl::PERMISSION_TYPE_USER) {
+				$sharedUsers[$acl->getParticipant()] = true;
+			}
+		}
+
+		foreach ($rows as $row) {
+			foreach ($row['assignedUsers'] as $displayName) {
+				$users = $this->userManager->searchDisplayName($displayName, 1);
+				if (!empty($users)) {
+					$user = reset($users);
+					$uid = $user->getUID();
+
+					// Skip the board owner and already-shared users
+					if ($uid === $ownerUid || isset($sharedUsers[$uid])) {
+						continue;
+					}
+
+					try {
+						$acl = new Acl();
+						$acl->setBoardId($boardId);
+						$acl->setType(Acl::PERMISSION_TYPE_USER);
+						$acl->setParticipant($uid);
+						$acl->setPermissionEdit(true);
+						$acl->setPermissionShare(false);
+						$acl->setPermissionManage(false);
+						$this->aclMapper->insert($acl);
+						$sharedUsers[$uid] = true;
+					} catch (\Exception $e) {
+						$this->logger->warning('Failed to share board with user "' . $uid . '"', ['exception' => $e]);
+					}
+				}
+			}
+		}
+	}
+}

--- a/lib/Service/Importer/BoardImportService.php
+++ b/lib/Service/Importer/BoardImportService.php
@@ -24,6 +24,7 @@ use OCA\Deck\Event\BoardImportGetAllowedEvent;
 use OCA\Deck\Exceptions\ConflictException;
 use OCA\Deck\NotFoundException;
 use OCA\Deck\Service\FileService;
+use OCA\Deck\Service\Importer\Systems\DeckCsvService;
 use OCA\Deck\Service\Importer\Systems\DeckJsonService;
 use OCA\Deck\Service\Importer\Systems\TrelloApiService;
 use OCA\Deck\Service\Importer\Systems\TrelloJsonService;
@@ -181,6 +182,11 @@ class BoardImportService {
 				'name' => TrelloJsonService::$name,
 				'class' => TrelloJsonService::class,
 				'internalName' => 'TrelloJson'
+			]);
+			$this->addAllowedImportSystem([
+				'name' => DeckCsvService::$name,
+				'class' => DeckCsvService::class,
+				'internalName' => 'DeckCsv'
 			]);
 		}
 		$this->eventDispatcher->dispatchTyped(new BoardImportGetAllowedEvent($this));

--- a/lib/Service/Importer/CsvParser.php
+++ b/lib/Service/Importer/CsvParser.php
@@ -1,0 +1,267 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Service\Importer;
+
+use OCP\L10N\IFactory;
+
+class CsvParser {
+
+	private const HEADER_MAP = [
+		'ID' => 'id',
+		'Card title' => 'title',
+		'Description' => 'description',
+		'List name' => 'stackName',
+		'Tags' => 'tags',
+		'Assigned users' => 'assignedUsers',
+		'Due date' => 'duedate',
+		'Created' => 'createdAt',
+		'Modified' => 'lastModified',
+	];
+
+	/** Date-only formats to try, ordered from unambiguous to locale-specific */
+	private const DATE_FORMATS = [
+		'Y-m-d',   // ISO date (sv-SE, lt-LT)
+		'Y/n/j',   // ja-JP, zh-CN, ko-KR
+		'j.n.Y',   // de-DE, de-AT, de-CH
+		'j/n/Y',   // en-GB, most of Europe
+	];
+
+	/**
+	 * Maps ICU date pattern characters to PHP date format characters.
+	 * Only covers the short date patterns produced by IntlDateFormatter::SHORT.
+	 */
+	private const ICU_TO_PHP = [
+		'dd' => 'd', 'd' => 'j',
+		'MM' => 'm', 'M' => 'n',
+		'yyyy' => 'Y', 'yy' => 'y',
+		'y' => 'Y',
+	];
+
+	private ?string $localeFormat = null;
+
+	public function __construct(
+		?IFactory $l10nFactory = null,
+	) {
+		if ($l10nFactory !== null) {
+			$this->localeFormat = $this->detectLocaleFormat($l10nFactory->findLocale());
+		}
+	}
+
+	/**
+	 * Parse CSV content (possibly UTF-16LE with BOM) into an array of associative arrays.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function parse(string $rawContent): array {
+		$content = $this->convertEncoding($rawContent);
+		$content = $this->stripUtf8Bom($content);
+
+		$stream = fopen('php://temp', 'r+');
+		fwrite($stream, $content);
+		rewind($stream);
+
+		$delimiter = $this->detectDelimiter($stream);
+
+		$headers = fgetcsv($stream, 0, $delimiter, '"', '"');
+		if ($headers === false || $headers === [null]) {
+			fclose($stream);
+			return [];
+		}
+
+		$headerKeys = $this->mapHeaders($headers);
+
+		$rows = [];
+		while (($fields = fgetcsv($stream, 0, $delimiter, '"', '"')) !== false) {
+			if ($fields === [null]) {
+				continue;
+			}
+
+			$row = [];
+			foreach ($headerKeys as $index => $key) {
+				$value = $fields[$index] ?? '';
+				$row[$key] = $value;
+			}
+
+			$rawId = trim($row['id'] ?? '');
+			$row['id'] = ($rawId !== '' && is_numeric($rawId)) ? (int)$rawId : null;
+			$row['tags'] = $this->splitCommaSeparated($row['tags'] ?? '');
+			$row['assignedUsers'] = $this->splitCommaSeparated($row['assignedUsers'] ?? '');
+			$row['duedate'] = $this->parseDate($row['duedate'] ?? '');
+			$row['createdAt'] = $this->parseDate($row['createdAt'] ?? '');
+			$row['lastModified'] = $this->parseDate($row['lastModified'] ?? '');
+
+			$rows[] = $row;
+		}
+
+		fclose($stream);
+		return $rows;
+	}
+
+	/**
+	 * Detect delimiter by reading the first line and counting tab vs comma occurrences.
+	 * Rewinds the stream after detection.
+	 */
+	private function detectDelimiter($stream): string {
+		$firstLine = fgets($stream);
+		rewind($stream);
+
+		if ($firstLine === false) {
+			return "\t";
+		}
+
+		$tabs = substr_count($firstLine, "\t");
+		$commas = substr_count($firstLine, ',');
+
+		return $tabs >= $commas ? "\t" : ',';
+	}
+
+	private function convertEncoding(string $content): string {
+		// Detect UTF-16LE BOM (FF FE)
+		if (strlen($content) >= 2 && $content[0] === "\xFF" && $content[1] === "\xFE") {
+			$result = mb_convert_encoding($content, 'UTF-8', 'UTF-16LE');
+			return $result !== false ? $result : $content;
+		}
+
+		// Detect UTF-16BE BOM (FE FF)
+		if (strlen($content) >= 2 && $content[0] === "\xFE" && $content[1] === "\xFF") {
+			$result = mb_convert_encoding($content, 'UTF-8', 'UTF-16BE');
+			return $result !== false ? $result : $content;
+		}
+
+		return $content;
+	}
+
+	private function stripUtf8Bom(string $content): string {
+		if (str_starts_with($content, "\xEF\xBB\xBF")) {
+			return substr($content, 3);
+		}
+		return $content;
+	}
+
+	/**
+	 * @return array<int, string> index => normalized key
+	 */
+	private function mapHeaders(array $headers): array {
+		$mapped = [];
+		foreach ($headers as $index => $header) {
+			$header = trim($header);
+			$mapped[$index] = self::HEADER_MAP[$header] ?? $header;
+		}
+		return $mapped;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function splitCommaSeparated(string $value): array {
+		if (trim($value) === '') {
+			return [];
+		}
+
+		$items = explode(',', $value);
+		$result = [];
+		foreach ($items as $item) {
+			$trimmed = trim($item);
+			if ($trimmed !== '') {
+				$result[] = $trimmed;
+			}
+		}
+		return $result;
+	}
+
+	public function parseDate(?string $value): ?\DateTime {
+		if ($value === null || trim($value) === '' || trim($value) === 'null') {
+			return null;
+		}
+
+		$value = trim($value);
+
+		// Try ISO 8601 with time first (e.g. 2026-02-20T19:00:00+00:00)
+		$date = \DateTime::createFromFormat(\DateTime::ATOM, $value);
+		if ($date !== false) {
+			return $date;
+		}
+
+		// Try the user's locale format first if available
+		if ($this->localeFormat !== null) {
+			$date = \DateTime::createFromFormat($this->localeFormat, $value);
+			if ($date !== false && $this->isCleanParse()) {
+				$date->setTime(0, 0, 0);
+				return $date;
+			}
+		}
+
+		// Fall back to common formats
+		foreach (self::DATE_FORMATS as $format) {
+			$date = \DateTime::createFromFormat($format, $value);
+			if ($date !== false && $this->isCleanParse()) {
+				$date->setTime(0, 0, 0);
+				return $date;
+			}
+		}
+
+		// m/d/Y (en-US) — only when day > 12 to avoid ambiguity with d/m/Y
+		$parts = explode('/', $value);
+		if (count($parts) === 3 && (int)$parts[1] > 12) {
+			$date = \DateTime::createFromFormat('n/j/Y', $value);
+			if ($date !== false && $this->isCleanParse()) {
+				$date->setTime(0, 0, 0);
+				return $date;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Use IntlDateFormatter to derive the PHP date format for the user's locale.
+	 */
+	private function detectLocaleFormat(string $locale): ?string {
+		if (!class_exists(\IntlDateFormatter::class)) {
+			return null;
+		}
+
+		$formatter = new \IntlDateFormatter($locale, \IntlDateFormatter::SHORT, \IntlDateFormatter::NONE);
+		/** @var \IntlDateFormatter $formatter */
+
+		$icuPattern = $formatter->getPattern();
+		return $this->icuToPhpFormat($icuPattern);
+	}
+
+	/**
+	 * Convert an ICU short date pattern (e.g. "dd/MM/yyyy" or "M/d/yy")
+	 * to a PHP DateTime::createFromFormat string.
+	 */
+	private function icuToPhpFormat(string $icuPattern): ?string {
+		// Replace longer tokens first to avoid partial matches
+		$phpFormat = $icuPattern;
+		// Sort keys by length descending so 'dd' is replaced before 'd', etc.
+		$replacements = self::ICU_TO_PHP;
+		uksort($replacements, fn ($a, $b) => strlen($b) - strlen($a));
+
+		foreach ($replacements as $icu => $php) {
+			$phpFormat = str_replace($icu, $php, $phpFormat);
+		}
+
+		// Verify no ICU tokens remain (would indicate an unsupported pattern)
+		if (preg_match('/[a-zA-Z]/', preg_replace('/[djnmYy]/', '', $phpFormat))) {
+			return null;
+		}
+
+		return $phpFormat;
+	}
+
+	/**
+	 * Check that the last createFromFormat call produced no warnings or errors
+	 * (e.g. month 13 silently overflowing to January of next year).
+	 */
+	private function isCleanParse(): bool {
+		$errors = \DateTime::getLastErrors();
+		return $errors === false || ($errors['warning_count'] === 0 && $errors['error_count'] === 0);
+	}
+}

--- a/lib/Service/Importer/Systems/DeckCsvService.php
+++ b/lib/Service/Importer/Systems/DeckCsvService.php
@@ -1,0 +1,265 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Service\Importer\Systems;
+
+use OCA\Deck\Db\Acl;
+use OCA\Deck\Db\Assignment;
+use OCA\Deck\Db\Board;
+use OCA\Deck\Db\Card;
+use OCA\Deck\Db\Label;
+use OCA\Deck\Db\Stack;
+use OCA\Deck\Service\Importer\ABoardImportService;
+use OCA\Deck\Service\Importer\CsvParser;
+use OCP\IUserManager;
+
+class DeckCsvService extends ABoardImportService {
+	public static $name = 'Deck CSV';
+
+	protected bool $needValidateData = false;
+
+	private const DEFAULT_LABEL_COLORS = [
+		'CC317C', '317CCC', '2EA07B', 'F4A331',
+		'9C31CC', 'CC3131', '31CC7C', '3131CC',
+		'CC7C31', '7C31CC',
+	];
+
+	/** @var array<int, array<string, mixed>> */
+	private array $parsedRows = [];
+
+	/** @var array<string, int> stack name => index */
+	private array $stackNameIndex = [];
+
+	/** @var array<string, int> label title => index */
+	private array $labelNameIndex = [];
+
+	/** @var array<int, array<string, mixed>> */
+	private array $tmpCards = [];
+
+	public function __construct(
+		private CsvParser $csvParser,
+		private IUserManager $userManager,
+	) {
+	}
+
+	public function bootstrap(): void {
+		$this->parseIfNeeded();
+	}
+
+	private function parseIfNeeded(): void {
+		if (empty($this->parsedRows)) {
+			$data = $this->getImportService()->getData();
+			$this->parsedRows = $this->csvParser->parse($data->rawCsvContent);
+		}
+	}
+
+	public function getJsonSchemaPath(): string {
+		return implode(DIRECTORY_SEPARATOR, [
+			__DIR__,
+			'..',
+			'fixtures',
+			'config-deckCsv-schema.json',
+		]);
+	}
+
+	public function validateUsers(): void {
+	}
+
+	public function getBoard(): Board {
+		$board = $this->getImportService()->getBoard();
+		$boardTitle = $this->getImportService()->getConfig('boardTitle') ?? 'Imported Board';
+		$owner = $this->getImportService()->getConfig('owner');
+
+		$board->setTitle($boardTitle);
+		$board->setOwner($owner instanceof \OCP\IUser ? $owner->getUID() : (string)$owner);
+		$board->setColor('0800fd');
+		$board->setArchived(false);
+		$board->setDeletedAt(0);
+		$board->setLastModified(time());
+		return $board;
+	}
+
+	/**
+	 * @return Label[]
+	 */
+	public function getLabels(): array {
+		$this->parseIfNeeded();
+		$colorIndex = 0;
+		foreach ($this->parsedRows as $row) {
+			foreach ($row['tags'] as $tag) {
+				if (!isset($this->labelNameIndex[$tag])) {
+					$this->labelNameIndex[$tag] = $colorIndex;
+					$label = new Label();
+					$label->setTitle($tag);
+					$label->setColor(self::DEFAULT_LABEL_COLORS[$colorIndex % count(self::DEFAULT_LABEL_COLORS)]);
+					$label->setBoardId($this->getImportService()->getBoard()->getId());
+					$label->setLastModified(time());
+					$this->labels[$colorIndex] = $label;
+					$colorIndex++;
+				}
+			}
+		}
+		return $this->labels;
+	}
+
+	/**
+	 * @return Stack[]
+	 */
+	public function getStacks(): array {
+		$this->parseIfNeeded();
+		$order = 0;
+		foreach ($this->parsedRows as $index => $row) {
+			$stackName = $row['stackName'] ?? '';
+			if ($stackName === '') {
+				$stackName = 'Imported';
+			}
+
+			if (!isset($this->stackNameIndex[$stackName])) {
+				$this->stackNameIndex[$stackName] = count($this->stackNameIndex);
+				$stack = new Stack();
+				$stack->setTitle($stackName);
+				$stack->setBoardId($this->getImportService()->getBoard()->getId());
+				$stack->setOrder($order);
+				$stack->setLastModified(time());
+				$this->stacks[$this->stackNameIndex[$stackName]] = $stack;
+				$order++;
+			}
+
+			$row['_index'] = $index;
+			$row['_stackKey'] = $this->stackNameIndex[$stackName];
+			$this->tmpCards[] = $row;
+		}
+		return $this->stacks;
+	}
+
+	/**
+	 * @return Card[]
+	 */
+	public function getCards(): array {
+		$this->parseIfNeeded();
+		$cards = [];
+		$orderPerStack = [];
+
+		foreach ($this->tmpCards as $row) {
+			$stackKey = $row['_stackKey'];
+			if (!isset($orderPerStack[$stackKey])) {
+				$orderPerStack[$stackKey] = 0;
+			}
+
+			$card = new Card();
+			$card->setTitle($row['title'] ?? '');
+			$card->setDescription($row['description'] ?? '');
+			$card->setStackId($this->stacks[$stackKey]->getId());
+			$card->setType('plain');
+			$card->setOrder($orderPerStack[$stackKey]++);
+
+			$owner = $this->getImportService()->getConfig('owner');
+			$card->setOwner($owner instanceof \OCP\IUser ? $owner->getUID() : (string)$owner);
+
+			$card->setDuedate($row['duedate']);
+			$card->setCreatedAt($row['createdAt'] ? $row['createdAt']->getTimestamp() : null);
+			$card->setLastModified($row['lastModified'] ? $row['lastModified']->getTimestamp() : time());
+
+			$cards[$row['_index']] = $card;
+		}
+		return $cards;
+	}
+
+	public function getCardLabelAssignment(): array {
+		$cardsLabels = [];
+		foreach ($this->tmpCards as $row) {
+			$cardId = $this->cards[$row['_index']]->getId();
+			foreach ($row['tags'] as $tag) {
+				if (isset($this->labelNameIndex[$tag])) {
+					$labelId = $this->labels[$this->labelNameIndex[$tag]]->getId();
+					$cardsLabels[$cardId][] = $labelId;
+				}
+			}
+		}
+		return $cardsLabels;
+	}
+
+	public function getCardAssignments(): array {
+		$assignments = [];
+		foreach ($this->tmpCards as $row) {
+			$cardId = $this->cards[$row['_index']]->getId();
+			foreach ($row['assignedUsers'] as $displayName) {
+				$users = $this->userManager->searchDisplayName($displayName, 1);
+				if (!empty($users)) {
+					$user = reset($users);
+					$assignment = new Assignment();
+					$assignment->setCardId($cardId);
+					$assignment->setParticipant($user->getUID());
+					$assignment->setType(Assignment::TYPE_USER);
+					$assignments[$row['_index']][] = $assignment;
+				}
+			}
+		}
+		return $assignments;
+	}
+
+	/**
+	 * Share the board with all assigned users so they can be assigned to cards.
+	 *
+	 * @return Acl[]
+	 */
+	public function getAclList(): array {
+		$this->parseIfNeeded();
+		$acls = [];
+		$seenUsers = [];
+
+		foreach ($this->tmpCards as $row) {
+			foreach ($row['assignedUsers'] as $displayName) {
+				$users = $this->userManager->searchDisplayName($displayName, 1);
+				if (!empty($users)) {
+					$user = reset($users);
+					$uid = $user->getUID();
+
+					// Skip the board owner — they already have access
+					$owner = $this->getImportService()->getConfig('owner');
+					$ownerUid = $owner instanceof \OCP\IUser ? $owner->getUID() : (string)$owner;
+					if ($uid === $ownerUid) {
+						continue;
+					}
+
+					if (!isset($seenUsers[$uid])) {
+						$acl = new Acl();
+						$acl->setBoardId($this->getImportService()->getBoard()->getId());
+						$acl->setType(Acl::PERMISSION_TYPE_USER);
+						$acl->setParticipant($uid);
+						$acl->setPermissionEdit(true);
+						$acl->setPermissionShare(false);
+						$acl->setPermissionManage(false);
+						$acls[] = $acl;
+						$seenUsers[$uid] = true;
+					}
+				}
+			}
+		}
+
+		return $acls;
+	}
+
+	/**
+	 * @return array<int, array<string, \OCP\Comments\IComment>>
+	 */
+	public function getComments(): array {
+		return [];
+	}
+
+	public function getBoards(): array {
+		return [$this->getImportService()->getData()];
+	}
+
+	public function reset(): void {
+		parent::reset();
+		$this->parsedRows = [];
+		$this->stackNameIndex = [];
+		$this->labelNameIndex = [];
+		$this->tmpCards = [];
+	}
+}

--- a/lib/Service/Importer/fixtures/config-deckCsv-schema.json
+++ b/lib/Service/Importer/fixtures/config-deckCsv-schema.json
@@ -1,0 +1,19 @@
+{
+    "type": "object",
+    "properties": {
+        "owner": {
+            "type": "string",
+            "required": true,
+            "comment": "Nextcloud owner username"
+        },
+        "boardTitle": {
+            "type": "string",
+            "required": true,
+            "comment": "Title for the imported board"
+        },
+        "uidRelation": {
+            "type": "object",
+            "comment": "Relationship between display names and Nextcloud usernames"
+        }
+    }
+}

--- a/lib/Service/Importer/fixtures/config-deckCsv-schema.json.license
+++ b/lib/Service/Importer/fixtures/config-deckCsv-schema.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/src/components/DeckAppSettings.vue
+++ b/src/components/DeckAppSettings.vue
@@ -42,6 +42,35 @@
 			</NcFormBox>
 		</NcAppSettingsSection>
 
+		<NcAppSettingsSection v-if="canCreate" id="import-settings" :name="t('deck', 'Import')">
+			<p>{{ t('deck', 'Import a board from a JSON or CSV file.') }}</p>
+			<div class="import-buttons">
+				<NcButton type="secondary" @click="importFromNextcloud">
+					<template #icon>
+						<CloudUploadIcon :size="20" />
+					</template>
+					{{ t('deck', 'Import from Nextcloud') }}
+				</NcButton>
+				<NcButton type="secondary" @click="importFromDevice">
+					<template #icon>
+						<UploadIcon :size="20" />
+					</template>
+					{{ t('deck', 'Import from device') }}
+				</NcButton>
+			</div>
+			<input ref="fileInput"
+				type="file"
+				accept="application/json,.csv,text/csv"
+				style="display: none;"
+				@change="onLocalFileSelected">
+			<CsvImportModal v-if="importModalOpen"
+				:importing="importing"
+				:messages="importMessages"
+				:errors="importErrors"
+				:title="t('deck', 'Import board')"
+				@close="onCloseImportModal" />
+		</NcAppSettingsSection>
+
 		<NcAppSettingsShortcutsSection>
 			<NcHotkeyList :label="t('deck', 'Board actions')">
 				<NcHotkey :label="t('deck', 'Scroll sideways')" hotkey="Shift Scroll" />
@@ -74,15 +103,25 @@ import NcFormBox from '@nextcloud/vue/components/NcFormBox'
 import NcFormBoxSwitch from '@nextcloud/vue/components/NcFormBoxSwitch'
 import NcHotkeyList from '@nextcloud/vue/components/NcHotkeyList'
 import NcHotkey from '@nextcloud/vue/components/NcHotkey'
-import { NcSelect } from '@nextcloud/vue'
+import { NcButton, NcSelect } from '@nextcloud/vue'
 import { confirmPassword } from '@nextcloud/password-confirmation'
 import '@nextcloud/password-confirmation/style.css' // Required for dialog styles
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
+import { getFilePickerBuilder, FilePickerType } from '@nextcloud/dialogs'
+import { getClient, getRootPath } from '@nextcloud/files/dav'
+import { loadState } from '@nextcloud/initial-state'
+import CloudUploadIcon from 'vue-material-design-icons/CloudUpload.vue'
+import UploadIcon from 'vue-material-design-icons/Upload.vue'
+import CsvImportModal from './navigation/CsvImportModal.vue'
+
+const davClient = getClient()
+const canCreateState = loadState('deck', 'canCreate')
 
 export default {
 	name: 'DeckAppSettings',
 	components: {
+		NcButton,
 		NcSelect,
 		NcAppSettingsDialog,
 		NcAppSettingsSection,
@@ -91,6 +130,9 @@ export default {
 		NcFormBoxSwitch,
 		NcHotkeyList,
 		NcHotkey,
+		CloudUploadIcon,
+		UploadIcon,
+		CsvImportModal,
 	},
 
 	props: {
@@ -104,6 +146,11 @@ export default {
 		return {
 			groups: [],
 			groupLimit: [],
+			canCreate: canCreateState,
+			importModalOpen: false,
+			importing: false,
+			importMessages: [],
+			importErrors: [],
 		}
 	},
 
@@ -182,6 +229,70 @@ export default {
 			await this.$store.dispatch('setConfig', { groupLimit: this.groupLimit })
 		},
 
+		async importFromNextcloud() {
+			try {
+				const picker = getFilePickerBuilder(t('deck', 'Select file to import'))
+					.setMultiSelect(false)
+					.setMimeTypeFilter(['application/json', 'text/csv', 'text/plain'])
+					.setType(FilePickerType.Choose)
+					.build()
+				const path = await picker.pick()
+				const contents = await davClient.getFileContents(getRootPath() + path)
+				const filename = path.split('/').pop()
+				const mime = filename.endsWith('.csv') ? 'text/csv' : 'application/json'
+				const file = new File([contents], filename, { type: mime })
+				await this.doImport(file)
+			} catch (e) {
+				// FilePicker closed without selection
+			}
+		},
+		importFromDevice() {
+			this.$refs.fileInput.value = ''
+			this.$refs.fileInput.click()
+		},
+		async onLocalFileSelected(event) {
+			const file = event.target.files[0]
+			if (file) {
+				await this.doImport(file)
+			}
+		},
+		async doImport(file) {
+			this.importModalOpen = true
+			this.importing = true
+			this.importMessages = []
+			this.importErrors = []
+
+			try {
+				const result = await this.$store.dispatch('importBoard', file)
+				if (result?.message) {
+					this.importErrors = [result.message]
+				} else if (result instanceof Error) {
+					this.importErrors = [t('deck', 'Failed to import board')]
+				} else {
+					this.importErrors = result?.import?.errors ?? []
+					const board = result?.board
+					if (board) {
+						this.importMessages.push(t('deck', 'Board "{title}" created.', { title: board.title }))
+						const stackCount = board.stacks?.length ?? 0
+						if (stackCount > 0) {
+							this.importMessages.push(n('deck',
+								'%n stack created.',
+								'%n stacks created.',
+								stackCount))
+						}
+					}
+				}
+			} catch (e) {
+				this.importErrors = [t('deck', 'Failed to import board')]
+				console.error(e)
+			}
+
+			this.importing = false
+		},
+		onCloseImportModal() {
+			this.importModalOpen = false
+		},
+
 		async showKeyboardShortcuts() {
 			this.$emit('update:open', true)
 
@@ -200,5 +311,11 @@ export default {
 	&#settings-section_admin-settings p {
 		margin-bottom: 20px;
 	}
+}
+
+.import-buttons {
+	display: flex;
+	gap: 8px;
+	margin-top: 8px;
 }
 </style>

--- a/src/components/navigation/AppNavigation.vue
+++ b/src/components/navigation/AppNavigation.vue
@@ -44,7 +44,6 @@
 				</template>
 			</AppNavigationBoardCategory>
 			<AppNavigationAddBoard v-if="canCreate" />
-			<AppNavigationImportBoard v-if="canCreate" />
 		</template>
 		<template #default>
 			<DeckAppSettings :open.sync="settingsOpened"
@@ -77,7 +76,6 @@ import CalendarOutlineIcon from 'vue-material-design-icons/CalendarOutline.vue'
 import DeckIcon from './../icons/DeckIcon.vue'
 import ShareVariantIcon from 'vue-material-design-icons/ShareOutline.vue'
 import { subscribe } from '@nextcloud/event-bus'
-import AppNavigationImportBoard from './AppNavigationImportBoard.vue'
 import DeckAppSettings from '../DeckAppSettings.vue'
 import IconCog from 'vue-material-design-icons/CogOutline.vue'
 import { getCurrentUser } from '@nextcloud/auth'
@@ -90,7 +88,6 @@ export default {
 		NcAppNavigation,
 		AppNavigationAddBoard,
 		AppNavigationBoardCategory,
-		AppNavigationImportBoard,
 		NcAppNavigationItem,
 		ArchiveIcon,
 		ArchiveOutlineIcon,

--- a/src/components/navigation/AppNavigationBoard.vue
+++ b/src/components/navigation/AppNavigationBoard.vue
@@ -4,6 +4,11 @@
 -->
 <template>
 	<span>
+		<input ref="csvFileInput"
+			type="file"
+			accept=".csv,text/csv"
+			style="display: none;"
+			@change="onLocalCsvSelected">
 		<NcAppNavigationItem v-if="!editing"
 			:name="!deleted ? board.title : undoText"
 			:loading="loading"
@@ -20,6 +25,11 @@
 					:board-title="board.title"
 					@export="onExportBoard"
 					@close="onCloseExportBoard" />
+				<CsvImportModal v-if="csvImportModalOpen"
+					:importing="csvImporting"
+					:messages="csvImportMessages"
+					:errors="csvImportErrors"
+					@close="onCloseCsvImportModal" />
 			</template>
 
 			<template #counter>
@@ -68,6 +78,22 @@
 						:close-after-click="true"
 						@click="actionExport">
 						{{ t('deck', 'Export board') }}
+					</NcActionButton>
+					<NcActionButton v-if="canManage && !board.archived"
+						:close-after-click="true"
+						@click="importCsvFromNextcloud">
+						<template #icon>
+							<CloudUploadIcon :size="20" />
+						</template>
+						{{ t('deck', 'Import cards from Nextcloud') }}
+					</NcActionButton>
+					<NcActionButton v-if="canManage && !board.archived"
+						:close-after-click="true"
+						@click="importCsvFromDevice">
+						<template #icon>
+							<UploadIcon :size="20" />
+						</template>
+						{{ t('deck', 'Import cards from device') }}
 					</NcActionButton>
 					<NcActionButton v-if="!board.archived && board.acl?.length === 0" :icon="board.settings['notify-due'] === 'off' ? 'icon-sound' : 'icon-sound-off'" @click="board.settings['notify-due'] === 'off' ? updateSetting('notify-due', 'all') : updateSetting('notify-due', 'off')">
 						{{ board.settings['notify-due'] === 'off' ? t('deck', 'Turn on due date reminders') : t('deck', 'Turn off due date reminders') }}
@@ -181,6 +207,8 @@ import CloseIcon from 'vue-material-design-icons/Close.vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 import PinIcon from 'vue-material-design-icons/Pin.vue'
 import PinOffIcon from 'vue-material-design-icons/PinOff.vue'
+import CloudUploadIcon from 'vue-material-design-icons/CloudUpload.vue'
+import UploadIcon from 'vue-material-design-icons/Upload.vue'
 
 import { loadState } from '@nextcloud/initial-state'
 import { emit } from '@nextcloud/event-bus'
@@ -188,10 +216,13 @@ import { emit } from '@nextcloud/event-bus'
 import isTouchDevice from '../../mixins/isTouchDevice.js'
 import BoardCloneModal from './BoardCloneModal.vue'
 import BoardExportModal from './BoardExportModal.vue'
-import { showLoading, showError } from '@nextcloud/dialogs'
+import CsvImportModal from './CsvImportModal.vue'
+import { showError, showLoading, getFilePickerBuilder, FilePickerType } from '@nextcloud/dialogs'
+import { getClient, getRootPath } from '@nextcloud/files/dav'
 import { getCurrentUser } from '@nextcloud/auth'
 
 const canCreateState = loadState('deck', 'canCreate')
+const davClient = getClient()
 
 export default {
 	name: 'AppNavigationBoard',
@@ -209,9 +240,12 @@ export default {
 		CheckIcon,
 		PinIcon,
 		PinOffIcon,
+		CloudUploadIcon,
+		UploadIcon,
 		LeaveIcon,
 		BoardCloneModal,
 		BoardExportModal,
+		CsvImportModal,
 	},
 	directives: {
 		ClickOutside,
@@ -241,6 +275,10 @@ export default {
 			canCreate: canCreateState,
 			cloneModalOpen: false,
 			exportModalOpen: false,
+			csvImportModalOpen: false,
+			csvImporting: false,
+			csvImportMessages: [],
+			csvImportErrors: [],
 			currentUser: getCurrentUser(),
 			defaultBoardId: localStorage.getItem('deck.defaultBoardId'),
 		}
@@ -427,6 +465,81 @@ export default {
 		},
 		actionExport() {
 			this.exportModalOpen = true
+		},
+		async importCsvFromNextcloud() {
+			try {
+				const picker = getFilePickerBuilder(t('deck', 'Select CSV file to import'))
+					.setMultiSelect(false)
+					.setMimeTypeFilter(['text/csv', 'text/plain'])
+					.setType(FilePickerType.Choose)
+					.build()
+				const path = await picker.pick()
+				const contents = await davClient.getFileContents(getRootPath() + path)
+				const filename = path.split('/').pop()
+				const file = new File([contents], filename, { type: 'text/csv' })
+				await this.doImportCsv(file)
+			} catch (e) {
+				// FilePicker closed without selection
+			}
+		},
+		importCsvFromDevice() {
+			this.$refs.csvFileInput.value = ''
+			this.$refs.csvFileInput.click()
+		},
+		async onLocalCsvSelected(event) {
+			const file = event.target.files[0]
+			if (file) {
+				await this.doImportCsv(file)
+			}
+		},
+		async doImportCsv(file) {
+			this.csvImportModalOpen = true
+			this.csvImporting = true
+			this.csvImportMessages = []
+			this.csvImportErrors = []
+
+			try {
+				const result = await this.$store.dispatch('importCsvToBoard', { boardId: this.board.id, file })
+				if (result instanceof Error) {
+					this.csvImportErrors = [t('deck', 'Failed to import cards from CSV')]
+				} else {
+					const imp = result.import ?? {}
+					this.csvImportErrors = imp.errors ?? []
+					if (imp.imported > 0) {
+						this.csvImportMessages.push(n('deck',
+							'%n card imported.',
+							'%n cards imported.',
+							imp.imported))
+					}
+					if (imp.updated > 0) {
+						this.csvImportMessages.push(n('deck',
+							'%n card updated.',
+							'%n cards updated.',
+							imp.updated))
+					}
+					if (imp.stacksCreated > 0) {
+						this.csvImportMessages.push(n('deck',
+							'%n stack created.',
+							'%n stacks created.',
+							imp.stacksCreated))
+					}
+					if (imp.labelsCreated > 0) {
+						this.csvImportMessages.push(n('deck',
+							'%n label created.',
+							'%n labels created.',
+							imp.labelsCreated))
+					}
+				}
+			} catch (e) {
+				this.csvImportErrors = [t('deck', 'Failed to import cards from CSV')]
+				console.error(e)
+			}
+
+			this.csvImporting = false
+		},
+		onCloseCsvImportModal() {
+			this.csvImportModalOpen = false
+			this.$router.push({ name: 'board', params: { id: this.board.id } })
 		},
 		async onExportBoard(format) {
 			this.exportModalOpen = false

--- a/src/components/navigation/AppNavigationImportBoard.vue
+++ b/src/components/navigation/AppNavigationImportBoard.vue
@@ -4,23 +4,58 @@
 -->
 <template>
 	<div>
-		<NcAppNavigationItem :name="t('deck', 'Import board')" icon="icon-upload" @click.prevent.stop="startImportBoard" />
+		<NcAppNavigationItem :name="t('deck', 'Import board')"
+			icon="icon-upload"
+			:allow-collapse="true"
+			:open="menuOpen"
+			@update:open="menuOpen = $event">
+			<template #default>
+				<NcAppNavigationItem :name="t('deck', 'From Nextcloud')"
+					@click.prevent.stop="importFromNextcloud">
+					<template #icon>
+						<CloudUploadIcon :size="20" />
+					</template>
+				</NcAppNavigationItem>
+				<NcAppNavigationItem :name="t('deck', 'From device')"
+					@click.prevent.stop="importFromDevice">
+					<template #icon>
+						<UploadIcon :size="20" />
+					</template>
+				</NcAppNavigationItem>
+			</template>
+		</NcAppNavigationItem>
 		<input ref="fileInput"
 			type="file"
-			accept="application/json"
+			accept="application/json,.csv,text/csv"
 			style="display: none;"
-			@change="doImportBoard">
+			@change="onLocalFileSelected">
+		<CsvImportModal v-if="importModalOpen"
+			:importing="importing"
+			:messages="importMessages"
+			:errors="importErrors"
+			:title="t('deck', 'Import board')"
+			@close="onCloseImportModal" />
 	</div>
 </template>
 
 <script>
 import { NcAppNavigationItem } from '@nextcloud/vue'
-import { showError } from '../../helpers/errors.js'
-import { showSuccess, showLoading } from '@nextcloud/dialogs'
+import { getFilePickerBuilder, FilePickerType } from '@nextcloud/dialogs'
+import { getClient, getRootPath } from '@nextcloud/files/dav'
+import CloudUploadIcon from 'vue-material-design-icons/CloudUpload.vue'
+import UploadIcon from 'vue-material-design-icons/Upload.vue'
+import CsvImportModal from './CsvImportModal.vue'
+
+const davClient = getClient()
 
 export default {
 	name: 'AppNavigationImportBoard',
-	components: { NcAppNavigationItem },
+	components: {
+		NcAppNavigationItem,
+		CsvImportModal,
+		CloudUploadIcon,
+		UploadIcon,
+	},
 	props: {
 		loading: {
 			type: Boolean,
@@ -29,26 +64,78 @@ export default {
 	},
 	data() {
 		return {
-			value: '',
+			menuOpen: false,
+			importModalOpen: false,
+			importing: false,
+			importMessages: [],
+			importErrors: [],
 		}
 	},
 	methods: {
-		startImportBoard() {
+		async importFromNextcloud() {
+			this.menuOpen = false
+			try {
+				const picker = getFilePickerBuilder(t('deck', 'Select file to import'))
+					.setMultiSelect(false)
+					.setMimeTypeFilter(['application/json', 'text/csv', 'text/plain'])
+					.setType(FilePickerType.Choose)
+					.build()
+				const path = await picker.pick()
+				const contents = await davClient.getFileContents(getRootPath() + path)
+				const filename = path.split('/').pop()
+				const mime = filename.endsWith('.csv') ? 'text/csv' : 'application/json'
+				const file = new File([contents], filename, { type: mime })
+				await this.doImport(file)
+			} catch (e) {
+				// FilePicker closed without selection
+			}
+		},
+		importFromDevice() {
+			this.menuOpen = false
 			this.$refs.fileInput.value = ''
 			this.$refs.fileInput.click()
 		},
-		async doImportBoard(event) {
+		async onLocalFileSelected(event) {
 			const file = event.target.files[0]
 			if (file) {
-				const loadingToast = showLoading(t('deck', 'Importing board...'))
-				const result = await this.$store.dispatch('importBoard', file)
-				loadingToast.hideToast()
-				if (result?.message) {
-					showError(result)
-				} else {
-					showSuccess(t('deck', 'Board imported successfully'))
-				}
+				await this.doImport(file)
 			}
+		},
+		async doImport(file) {
+			this.importModalOpen = true
+			this.importing = true
+			this.importMessages = []
+			this.importErrors = []
+
+			try {
+				const result = await this.$store.dispatch('importBoard', file)
+				if (result?.message) {
+					this.importErrors = [result.message]
+				} else if (result instanceof Error) {
+					this.importErrors = [t('deck', 'Failed to import board')]
+				} else {
+					this.importErrors = result?.import?.errors ?? []
+					const board = result?.board
+					if (board) {
+						this.importMessages.push(t('deck', 'Board "{title}" created.', { title: board.title }))
+						const stackCount = board.stacks?.length ?? 0
+						if (stackCount > 0) {
+							this.importMessages.push(n('deck',
+								'%n stack created.',
+								'%n stacks created.',
+								stackCount))
+						}
+					}
+				}
+			} catch (e) {
+				this.importErrors = [t('deck', 'Failed to import board')]
+				console.error(e)
+			}
+
+			this.importing = false
+		},
+		onCloseImportModal() {
+			this.importModalOpen = false
 		},
 	},
 }

--- a/src/components/navigation/BoardExportModal.vue
+++ b/src/components/navigation/BoardExportModal.vue
@@ -19,7 +19,7 @@
 			</NcCheckboxRadioSwitch>
 
 			<p class="note">
-				{{ t('deck', 'Note: Only the JSON format is supported for importing back into the Deck app.') }}
+				{{ t('deck', 'Note: Both JSON and CSV formats can be imported back into Deck.') }}
 			</p>
 		</div>
 

--- a/src/components/navigation/CsvImportModal.vue
+++ b/src/components/navigation/CsvImportModal.vue
@@ -1,0 +1,145 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<NcDialog :name="title"
+		size="normal"
+		:can-close="!importing"
+		@update:open="close">
+		<div class="csv-import-modal">
+			<div v-if="importing" class="csv-import-modal__progress">
+				<NcLoadingIcon :size="44" />
+				<p class="csv-import-modal__status">
+					{{ t('deck', 'Importing cards...') }}
+				</p>
+			</div>
+
+			<div v-else class="csv-import-modal__result">
+				<div v-for="(msg, index) in messages" :key="'msg-' + index" class="csv-import-modal__line">
+					<CheckIcon :size="20" class="csv-import-modal__icon--success" />
+					<span>{{ msg }}</span>
+				</div>
+				<div v-if="messages.length === 0 && errors.length === 0" class="csv-import-modal__line">
+					<span>{{ t('deck', 'Nothing to import.') }}</span>
+				</div>
+				<div v-if="errors.length > 0" class="csv-import-modal__line">
+					<AlertCircleOutlineIcon :size="20" class="csv-import-modal__icon--warning" />
+					<span>{{ t('deck', 'Import finished with {errors} errors.', { errors: errors.length }) }}</span>
+				</div>
+
+				<div v-if="errors.length > 0" class="csv-import-modal__errors">
+					<ul>
+						<li v-for="(error, index) in errors" :key="'err-' + index">
+							{{ error }}
+						</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+
+		<template #actions>
+			<NcButton v-if="!importing" type="primary" @click="close">
+				{{ t('deck', 'Close') }}
+			</NcButton>
+		</template>
+	</NcDialog>
+</template>
+
+<script>
+import { NcButton, NcDialog, NcLoadingIcon } from '@nextcloud/vue'
+import CheckIcon from 'vue-material-design-icons/Check.vue'
+import AlertCircleOutlineIcon from 'vue-material-design-icons/AlertCircleOutline.vue'
+
+export default {
+	name: 'CsvImportModal',
+	components: {
+		NcButton,
+		NcDialog,
+		NcLoadingIcon,
+		CheckIcon,
+		AlertCircleOutlineIcon,
+	},
+	props: {
+		importing: {
+			type: Boolean,
+			default: true,
+		},
+		messages: {
+			type: Array,
+			default: () => [],
+		},
+		errors: {
+			type: Array,
+			default: () => [],
+		},
+		title: {
+			type: String,
+			default() {
+				return t('deck', 'Import CSV')
+			},
+		},
+	},
+	methods: {
+		close() {
+			if (!this.importing) {
+				this.$emit('close')
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.csv-import-modal {
+	min-height: 100px;
+
+	&__progress {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 12px;
+		padding: 20px 0;
+	}
+
+	&__status {
+		color: var(--color-text-maxcontrast);
+	}
+
+	&__result {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	&__line {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	&__icon--success {
+		color: var(--color-success);
+	}
+
+	&__icon--warning {
+		color: var(--color-warning);
+	}
+
+	&__errors {
+		margin-top: 4px;
+		max-height: 300px;
+		overflow-y: auto;
+
+		ul {
+			list-style: disc;
+			padding-left: 20px;
+
+			li {
+				margin-bottom: 4px;
+				color: var(--color-text-maxcontrast);
+			}
+		}
+	}
+}
+</style>

--- a/src/services/BoardApi.js
+++ b/src/services/BoardApi.js
@@ -182,7 +182,7 @@ export class BoardApi {
 						return Promise.resolve()
 					}
 
-					const fields = { title: t('deck', 'Card title'), description: t('deck', 'Description'), stackId: t('deck', 'List name'), labels: t('deck', 'Tags'), assignedUsers: t('deck', 'Assigned users'), duedate: t('deck', 'Due date'), createdAt: t('deck', 'Created'), lastModified: t('deck', 'Modified') }
+					const fields = { id: t('deck', 'ID'), title: t('deck', 'Card title'), description: t('deck', 'Description'), stackId: t('deck', 'List name'), labels: t('deck', 'Tags'), assignedUsers: t('deck', 'Assigned users'), duedate: t('deck', 'Due date'), createdAt: t('deck', 'Created'), lastModified: t('deck', 'Modified') }
 					let row = ''
 					Object.keys(fields).forEach(field => {
 						row += '"' + fields[field] + '"' + '\t'
@@ -258,6 +258,27 @@ export class BoardApi {
 		const formData = new FormData()
 		formData.append('file', file)
 		return axios.post(this.url('/boards/import'), formData, {
+			headers: {
+				'Content-Type': 'multipart/form-data',
+			},
+		})
+			.then(
+				(response) => {
+					return Promise.resolve(response.data)
+				},
+				(err) => {
+					return Promise.reject(err)
+				},
+			)
+			.catch((err) => {
+				return Promise.reject(err)
+			})
+	}
+
+	importCsvToBoard(boardId, file) {
+		const formData = new FormData()
+		formData.append('file', file)
+		return axios.post(this.url(`/boards/${boardId}/importCsv`), formData, {
 			headers: {
 				'Content-Type': 'multipart/form-data',
 			},

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -406,8 +406,18 @@ export default function storeFactory() {
 			},
 			async importBoard({ commit }, file) {
 				try {
-					const board = await apiClient.importBoard(file)
-					commit('addBoard', board)
+					const result = await apiClient.importBoard(file)
+					commit('addBoard', result.board)
+					return result
+				} catch (err) {
+					return err
+				}
+			},
+			async importCsvToBoard({ commit }, { boardId, file }) {
+				try {
+					const result = await apiClient.importCsvToBoard(boardId, file)
+					commit('addBoard', result.board)
+					return result
 				} catch (err) {
 					return err
 				}

--- a/tests/bootstrap-standalone.php
+++ b/tests/bootstrap-standalone.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Bootstrap for running unit tests that have no Nextcloud server dependencies.
+ * Usage: vendor/bin/phpunit --bootstrap tests/bootstrap-standalone.php tests/unit/Service/Importer/CsvParserTest.php
+ */
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+spl_autoload_register(function (string $class) {
+	$prefix = 'OCA\\Deck\\';
+	if (str_starts_with($class, $prefix)) {
+		$relativeClass = substr($class, strlen($prefix));
+		$file = __DIR__ . '/../lib/' . str_replace('\\', '/', $relativeClass) . '.php';
+		if (file_exists($file)) {
+			require_once $file;
+		}
+	}
+});

--- a/tests/integration/features/bootstrap/BoardContext.php
+++ b/tests/integration/features/bootstrap/BoardContext.php
@@ -1,6 +1,7 @@
 <?php
 
 use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
@@ -20,6 +21,9 @@ class BoardContext implements Context {
 	private array $storedStacks = [];
 	private ?array $activities = null;
 
+	/** @var int[] Board IDs created during the current scenario */
+	private array $createdBoardIds = [];
+
 	private ServerContext $serverContext;
 
 	/** @BeforeScenario */
@@ -27,6 +31,24 @@ class BoardContext implements Context {
 		$environment = $scope->getEnvironment();
 
 		$this->serverContext = $environment->getContext('ServerContext');
+	}
+
+	/** @AfterScenario */
+	public function cleanupBoards(AfterScenarioScope $scope): void {
+		foreach ($this->createdBoardIds as $boardId) {
+			try {
+				$this->requestContext->sendJSONrequest('DELETE', '/index.php/apps/deck/boards/' . $boardId);
+			} catch (\Exception $e) {
+				// Ignore cleanup errors
+			}
+		}
+		$this->createdBoardIds = [];
+	}
+
+	private function trackBoard(?array $board): void {
+		if (is_array($board) && isset($board['id'])) {
+			$this->createdBoardIds[] = $board['id'];
+		}
 	}
 
 	public function getLastUsedCard() {
@@ -56,6 +78,7 @@ class BoardContext implements Context {
 		]);
 		$this->getResponse()->getBody()->seek(0);
 		$this->board = json_decode((string)$this->getResponse()->getBody(), true);
+		$this->trackBoard($this->board);
 	}
 
 	/**
@@ -468,6 +491,169 @@ class BoardContext implements Context {
 		}
 		Assert::assertNotNull($found, 'Current stack not found in board stacks');
 		return $found;
+	}
+
+	/**
+	 * @When /^importing a board from CSV file with content$/
+	 */
+	public function importingABoardFromCsvFileWithContent(\Behat\Gherkin\Node\PyStringNode $content) {
+		$csvContent = $content->getRaw();
+		$this->requestContext->sendPlainRequest('POST', '/index.php/apps/deck/boards/import', [
+			'multipart' => [
+				[
+					'name' => 'file',
+					'contents' => $csvContent,
+					'filename' => 'import.csv',
+					'headers' => ['Content-Type' => 'text/csv'],
+				],
+			],
+		]);
+		$this->getResponse()->getBody()->seek(0);
+		$body = json_decode((string)$this->getResponse()->getBody(), true);
+		if ($this->getResponse()->getStatusCode() === 200 && is_array($body) && isset($body['board'])) {
+			$this->board = $body['board'];
+			$this->trackBoard($this->board);
+		}
+	}
+
+	/**
+	 * @When /^importing CSV cards into the current board with content$/
+	 */
+	public function importingCsvCardsIntoTheCurrentBoardWithContent(\Behat\Gherkin\Node\PyStringNode $content) {
+		Assert::assertNotNull($this->board, 'Board must be created first');
+		$csvContent = $content->getRaw();
+		// Allow tests to reference the last created card's ID via {lastCardId}
+		if ($this->card !== null && isset($this->card['id'])) {
+			$csvContent = str_replace('{lastCardId}', (string)$this->card['id'], $csvContent);
+		}
+		$this->requestContext->sendPlainRequest('POST', '/index.php/apps/deck/boards/' . $this->board['id'] . '/importCsv', [
+			'multipart' => [
+				[
+					'name' => 'file',
+					'contents' => $csvContent,
+					'filename' => 'cards.csv',
+					'headers' => ['Content-Type' => 'text/csv'],
+				],
+			],
+		]);
+		$this->getResponse()->getBody()->seek(0);
+		$body = json_decode((string)$this->getResponse()->getBody(), true);
+		if ($this->getResponse()->getStatusCode() === 200 && is_array($body) && isset($body['board'])) {
+			$this->board = $body['board'];
+		}
+	}
+
+	/**
+	 * @When /^importing a non-CSV file into the current board$/
+	 */
+	public function importingANonCsvFileIntoTheCurrentBoard() {
+		Assert::assertNotNull($this->board, 'Board must be created first');
+		$this->requestContext->sendPlainRequest('POST', '/index.php/apps/deck/boards/' . $this->board['id'] . '/importCsv', [
+			'multipart' => [
+				[
+					'name' => 'file',
+					'contents' => '{"not": "csv"}',
+					'filename' => 'data.json',
+					'headers' => ['Content-Type' => 'application/json'],
+				],
+			],
+		]);
+	}
+
+	/**
+	 * @Then /^the board should have (\d+) stacks$/
+	 */
+	public function theBoardShouldHaveStacks($count) {
+		$this->requestContext->sendJSONrequest('GET', '/index.php/apps/deck/stacks/' . $this->board['id']);
+		$this->requestContext->getResponse()->getBody()->seek(0);
+		$stacks = json_decode((string)$this->getResponse()->getBody(), true);
+		Assert::assertCount((int)$count, $stacks, 'Expected ' . $count . ' stacks, got ' . count($stacks));
+	}
+
+	/**
+	 * @Then /^the board should have a stack named "([^"]*)"$/
+	 */
+	public function theBoardShouldHaveAStackNamed($name) {
+		$this->requestContext->sendJSONrequest('GET', '/index.php/apps/deck/stacks/' . $this->board['id']);
+		$this->requestContext->getResponse()->getBody()->seek(0);
+		$stacks = json_decode((string)$this->getResponse()->getBody(), true);
+		$found = array_filter($stacks, fn ($s) => $s['title'] === $name);
+		Assert::assertNotEmpty($found, 'Stack "' . $name . '" not found on board');
+	}
+
+	/**
+	 * @Then /^the stack "([^"]*)" should have (\d+) cards$/
+	 */
+	public function theStackShouldHaveCards($stackName, $count) {
+		$this->requestContext->sendJSONrequest('GET', '/index.php/apps/deck/stacks/' . $this->board['id']);
+		$this->requestContext->getResponse()->getBody()->seek(0);
+		$stacks = json_decode((string)$this->getResponse()->getBody(), true);
+		$found = null;
+		foreach ($stacks as $stack) {
+			if ($stack['title'] === $stackName) {
+				$found = $stack;
+				break;
+			}
+		}
+		Assert::assertNotNull($found, 'Stack "' . $stackName . '" not found');
+		$cardCount = count($found['cards'] ?? []);
+		Assert::assertEquals((int)$count, $cardCount, 'Expected ' . $count . ' cards in stack "' . $stackName . '", got ' . $cardCount);
+	}
+
+	/**
+	 * @Then /^the board should have labels "([^"]*)"$/
+	 */
+	public function theBoardShouldHaveLabels($labelList) {
+		$expectedLabels = array_map('trim', explode(',', $labelList));
+		$this->requestContext->sendJSONrequest('GET', '/index.php/apps/deck/boards/' . $this->board['id']);
+		$this->requestContext->getResponse()->getBody()->seek(0);
+		$board = json_decode((string)$this->getResponse()->getBody(), true);
+		$actualLabels = array_map(fn ($l) => $l['title'], $board['labels'] ?? []);
+		foreach ($expectedLabels as $expected) {
+			Assert::assertContains($expected, $actualLabels, 'Label "' . $expected . '" not found on board. Existing: ' . implode(', ', $actualLabels));
+		}
+	}
+
+	/**
+	 * @Then /^the card "([^"]*)" should have duedate "([^"]*)"$/
+	 */
+	public function theCardShouldHaveDuedate($cardTitle, $expectedDuedate) {
+		$card = $this->findCardOnBoard($cardTitle);
+		Assert::assertNotNull($card, 'Card "' . $cardTitle . '" not found on board');
+		Assert::assertNotEmpty($card['duedate'], 'Card "' . $cardTitle . '" has no duedate set');
+		Assert::assertEquals($expectedDuedate, $card['duedate'], 'Duedate mismatch for card "' . $cardTitle . '"');
+	}
+
+	/**
+	 * @Then /^the card "([^"]*)" should not have a duedate$/
+	 */
+	public function theCardShouldNotHaveADuedate($cardTitle) {
+		$card = $this->findCardOnBoard($cardTitle);
+		Assert::assertNotNull($card, 'Card "' . $cardTitle . '" not found on board');
+		Assert::assertEmpty($card['duedate'], 'Expected no duedate for card "' . $cardTitle . '", got "' . ($card['duedate'] ?? '') . '"');
+	}
+
+	/**
+	 * @Then /^the card "([^"]*)" should have description "([^"]*)"$/
+	 */
+	public function theCardShouldHaveDescription($cardTitle, $expectedDescription) {
+		$card = $this->findCardOnBoard($cardTitle);
+		Assert::assertNotNull($card, 'Card "' . $cardTitle . '" not found on board');
+		Assert::assertEquals($expectedDescription, $card['description'], 'Card description mismatch');
+	}
+
+	private function findCardOnBoard(string $cardTitle): ?array {
+		$this->requestContext->sendJSONrequest('GET', '/index.php/apps/deck/stacks/' . $this->board['id']);
+		$this->requestContext->getResponse()->getBody()->seek(0);
+		$stacks = json_decode((string)$this->getResponse()->getBody(), true);
+		foreach ($stacks as $stack) {
+			foreach ($stack['cards'] ?? [] as $card) {
+				if ($card['title'] === $cardTitle) {
+					return $card;
+				}
+			}
+		}
+		return null;
 	}
 
 }

--- a/tests/integration/features/csv-import.feature
+++ b/tests/integration/features/csv-import.feature
@@ -1,0 +1,101 @@
+Feature: CSV Import
+
+  Background:
+    Given user "admin" exists
+    Given user "user0" exists
+
+  Scenario: Import a new board from CSV
+    Given Logging in using web as "admin"
+    When importing a board from CSV file with content
+      """
+      "Card title"	"Description"	"List name"	"Tags"	"Due date"	"Created"	"Modified"
+      "First card"	"A description"	"To Do"	"Feature, Bug,"	"null"	"01/02/2026"	"15/03/2026"
+      "Second card"	""	"Done"	"Feature,"	"2026-03-20T19:00:00+00:00"	"10/02/2026"	"20/03/2026"
+      "Third card"	"Line 1
+Line 2"	"To Do"	""	"null"	"05/03/2026"	"05/03/2026"
+      """
+    Then the response should have a status code "200"
+    When fetches the board named "import"
+    Then the board should have 2 stacks
+    And the board should have a stack named "To Do"
+    And the board should have a stack named "Done"
+    And the stack "To Do" should have 2 cards
+    And the stack "Done" should have 1 cards
+
+  Scenario: Import cards from CSV into an existing board
+    Given Logging in using web as "admin"
+    And creates a board named "MyBoard" with color "000000"
+    And create a stack named "To Do"
+    And create a card named "Existing card"
+    When importing CSV cards into the current board with content
+      """
+      "Card title"	"Description"	"List name"	"Tags"	"Due date"	"Created"	"Modified"
+      "Imported card 1"	"Some description"	"To Do"	"Urgent,"	"null"	"01/01/2026"	"01/01/2026"
+      "Imported card 2"	""	"New Stack"	""	"null"	"02/01/2026"	"02/01/2026"
+      """
+    Then the response should have a status code "200"
+    When fetches the board named "MyBoard"
+    Then the board should have 2 stacks
+    And the board should have a stack named "To Do"
+    And the board should have a stack named "New Stack"
+    And the stack "To Do" should have 2 cards
+    And the stack "New Stack" should have 1 cards
+
+  Scenario: Import CSV with labels creates labels on the board
+    Given Logging in using web as "admin"
+    And creates a board named "LabelBoard" with color "000000"
+    And create a stack named "To Do"
+    When importing CSV cards into the current board with content
+      """
+      "Card title"	"Description"	"List name"	"Tags"	"Due date"	"Created"	"Modified"
+      "Card A"	""	"To Do"	"Feature, Bug,"	"null"	"01/01/2026"	"01/01/2026"
+      "Card B"	""	"To Do"	"Feature,"	"null"	"01/01/2026"	"01/01/2026"
+      """
+    Then the response should have a status code "200"
+    When fetches the board named "LabelBoard"
+    Then the board should have labels "Feature, Bug"
+
+  Scenario: Import CSV with various date formats
+    Given Logging in using web as "admin"
+    And creates a board named "DateBoard" with color "000000"
+    And create a stack named "To Do"
+    When importing CSV cards into the current board with content
+      """
+      "Card title"	"Description"	"List name"	"Tags"	"Due date"	"Created"	"Modified"
+      "ISO 8601 due"	""	"To Do"	""	"2026-03-20T19:00:00+00:00"	"23/02/2026"	"28/03/2026"
+      "ISO date due"	""	"To Do"	""	"2026-06-15"	"2026-01-10"	"2026-06-15"
+      "Dot format dates"	""	"To Do"	""	"null"	"15.03.2026"	"20.3.2026"
+      "Slash Y/m/d dates"	""	"To Do"	""	"null"	"2026/3/15"	"2026/03/20"
+      "Null due date"	""	"To Do"	""	"null"	"01/02/2026"	"01/02/2026"
+      "Empty due date"	""	"To Do"	""	""	"01/02/2026"	"01/02/2026"
+      """
+    Then the response should have a status code "200"
+    When fetches the board named "DateBoard"
+    And the stack "To Do" should have 6 cards
+    Then the card "ISO 8601 due" should have duedate "2026-03-20T19:00:00+00:00"
+    And the card "ISO date due" should have duedate "2026-06-15T00:00:00+00:00"
+    And the card "Null due date" should not have a duedate
+    And the card "Empty due date" should not have a duedate
+
+  Scenario: Re-import CSV with card ID updates existing card
+    Given Logging in using web as "admin"
+    And creates a board named "UpdateBoard" with color "000000"
+    And create a stack named "To Do"
+    And create a card named "Original title"
+    When importing CSV cards into the current board with content
+      """
+      "ID"	"Card title"	"Description"	"List name"	"Tags"	"Due date"	"Created"	"Modified"
+      "{lastCardId}"	"Updated title"	"New description"	"To Do"	""	"null"	"01/01/2026"	"01/01/2026"
+      ""	"Brand new card"	""	"To Do"	""	"null"	"01/01/2026"	"01/01/2026"
+      """
+    Then the response should have a status code "200"
+    When fetches the board named "UpdateBoard"
+    Then the board should have a stack named "To Do"
+    And the stack "To Do" should have 2 cards
+    And the card "Updated title" should have description "New description"
+
+  Scenario: Reject non-CSV file for card import
+    Given Logging in using web as "admin"
+    And creates a board named "MyBoard" with color "000000"
+    When importing a non-CSV file into the current board
+    Then the response should have a status code "400"

--- a/tests/unit/Middleware/ExceptionMiddlewareTest.php
+++ b/tests/unit/Middleware/ExceptionMiddlewareTest.php
@@ -29,6 +29,7 @@ use OCA\Deck\Controller\PageController;
 use OCA\Deck\NoPermissionException;
 use OCA\Deck\NotFoundException;
 use OCA\Deck\Service\BoardService;
+use OCA\Deck\Service\CsvImportService;
 use OCA\Deck\Service\ExternalBoardService;
 use OCA\Deck\Service\Importer\BoardImportService;
 use OCA\Deck\Service\PermissionService;
@@ -95,6 +96,7 @@ class ExceptionMiddlewareTest extends \Test\TestCase {
 			$this->createMock(ExternalBoardService::class),
 			$this->createMock(PermissionService::class),
 			$this->createMock(BoardImportService::class),
+			$this->createMock(CsvImportService::class),
 			$this->createMock(\OCP\IL10N::class),
 			'admin'
 		);

--- a/tests/unit/Service/Importer/CsvParserTest.php
+++ b/tests/unit/Service/Importer/CsvParserTest.php
@@ -1,0 +1,300 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Service\Importer;
+
+use PHPUnit\Framework\TestCase;
+
+class CsvParserTest extends TestCase {
+
+	private CsvParser $parser;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->parser = new CsvParser();
+	}
+
+	public function testParseSimpleCsv(): void {
+		$csv = "\"Card title\"\t\"Description\"\t\"List name\"\t\"Tags\"\t\"Due date\"\t\"Created\"\t\"Modified\"\r\n";
+		$csv .= "\"My Card\"\t\"A description\"\t\"To Do\"\t\"Feature, Bug,\"\t\"null\"\t\"01/02/2026\"\t\"15/03/2026\"\r\n";
+
+		$rows = $this->parser->parse($csv);
+
+		$this->assertCount(1, $rows);
+		$this->assertEquals('My Card', $rows[0]['title']);
+		$this->assertEquals('A description', $rows[0]['description']);
+		$this->assertEquals('To Do', $rows[0]['stackName']);
+		$this->assertEquals(['Feature', 'Bug'], $rows[0]['tags']);
+		$this->assertNull($rows[0]['duedate']);
+		$this->assertInstanceOf(\DateTime::class, $rows[0]['createdAt']);
+		$this->assertEquals('2026-02-01', $rows[0]['createdAt']->format('Y-m-d'));
+		$this->assertInstanceOf(\DateTime::class, $rows[0]['lastModified']);
+		$this->assertEquals('2026-03-15', $rows[0]['lastModified']->format('Y-m-d'));
+	}
+
+	public function testParseUtf16LeWithBom(): void {
+		$csv = "\"Card title\"\t\"Description\"\t\"List name\"\t\"Tags\"\t\"Due date\"\t\"Created\"\t\"Modified\"\r\n";
+		$csv .= "\"Test\"\t\"\"\t\"Done\"\t\"\"\t\"null\"\t\"01/01/2026\"\t\"01/01/2026\"\r\n";
+
+		$utf16 = mb_convert_encoding($csv, 'UTF-16LE', 'UTF-8');
+		// Add BOM
+		$utf16WithBom = "\xFF\xFE" . $utf16;
+
+		$rows = $this->parser->parse($utf16WithBom);
+
+		$this->assertCount(1, $rows);
+		$this->assertEquals('Test', $rows[0]['title']);
+		$this->assertEquals('Done', $rows[0]['stackName']);
+	}
+
+	public function testParseMultilineDescription(): void {
+		$csv = "\"Card title\"\t\"Description\"\t\"List name\"\t\"Tags\"\t\"Due date\"\t\"Created\"\t\"Modified\"\r\n";
+		$csv .= "\"My Card\"\t\"Line 1\nLine 2\nLine 3\"\t\"To Do\"\t\"\"\t\"null\"\t\"01/01/2026\"\t\"01/01/2026\"\r\n";
+
+		$rows = $this->parser->parse($csv);
+
+		$this->assertCount(1, $rows);
+		$this->assertEquals("Line 1\nLine 2\nLine 3", $rows[0]['description']);
+	}
+
+	public function testParseEscapedQuotes(): void {
+		$csv = "\"Card title\"\t\"Description\"\t\"List name\"\t\"Tags\"\t\"Due date\"\t\"Created\"\t\"Modified\"\r\n";
+		$csv .= "\"Card with \"\"quotes\"\"\"\t\"\"\t\"To Do\"\t\"\"\t\"null\"\t\"01/01/2026\"\t\"01/01/2026\"\r\n";
+
+		$rows = $this->parser->parse($csv);
+
+		$this->assertCount(1, $rows);
+		$this->assertEquals('Card with "quotes"', $rows[0]['title']);
+	}
+
+	public function testParseDateFormats(): void {
+		$csv = "\"Card title\"\t\"Description\"\t\"List name\"\t\"Tags\"\t\"Due date\"\t\"Created\"\t\"Modified\"\r\n";
+		$csv .= "\"Card 1\"\t\"\"\t\"To Do\"\t\"\"\t\"2026-02-20T19:00:00+00:00\"\t\"23/02/2026\"\t\"28/03/2026\"\r\n";
+		$csv .= "\"Card 2\"\t\"\"\t\"To Do\"\t\"\"\t\"null\"\t\"01/01/2026\"\t\"01/01/2026\"\r\n";
+
+		$rows = $this->parser->parse($csv);
+
+		$this->assertCount(2, $rows);
+		// ISO 8601 date
+		$this->assertInstanceOf(\DateTime::class, $rows[0]['duedate']);
+		$this->assertEquals('2026-02-20', $rows[0]['duedate']->format('Y-m-d'));
+		// null date
+		$this->assertNull($rows[1]['duedate']);
+		// d/m/Y date
+		$this->assertInstanceOf(\DateTime::class, $rows[0]['createdAt']);
+		$this->assertEquals('2026-02-23', $rows[0]['createdAt']->format('Y-m-d'));
+	}
+
+	/**
+	 * @dataProvider dateFormatProvider
+	 */
+	public function testParseDateVariousFormats(string $input, ?string $expectedDate): void {
+		$result = $this->parser->parseDate($input);
+		if ($expectedDate === null) {
+			$this->assertNull($result, 'Expected null for input "' . $input . '", got ' . ($result ? $result->format('Y-m-d') : 'null'));
+		} else {
+			$this->assertInstanceOf(\DateTime::class, $result, 'Expected DateTime for input "' . $input . '"');
+			$this->assertEquals($expectedDate, $result->format('Y-m-d'), 'Date mismatch for input "' . $input . '"');
+		}
+	}
+
+	public static function dateFormatProvider(): array {
+		return [
+			// ISO 8601 with timezone
+			'ISO 8601' => ['2026-02-20T19:00:00+00:00', '2026-02-20'],
+			'ISO 8601 negative offset' => ['2026-07-15T10:30:00-05:00', '2026-07-15'],
+
+			// ISO date without time (sv-SE, lt-LT locales)
+			'ISO date' => ['2026-02-20', '2026-02-20'],
+			'ISO date end of year' => ['2026-12-31', '2026-12-31'],
+
+			// d/m/Y - en-GB, most of Europe
+			'd/m/Y zero-padded' => ['23/02/2026', '2026-02-23'],
+			'd/m/Y no padding' => ['3/2/2026', '2026-02-03'],
+			'd/m/Y single digit day' => ['1/12/2026', '2026-12-01'],
+
+			// d.m.Y - de-DE, de-AT, de-CH
+			'd.m.Y zero-padded' => ['23.02.2026', '2026-02-23'],
+			'd.m.Y no padding' => ['3.2.2026', '2026-02-03'],
+			'd.m.Y single digit month' => ['15.1.2026', '2026-01-15'],
+
+			// Y/m/d - ja-JP, zh-CN, ko-KR
+			'Y/m/d zero-padded' => ['2026/02/23', '2026-02-23'],
+			'Y/m/d no padding' => ['2026/2/3', '2026-02-03'],
+
+			// m/d/Y - en-US (unambiguous cases where day > 12)
+			'm/d/Y day > 12' => ['2/23/2026', '2026-02-23'],
+			'm/d/Y both > 0' => ['1/31/2026', '2026-01-31'],
+
+			// null/empty
+			'null string' => ['null', null],
+			'empty string' => ['', null],
+			'whitespace' => ['  ', null],
+
+			// Invalid
+			'garbage' => ['not-a-date', null],
+			'partial date' => ['02/2026', null],
+		];
+	}
+
+	public function testParseDateFormatsInFullCsv(): void {
+		$csv = "\"Card title\"\t\"Description\"\t\"List name\"\t\"Tags\"\t\"Due date\"\t\"Created\"\t\"Modified\"\r\n";
+		// ISO date without time
+		$csv .= "\"Card ISO\"\t\"\"\t\"To Do\"\t\"\"\t\"2026-03-15\"\t\"2026-01-10\"\t\"2026-03-15\"\r\n";
+		// German dots format
+		$csv .= "\"Card DE\"\t\"\"\t\"To Do\"\t\"\"\t\"null\"\t\"15.03.2026\"\t\"20.3.2026\"\r\n";
+		// Japanese slashes format
+		$csv .= "\"Card JP\"\t\"\"\t\"To Do\"\t\"\"\t\"null\"\t\"2026/3/15\"\t\"2026/03/20\"\r\n";
+		// US format (unambiguous, day > 12)
+		$csv .= "\"Card US\"\t\"\"\t\"To Do\"\t\"\"\t\"null\"\t\"3/15/2026\"\t\"3/20/2026\"\r\n";
+
+		$rows = $this->parser->parse($csv);
+
+		$this->assertCount(4, $rows);
+
+		// ISO date
+		$this->assertEquals('2026-03-15', $rows[0]['duedate']->format('Y-m-d'));
+		$this->assertEquals('2026-01-10', $rows[0]['createdAt']->format('Y-m-d'));
+
+		// German dots
+		$this->assertEquals('2026-03-15', $rows[1]['createdAt']->format('Y-m-d'));
+		$this->assertEquals('2026-03-20', $rows[1]['lastModified']->format('Y-m-d'));
+
+		// Japanese slashes
+		$this->assertEquals('2026-03-15', $rows[2]['createdAt']->format('Y-m-d'));
+		$this->assertEquals('2026-03-20', $rows[2]['lastModified']->format('Y-m-d'));
+
+		// US format
+		$this->assertEquals('2026-03-15', $rows[3]['createdAt']->format('Y-m-d'));
+		$this->assertEquals('2026-03-20', $rows[3]['lastModified']->format('Y-m-d'));
+	}
+
+	public function testParseTagsSplitting(): void {
+		$csv = "\"Card title\"\t\"Description\"\t\"List name\"\t\"Tags\"\t\"Due date\"\t\"Created\"\t\"Modified\"\r\n";
+		$csv .= "\"Card\"\t\"\"\t\"To Do\"\t\"Dev work, Chore, AI Supported,\"\t\"null\"\t\"01/01/2026\"\t\"01/01/2026\"\r\n";
+
+		$rows = $this->parser->parse($csv);
+
+		$this->assertCount(1, $rows);
+		$this->assertEquals(['Dev work', 'Chore', 'AI Supported'], $rows[0]['tags']);
+	}
+
+	public function testParseAssignedUsers(): void {
+		$csv = "\"Card title\"\t\"Description\"\t\"List name\"\t\"Tags\"\t\"Assigned users\"\t\"Due date\"\t\"Created\"\t\"Modified\"\r\n";
+		$csv .= "\"Card\"\t\"\"\t\"To Do\"\t\"\"\t\"Anna Larch, John Doe,\"\t\"null\"\t\"01/01/2026\"\t\"01/01/2026\"\r\n";
+
+		$rows = $this->parser->parse($csv);
+
+		$this->assertCount(1, $rows);
+		$this->assertEquals(['Anna Larch', 'John Doe'], $rows[0]['assignedUsers']);
+	}
+
+	public function testParseEmptyCsv(): void {
+		$csv = "\"Card title\"\t\"Description\"\t\"List name\"\t\"Tags\"\t\"Due date\"\t\"Created\"\t\"Modified\"\r\n";
+
+		$rows = $this->parser->parse($csv);
+
+		$this->assertCount(0, $rows);
+	}
+
+	public function testParseEmptyContent(): void {
+		$rows = $this->parser->parse('');
+
+		$this->assertCount(0, $rows);
+	}
+
+	public function testParseEmptyTags(): void {
+		$csv = "\"Card title\"\t\"Description\"\t\"List name\"\t\"Tags\"\t\"Due date\"\t\"Created\"\t\"Modified\"\r\n";
+		$csv .= "\"Card\"\t\"\"\t\"To Do\"\t\"\"\t\"null\"\t\"01/01/2026\"\t\"01/01/2026\"\r\n";
+
+		$rows = $this->parser->parse($csv);
+
+		$this->assertCount(1, $rows);
+		$this->assertEquals([], $rows[0]['tags']);
+	}
+
+	public function testParseMultipleRows(): void {
+		$csv = "\"Card title\"\t\"Description\"\t\"List name\"\t\"Tags\"\t\"Due date\"\t\"Created\"\t\"Modified\"\r\n";
+		$csv .= "\"Card 1\"\t\"Desc 1\"\t\"To Do\"\t\"Bug,\"\t\"null\"\t\"01/01/2026\"\t\"01/01/2026\"\r\n";
+		$csv .= "\"Card 2\"\t\"Desc 2\"\t\"Done\"\t\"Feature,\"\t\"null\"\t\"02/01/2026\"\t\"02/01/2026\"\r\n";
+		$csv .= "\"Card 3\"\t\"Desc 3\"\t\"To Do\"\t\"\"\t\"null\"\t\"03/01/2026\"\t\"03/01/2026\"\r\n";
+
+		$rows = $this->parser->parse($csv);
+
+		$this->assertCount(3, $rows);
+		$this->assertEquals('Card 1', $rows[0]['title']);
+		$this->assertEquals('Card 2', $rows[1]['title']);
+		$this->assertEquals('Card 3', $rows[2]['title']);
+		$this->assertEquals('To Do', $rows[0]['stackName']);
+		$this->assertEquals('Done', $rows[1]['stackName']);
+	}
+
+	public function testParseWithIdColumn(): void {
+		$csv = "\"ID\"\t\"Card title\"\t\"Description\"\t\"List name\"\t\"Tags\"\t\"Due date\"\t\"Created\"\t\"Modified\"\r\n";
+		$csv .= "\"42\"\t\"Existing card\"\t\"Updated desc\"\t\"To Do\"\t\"\"\t\"null\"\t\"01/01/2026\"\t\"01/01/2026\"\r\n";
+		$csv .= "\"\"\t\"New card\"\t\"\"\t\"To Do\"\t\"\"\t\"null\"\t\"01/01/2026\"\t\"01/01/2026\"\r\n";
+
+		$rows = $this->parser->parse($csv);
+
+		$this->assertCount(2, $rows);
+		$this->assertSame(42, $rows[0]['id']);
+		$this->assertEquals('Existing card', $rows[0]['title']);
+		$this->assertNull($rows[1]['id']);
+		$this->assertEquals('New card', $rows[1]['title']);
+	}
+
+	public function testParseWithoutIdColumn(): void {
+		$csv = "\"Card title\"\t\"Description\"\t\"List name\"\t\"Tags\"\t\"Due date\"\t\"Created\"\t\"Modified\"\r\n";
+		$csv .= "\"My Card\"\t\"\"\t\"To Do\"\t\"\"\t\"null\"\t\"01/01/2026\"\t\"01/01/2026\"\r\n";
+
+		$rows = $this->parser->parse($csv);
+
+		$this->assertCount(1, $rows);
+		$this->assertNull($rows[0]['id']);
+	}
+
+	public function testParseUtf8Bom(): void {
+		$csv = "\xEF\xBB\xBF\"Card title\"\t\"Description\"\t\"List name\"\t\"Tags\"\t\"Due date\"\t\"Created\"\t\"Modified\"\r\n";
+		$csv .= "\"Test\"\t\"\"\t\"To Do\"\t\"\"\t\"null\"\t\"01/01/2026\"\t\"01/01/2026\"\r\n";
+
+		$rows = $this->parser->parse($csv);
+
+		$this->assertCount(1, $rows);
+		$this->assertEquals('Test', $rows[0]['title']);
+	}
+
+	public function testParseCommaDelimited(): void {
+		$csv = "ID,Card title,Description,List name,Tags,Due date,Created,Modified\r\n";
+		$csv .= "42,My Card,,To Do,\"Feature, Bug,\",null,01/01/2026,01/01/2026\r\n";
+		$csv .= ",New Card,Some desc,Done,,null,02/01/2026,02/01/2026\r\n";
+
+		$rows = $this->parser->parse($csv);
+
+		$this->assertCount(2, $rows);
+		$this->assertSame(42, $rows[0]['id']);
+		$this->assertEquals('My Card', $rows[0]['title']);
+		$this->assertEquals('To Do', $rows[0]['stackName']);
+		$this->assertEquals(['Feature', 'Bug'], $rows[0]['tags']);
+		$this->assertNull($rows[1]['id']);
+		$this->assertEquals('New Card', $rows[1]['title']);
+		$this->assertEquals('Done', $rows[1]['stackName']);
+	}
+
+	public function testParseCommaDelimitedUtf16Le(): void {
+		$csv = "Card title,Description,List name,Tags,Due date,Created,Modified\r\n";
+		$csv .= "Test,,To Do,,null,01/01/2026,01/01/2026\r\n";
+
+		$utf16 = mb_convert_encoding($csv, 'UTF-16LE', 'UTF-8');
+		$utf16WithBom = "\xFF\xFE" . $utf16;
+
+		$rows = $this->parser->parse($utf16WithBom);
+
+		$this->assertCount(1, $rows);
+		$this->assertEquals('Test', $rows[0]['title']);
+		$this->assertEquals('To Do', $rows[0]['stackName']);
+	}
+}

--- a/tests/unit/controller/BoardControllerTest.php
+++ b/tests/unit/controller/BoardControllerTest.php
@@ -29,6 +29,7 @@ namespace OCA\Deck\Controller;
 use OCA\Deck\Db\Acl;
 use OCA\Deck\Db\Board;
 use OCA\Deck\Service\BoardService;
+use OCA\Deck\Service\CsvImportService;
 use OCA\Deck\Service\ExternalBoardService;
 use OCA\Deck\Service\Importer\BoardImportService;
 use OCA\Deck\Service\PermissionService;
@@ -87,6 +88,7 @@ class BoardControllerTest extends \Test\TestCase {
 			$this->createMock(ExternalBoardService::class),
 			$this->permissionService,
 			$this->boardImportService,
+			$this->createMock(CsvImportService::class),
 			$this->l10n,
 			$this->userId
 		);


### PR DESCRIPTION
* Target version: main

### Summary

Allows importing a new board from CSV /JSON and adding / updating cards for existing boards from CSV / JSON.

Import board:
<img width="913" height="520" alt="image" src="https://github.com/user-attachments/assets/c27d187c-f4a9-46ca-af28-478aa1be0a8b" />

Import cards:

<img width="562" height="390" alt="image" src="https://github.com/user-attachments/assets/837e1233-7082-4a83-a8e0-4c7d5e6fb189" />
<img width="635" height="224" alt="image" src="https://github.com/user-attachments/assets/360664ea-653b-4526-9b1b-fa8869774998" />


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
- [x] This PR was partly or wholly created by AI
