### PR TITLE
fix(teams): use lighter probeCircles()

### DIFF
--- a/lib/Service/CirclesService.php
+++ b/lib/Service/CirclesService.php
@@ -14,6 +14,7 @@ use OCA\Circles\CirclesManager;
 use OCA\Circles\Model\Circle;
 use OCA\Circles\Model\Member;
 use OCA\Circles\Model\Probes\CircleProbe;
+use OCA\Circles\Model\Probes\DataProbe;
 use OCP\App\IAppManager;
 use OCP\Server;
 use Throwable;
@@ -45,7 +46,9 @@ class CirclesService {
 			// Enforce current user condition since we always want the full list of members
 			$circlesManager = Server::get(CirclesManager::class);
 			$circlesManager->startSuperSession();
-			return $circlesManager->getCircle($circleId);
+			$dataProbe = new DataProbe();
+			$dataProbe->add(DataProbe::OWNER);
+			return $circlesManager->probeCircle($circleId, null, $dataProbe);
 		} catch (Throwable $e) {
 		}
 		return null;
@@ -64,7 +67,9 @@ class CirclesService {
 			$circlesManager = Server::get(CirclesManager::class);
 			$federatedUser = $circlesManager->getFederatedUser($userId, Member::TYPE_USER);
 			$circlesManager->startSession($federatedUser);
-			$circle = $circlesManager->getCircle($circleId);
+			$dataProbe = new DataProbe();
+			$dataProbe->add(DataProbe::INITIATOR);
+			$circle = $circlesManager->probeCircle($circleId, null, $dataProbe);
 			$member = $circle->getInitiator();
 			$isUserInCircle = $member->getLevel() >= Member::LEVEL_MEMBER;
 
@@ -96,7 +101,7 @@ class CirclesService {
 			$probe->mustBeMember();
 			return array_map(function (Circle $circle) {
 				return $circle->getSingleId();
-			}, $circlesManager->getCircles($probe));
+			}, $circlesManager->probeCircles($probe));
 		} catch (Throwable $e) {
 		}
 		return [];

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -99,17 +99,27 @@ namespace OCA\Circles\Model\Probes {
 		public function __construct() {}
 		public function mustBeMember(bool $must = true): self {}
 	}
+	class DataProbe {
+		public const OWNER = 'd';
+		public const INITIATOR = 'h';
+		public function __construct() {}
+		public function add(string $key, array $path = []): self {}
+		public function mustBeMember(bool $must = true): self {}
+	}
 }
 
 namespace OCA\Circles {
 	use OCA\Circles\Model\Circle;
 	use OCA\Circles\Model\FederatedUser;
 	use OCA\Circles\Model\Probes\CircleProbe;
+	use OCA\Circles\Model\Probes\DataProbe;
 	class CirclesManager {
 		public function startSuperSession(): void {}
 		public function startSession(?FederatedUser $federatedUser = null): void {}
 		public function getCircles(?CircleProbe $probe = null): array {}
 		public function getCircle(string $singleId, ?CircleProbe $probe = null): Circle {}
+		public function probeCircles(?CircleProbe $circleProbe = null, ?DataProbe $dataProbe = null): array {}
+		public function probeCircle(string $singleId, ?CircleProbe $probe = null, ?DataProbe $dataProbe = null): Circle {}
 		public function getFederatedUser(string $federatedId, int $type = Member::TYPE_SINGLE): FederatedUser {}
 	}
 }


### PR DESCRIPTION
it is advice to use `probeCircles()` for this purpose, the backend will request a structured/cached version of data about memberships,
it also extract less data from database and provide a way to request extra data. (`DataProbe`)