### PR TITLE
feat: Add swimlane grouping by labels and assignees

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,7 +42,7 @@
         <database min-version="9.4">pgsql</database>
         <database>sqlite</database>
         <database min-version="8.0">mysql</database>
-        <nextcloud min-version="35" max-version="35"/>
+        <nextcloud min-version="34" max-version="35"/>
     </dependencies>
     <background-jobs>
         <job>OCA\Deck\Cron\DeleteCron</job>

--- a/cypress/e2e/swimlanesFeatures.js
+++ b/cypress/e2e/swimlanesFeatures.js
@@ -1,0 +1,243 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { randUser } from '../utils/index.js'
+
+const user = randUser()
+
+/**
+ * Builds a board with three stacks, three labels, two cards \u2014 one card
+ * has two labels so it should render in two lanes when grouped by labels.
+ */
+function seedSwimlaneBoard() {
+	const auth = { user: user.userId, password: user.password }
+	const baseUrl = Cypress.env('baseUrl')
+	const api = `${baseUrl}/index.php/apps/deck/api/v1.0`
+
+	return cy.request({
+		method: 'POST',
+		url: `${api}/boards`,
+		auth,
+		body: { title: 'Swimlanes', color: '00ff00' },
+	}).then(({ body: board }) => {
+		const boardId = board.id
+
+		const stackReq = (title) => cy.request({
+			method: 'POST',
+			url: `${api}/boards/${boardId}/stacks`,
+			auth,
+			body: { title, order: 0 },
+		})
+		const labelReq = (title, color) => cy.request({
+			method: 'POST',
+			url: `${api}/boards/${boardId}/labels`,
+			auth,
+			body: { title, color },
+		}).then(({ body }) => body)
+
+		// Cypress chainables are not promises, so the requests are chained
+		// sequentially instead of via Promise.all
+		const ids = {}
+		return stackReq('Todo').then(({ body }) => {
+			ids.todo = body.id
+		}).then(() => stackReq('Doing'))
+			.then(() => stackReq('Done'))
+			.then(() => labelReq('Bug', 'ff0000'))
+			.then((label) => {
+				ids.bug = label.id
+			})
+			.then(() => labelReq('Feature', '00ff00'))
+			.then((label) => {
+				ids.feature = label.id
+			})
+			.then(() => labelReq('Backend', '0000ff'))
+			.then((label) => {
+				ids.backend = label.id
+			})
+			.then(() => {
+				const mk = (title) => cy.request({
+					method: 'POST',
+					url: `${api}/boards/${boardId}/stacks/${ids.todo}/cards`,
+					auth,
+					body: { title, description: '' },
+				}).then(({ body }) => body)
+				const assignLabel = (cardId, labelId) => cy.request({
+					method: 'PUT',
+					url: `${api}/boards/${boardId}/stacks/${ids.todo}/cards/${cardId}/assignLabel`,
+					auth,
+					body: { labelId },
+				})
+				return mk('Fix login bug').then((card) =>
+					// two labels on this card
+					assignLabel(card.id, ids.bug).then(() => assignLabel(card.id, ids.backend)),
+				).then(() =>
+					mk('Ship feature').then((card) => assignLabel(card.id, ids.feature)),
+				).then(() => mk('Unlabeled work'))
+					.then(() => cy.wrap({ boardId }))
+			})
+	})
+}
+
+const viewer = randUser()
+
+describe('Swimlane grouping — editor-only restriction', function() {
+	const owner = randUser()
+	let restrictedBoardId
+
+	before(function() {
+		cy.createUser(owner)
+		cy.createUser(viewer)
+		const ownerAuth = { user: owner.userId, password: owner.password }
+		const base = `${Cypress.env('baseUrl')}/index.php/apps/deck/api/v1.0`
+		cy.request({
+			method: 'POST',
+			url: `${base}/boards`,
+			auth: ownerAuth,
+			body: { title: 'Restricted board', color: '0000ff' },
+		}).then(({ body }) => {
+			restrictedBoardId = body.id
+			// Share via API with all permission flags explicitly false; the
+			// share dialog grants edit by default, which would invalidate this
+			// "read-only" suite. PERMISSION_TYPE_USER = 0.
+			cy.request({
+				method: 'POST',
+				url: `${base}/boards/${restrictedBoardId}/acl`,
+				auth: ownerAuth,
+				body: {
+					type: 0,
+					participant: viewer.userId,
+					permissionEdit: false,
+					permissionShare: false,
+					permissionManage: false,
+				},
+			})
+		})
+	})
+
+	it('read-only user cannot set swimlaneMode via the API (403)', function() {
+		// Clear cookies so the basic-auth credentials below aren't silently
+		// overridden by a logged-in session left over from cy.createUser /
+		// cy.shareBoardWithUi (which authenticate as admin and would make
+		// the request succeed as admin, masking the permission check).
+		cy.clearCookies()
+		cy.request({
+			method: 'POST',
+			failOnStatusCode: false,
+			url: `${Cypress.env('baseUrl')}/ocs/v2.php/apps/deck/api/v1.0/config/board:${restrictedBoardId}:swimlaneMode?format=json`,
+			auth: { user: viewer.userId, password: viewer.password },
+			headers: { 'OCS-APIRequest': 'true' },
+			body: { value: 'labels' },
+		}).then((response) => {
+			expect(response.status).to.equal(403)
+		})
+	})
+
+	it('swimlane grouping controls are disabled in the UI for a read-only user', function() {
+		cy.login(viewer)
+		cy.visit(`/apps/deck/board/${restrictedBoardId}`)
+		cy.get('button[aria-label="View Modes"]', { timeout: 10000 }).first().click()
+		cy.get('input[name="swimlaneMode"]').each(($input) => {
+			cy.wrap($input).should('be.disabled')
+		})
+	})
+})
+
+describe('Swimlane grouping', function() {
+	let boardId
+
+	before(function() {
+		cy.createUser(user)
+		cy.login(user)
+		seedSwimlaneBoard().then((ctx) => { boardId = ctx.boardId })
+	})
+
+	beforeEach(function() {
+		// Reset the board to flat view before each test so the tests are
+		// independent (done here rather than in afterEach so that a config
+		// request still in flight when the previous test ends cannot undo it)
+		cy.request({
+			method: 'POST',
+			url: `${Cypress.env('baseUrl')}/ocs/v2.php/apps/deck/api/v1.0/config/board:${boardId}:swimlaneMode?format=json`,
+			auth: { user: user.userId, password: user.password },
+			body: { value: 'none' },
+		})
+		cy.login(user)
+		cy.visit(`/apps/deck/board/${boardId}`)
+		cy.get('.stack', { timeout: 10000 }).should('have.length', 3)
+	})
+
+	// Selects a grouping mode in the View Modes menu and waits for the
+	// config request to be persisted, so the next test cannot race it
+	const setModeViaMenu = (label) => {
+		cy.intercept('POST', '**/apps/deck/api/v1.0/config/**').as('saveSwimlaneMode')
+		cy.get('button[aria-label="View Modes"]').first().click()
+		// {force: true} is needed because the NcActions menu has a brief
+		// CSS visibility:hidden phase on the action-radio span while it
+		// animates open, which is what an end user would see as a normal
+		// click target
+		cy.contains('.action-radio__label', label).click({ force: true })
+		cy.wait('@saveSwimlaneMode')
+	}
+
+	it('flat view shows no swimlanes initially', function() {
+		cy.get('.swimlane').should('not.exist')
+		cy.get('.card').should('have.length.at.least', 3)
+	})
+
+	it('groups cards by labels', function() {
+		setModeViaMenu('Labels')
+
+		cy.get('.swimlane', { timeout: 8000 }).should('have.length.at.least', 4)
+		cy.get('.swimlane-header__title, .swimlane-header__label').should('contain.text', 'Bug')
+		cy.get('.swimlane-header__title, .swimlane-header__label').should('contain.text', 'Feature')
+		cy.get('.swimlane-header__title, .swimlane-header__label').should('contain.text', 'Backend')
+		cy.get('.swimlane-header__title, .swimlane-header__label').last().should('contain.text', 'No label')
+	})
+
+	it('renders a multi-label card in every matching lane', function() {
+		setModeViaMenu('Labels')
+		cy.get('.swimlane', { timeout: 8000 }).should('have.length.at.least', 4)
+
+		// "Fix login bug" has Bug + Backend labels \u2014 must appear in both lanes.
+		// Use cy.contains() to avoid embedding lane names into a CSS selector string.
+		const expectCardInLane = (laneName, cardTitle) => {
+			cy.contains('.swimlane-header', laneName)
+				.parents('.swimlane')
+				.find('.card')
+				.contains(cardTitle)
+				.should('exist')
+		}
+		expectCardInLane('Bug', 'Fix login bug')
+		expectCardInLane('Backend', 'Fix login bug')
+	})
+
+	it('groups cards by assignees with Unassigned catchall last', function() {
+		setModeViaMenu('Assignees')
+
+		cy.get('.swimlane', { timeout: 8000 }).should('have.length.at.least', 1)
+		cy.get('.swimlane-header__title').last().should('contain.text', 'Unassigned')
+	})
+
+	it('returns to flat view when No grouping is selected', function() {
+		setModeViaMenu('Labels')
+		cy.get('.swimlane', { timeout: 8000 }).should('exist')
+
+		setModeViaMenu('No grouping')
+
+		cy.get('.swimlane').should('not.exist')
+		cy.get('.stack').should('have.length', 3)
+	})
+
+	it('persists the grouping mode across reload', function() {
+		setModeViaMenu('Labels')
+		cy.get('.swimlane', { timeout: 8000 }).should('exist')
+
+		cy.reload()
+		cy.get('.swimlane', { timeout: 10000 }).should('have.length.at.least', 4)
+
+		// Radio reflects the persisted mode after reload
+		cy.get('button[aria-label="View Modes"]').first().click()
+		cy.get('input[name="swimlaneMode"][value="labels"]').should('be.checked')
+	})
+})

--- a/lib/Service/BoardService.php
+++ b/lib/Service/BoardService.php
@@ -341,9 +341,13 @@ class BoardService {
 
 	public function enrichWithBoardSettings(Board $board): void {
 		$globalCalendarConfig = (bool)$this->config->getUserValue($this->userId, Application::APP_ID, 'calendar', true);
+		$boardId = $board->getId();
 		$settings = [
-			'notify-due' => $this->config->getUserValue($this->userId, Application::APP_ID, 'board:' . $board->getId() . ':notify-due', ConfigService::SETTING_BOARD_NOTIFICATION_DUE_ASSIGNED),
-			'calendar' => $this->config->getUserValue($this->userId, Application::APP_ID, 'board:' . $board->getId() . ':calendar', $globalCalendarConfig),
+			'notify-due' => $this->config->getUserValue($this->userId, Application::APP_ID, 'board:' . $boardId . ':notify-due', ConfigService::SETTING_BOARD_NOTIFICATION_DUE_ASSIGNED),
+			'calendar' => $this->config->getUserValue($this->userId, Application::APP_ID, 'board:' . $boardId . ':calendar', $globalCalendarConfig),
+			'swimlaneMode' => $this->config->getAppValue(Application::APP_ID, 'board:' . $boardId . ':swimlaneMode', 'none'),
+			'swimlaneLabelOrder' => $this->config->getAppValue(Application::APP_ID, 'board:' . $boardId . ':swimlaneLabelOrder', '[]'),
+			'swimlaneUserOrder' => $this->config->getAppValue(Application::APP_ID, 'board:' . $boardId . ':swimlaneUserOrder', '[]'),
 		];
 		$board->setSettings($settings);
 	}

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -24,6 +24,8 @@ class ConfigService {
 	public const SETTING_BOARD_NOTIFICATION_DUE_ALL = 'all';
 	public const SETTING_BOARD_NOTIFICATION_DUE_DEFAULT = self::SETTING_BOARD_NOTIFICATION_DUE_ASSIGNED;
 
+	private const SWIMLANE_CONFIG_KEYS = ['swimlaneMode', 'swimlaneLabelOrder', 'swimlaneUserOrder'];
+
 	private ?string $userId = null;
 
 	public function __construct(
@@ -187,14 +189,61 @@ class ConfigService {
 				if (count($parts) < 3) {
 					break;
 				}
+				$boardId = $parts[1];
 				$boardConfigKey = $parts[2];
+				if ($boardId === '' || $boardConfigKey === '') {
+					throw new BadRequestException('Board config key must be in the form board:<id>:<setting>');
+				}
 				if ($boardConfigKey === 'notify-due' && !in_array($value, [self::SETTING_BOARD_NOTIFICATION_DUE_ALL, self::SETTING_BOARD_NOTIFICATION_DUE_ASSIGNED, self::SETTING_BOARD_NOTIFICATION_DUE_OFF], true)) {
 					throw new BadRequestException('Board notification option must be one of: off, assigned, all');
 				}
-				$this->config->setUserValue($userId, Application::APP_ID, $key, (string)$value);
+				if (in_array($boardConfigKey, self::SWIMLANE_CONFIG_KEYS, true)) {
+					// Shared board-level setting (visible to every board member).
+					// EDIT permission is enforced in ConfigController::setValue(),
+					// whose board:(\d+): match requires a numeric board id — so a
+					// numeric id is required here too, otherwise the permission
+					// check could be bypassed.
+					if (!ctype_digit($boardId)) {
+						throw new BadRequestException('Board id must be numeric');
+					}
+					$this->validateSwimlaneValue($boardConfigKey, $value);
+					$this->config->setAppValue(Application::APP_ID, $key, (string)$value);
+				} else {
+					$this->config->setUserValue($userId, Application::APP_ID, $key, (string)$value);
+				}
 				$result = $value;
 		}
 		return $result;
+	}
+
+	/**
+	 * Shared swimlane settings live in app config and are delivered to every
+	 * board member on board load, so reject malformed values before storing.
+	 */
+	private function validateSwimlaneValue(string $boardConfigKey, mixed $value): void {
+		if ($boardConfigKey === 'swimlaneMode') {
+			if (!in_array($value, ['none', 'labels', 'assignees'], true)) {
+				throw new BadRequestException('Swimlane mode must be one of: none, labels, assignees');
+			}
+			return;
+		}
+
+		// swimlaneLabelOrder / swimlaneUserOrder: JSON array of lane ids
+		// (label ids, user ids or the '__none__' catch-all lane).
+		if (!is_string($value) || strlen($value) > 8192) {
+			throw new BadRequestException('Swimlane order must be a JSON array of lane ids');
+		}
+		$order = json_decode($value, true);
+		if (!is_array($order) || !array_is_list($order) || count($order) > 1000) {
+			throw new BadRequestException('Swimlane order must be a JSON array of lane ids');
+		}
+		foreach ($order as $laneId) {
+			$isIntId = is_int($laneId);
+			$isStringId = is_string($laneId) && $laneId !== '' && strlen($laneId) <= 64;
+			if (!$isIntId && !$isStringId) {
+				throw new BadRequestException('Swimlane order entries must be label ids, user ids or "__none__"');
+			}
+		}
 	}
 
 	/**

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -263,6 +263,31 @@
 						</template>
 						{{ showCardCover ? t('deck', 'Hide card cover images') : t('deck', 'Show card cover images') }}
 					</NcActionButton>
+					<template v-if="viewMode === 'kanban'">
+						<NcActionSeparator />
+						<NcActionCaption :name="t('deck', 'Group by')" />
+						<NcActionRadio name="swimlaneMode"
+							value="none"
+							:model-value="swimlaneMode"
+							:disabled="!canEdit"
+							@update:model-value="setSwimlaneMode">
+							{{ t('deck', 'No grouping') }}
+						</NcActionRadio>
+						<NcActionRadio name="swimlaneMode"
+							value="labels"
+							:model-value="swimlaneMode"
+							:disabled="!canEdit"
+							@update:model-value="setSwimlaneMode">
+							{{ t('deck', 'Labels') }}
+						</NcActionRadio>
+						<NcActionRadio name="swimlaneMode"
+							value="assignees"
+							:model-value="swimlaneMode"
+							:disabled="!canEdit"
+							@update:model-value="setSwimlaneMode">
+							{{ t('deck', 'Assignees') }}
+						</NcActionRadio>
+					</template>
 				</NcActions>
 				<!-- FIXME: NcActionRouter currently doesn't work as an inline action -->
 				<NcActions v-if="isFullApp">
@@ -279,7 +304,7 @@
 <script>
 import { mapState, mapGetters } from 'vuex'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
-import { NcActions, NcActionButton, NcActionSeparator, NcAvatar, NcButton, NcPopover, NcModal } from '@nextcloud/vue'
+import { NcActions, NcActionButton, NcActionCaption, NcActionRadio, NcActionSeparator, NcAvatar, NcButton, NcPopover, NcModal } from '@nextcloud/vue'
 import labelStyle from '../mixins/labelStyle.js'
 import ArchiveIcon from 'vue-material-design-icons/ArchiveOutline.vue'
 import ImageIcon from 'vue-material-design-icons/ImageMultipleOutline.vue'
@@ -302,6 +327,9 @@ export default {
 		NcModal,
 		NcActions,
 		NcActionButton,
+		NcActionCaption,
+		NcActionRadio,
+		NcActionSeparator,
 		NcButton,
 		NcPopover,
 		NcAvatar,
@@ -313,7 +341,6 @@ export default {
 		ArrowExpandVerticalIcon,
 		ViewColumnIcon,
 		ChartGanttIcon,
-		NcActionSeparator,
 		TableColumnPlusAfter,
 		SessionList,
 	},
@@ -366,6 +393,9 @@ export default {
 		},
 		labelsSorted() {
 			return [...this.board.labels].sort((a, b) => (a.title < b.title) ? -1 : 1)
+		},
+		swimlaneMode() {
+			return this.board?.settings?.swimlaneMode || 'none'
 		},
 		presentUsers() {
 			if (!this.board) return []
@@ -432,6 +462,11 @@ export default {
 		},
 		toggleShowArchived() {
 			this.$store.dispatch('toggleShowArchived')
+		},
+		setSwimlaneMode(mode) {
+			if (this.board?.id && this.canEdit) {
+				this.$store.dispatch('setSwimlaneMode', { boardId: this.board.id, mode })
+			}
 		},
 		addNewStack() {
 			this.stack = { title: this.newStackTitle }

--- a/src/components/board/Board.vue
+++ b/src/components/board/Board.vue
@@ -50,7 +50,7 @@
 				key="gantt"
 				:board="board"
 				:stacks="stacksByBoard" />
-			<div v-else-if="!isEmpty && !loading"
+			<div v-else-if="!isEmpty && !loading && swimlaneMode === 'none'"
 				key="board"
 				ref="board"
 				class="board"
@@ -68,6 +68,41 @@
 						data-dragscroll-enabled
 						class="stack-draggable-wrapper">
 						<Stack :stack="stack" :dragging="draggingStack" data-click-closes-sidebar="true" />
+					</Draggable>
+				</Container>
+			</div>
+			<div v-else-if="!isEmpty && !loading && viewMode === 'kanban'"
+				key="board-swimlanes"
+				ref="board"
+				role="region"
+				:aria-label="t('deck', 'Board grouped by {mode}', { mode: swimlaneMode })"
+				class="board board--swimlanes">
+				<div class="board__stack-headers">
+					<Container orientation="horizontal"
+						:drag-handle-selector="dragHandleSelector"
+						data-click-closes-sidebar="true"
+						@drag-start="draggingStack = true"
+						@drag-end="draggingStack = false"
+						@drop="onDropStack">
+						<Draggable v-for="stack in stacksByBoard"
+							:key="stack.id"
+							data-click-closes-sidebar="true"
+							class="stack-draggable-wrapper">
+							<Stack :stack="stack"
+								:dragging="draggingStack"
+								header-only
+								data-click-closes-sidebar="true" />
+						</Draggable>
+					</Container>
+				</div>
+				<Container orientation="vertical"
+					:drag-handle-selector="canEdit ? '.swimlane-header__drag-handle' : '.no-drag'"
+					@drop="onReorderLane">
+					<Draggable v-for="lane in computedLanes"
+						:key="lane.key">
+						<Swimlane :lane="lane"
+							:stacks="stacksByBoard"
+							:board-id="board.id" />
 					</Draggable>
 				</Container>
 			</div>
@@ -93,6 +128,7 @@ import DeckIcon from '../icons/DeckIcon.vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 import Stack from './Stack.vue'
 import GanttView from './GanttView.vue'
+import Swimlane from './Swimlane.vue'
 import { NcEmptyContent, NcModal, NcButton, NcTextField, NcLoadingIcon } from '@nextcloud/vue'
 import GlobalSearchResults from '../search/GlobalSearchResults.vue'
 import { showError } from '../../helpers/errors.js'
@@ -108,6 +144,7 @@ export default {
 		Draggable,
 		Stack,
 		GanttView,
+		Swimlane,
 		NcEmptyContent,
 		NcModal,
 		NcTextField,
@@ -154,6 +191,104 @@ export default {
 		},
 		isEmpty() {
 			return this.stacksByBoard.length === 0
+		},
+		swimlaneMode() {
+			return this.board?.settings?.swimlaneMode || 'none'
+		},
+		computedLanes() {
+			if (this.swimlaneMode === 'none' || !this.board) {
+				return []
+			}
+			const lanes = []
+			const seen = new Set()
+			let hasNoValue = false
+
+			for (const stack of this.stacksByBoard) {
+				const cards = this.$store.getters.cardsByStack(stack.id).filter(
+					c => this.showArchived ? c.archived : !c.archived,
+				)
+				for (const card of cards) {
+					if (this.swimlaneMode === 'labels') {
+						if (!card.labels || card.labels.length === 0) {
+							hasNoValue = true
+						} else {
+							for (const label of card.labels) {
+								if (!seen.has(label.id)) {
+									seen.add(label.id)
+									lanes.push({
+										key: 'label-' + label.id,
+										id: label.id,
+										type: 'label',
+										title: label.title,
+										color: label.color,
+									})
+								}
+							}
+						}
+					} else if (this.swimlaneMode === 'assignees') {
+						if (!card.assignedUsers || card.assignedUsers.length === 0) {
+							hasNoValue = true
+						} else {
+							for (const user of card.assignedUsers) {
+								// Skip entries whose participant was deleted or
+								// couldn't be resolved (e.g. broken federation)
+								// so the whole view doesn't unmount on bad data
+								const uid = user?.participant?.uid
+								if (!uid) continue
+								if (!seen.has(uid)) {
+									seen.add(uid)
+									lanes.push({
+										key: 'assignee-' + uid,
+										id: uid,
+										type: 'assignee',
+										uid,
+										title: user.participant.displayname,
+									})
+								}
+							}
+						}
+					}
+				}
+			}
+
+			const savedOrder = this.swimlaneMode === 'labels'
+				? this.$store.state.swimlaneLabelOrder[this.board.id]
+				: this.$store.state.swimlaneUserOrder[this.board.id]
+
+			// Always sort to keep lane order stable across card moves.
+			// Lanes in savedOrder come first in their saved order; the rest
+			// fall back to a deterministic by-id ordering instead of card-
+			// iteration order (which shuffles when cards are moved).
+			lanes.sort((a, b) => {
+				if (savedOrder && savedOrder.length > 0) {
+					const aIdx = savedOrder.indexOf(a.id)
+					const bIdx = savedOrder.indexOf(b.id)
+					const aInSaved = aIdx !== -1
+					const bInSaved = bIdx !== -1
+					if (aInSaved && bInSaved) return aIdx - bIdx
+					if (aInSaved) return -1
+					if (bInSaved) return 1
+				}
+				if (typeof a.id === 'number' && typeof b.id === 'number') {
+					return a.id - b.id
+				}
+				return String(a.id).localeCompare(String(b.id))
+			})
+
+			if (hasNoValue) {
+				const noValueTitle = this.swimlaneMode === 'labels'
+					? t('deck', 'No label')
+					: t('deck', 'Unassigned')
+				lanes.push({
+					key: '__none__',
+					id: '__none__',
+					type: this.swimlaneMode === 'labels' ? 'label' : 'assignee',
+					title: noValueTitle,
+					color: null,
+				})
+			}
+
+			return lanes
 		},
 	},
 	watch: {
@@ -209,6 +344,22 @@ export default {
 
 		onDropStack({ removedIndex, addedIndex }) {
 			this.$store.dispatch('orderStack', { stack: this.stacksByBoard[removedIndex], removedIndex, addedIndex })
+		},
+
+		onReorderLane({ removedIndex, addedIndex }) {
+			if (removedIndex === null || addedIndex === null || !this.canEdit) {
+				return
+			}
+			const lanes = [...this.computedLanes]
+			const [moved] = lanes.splice(removedIndex, 1)
+			lanes.splice(addedIndex, 0, moved)
+			const order = lanes.map(l => l.id)
+			const type = this.swimlaneMode === 'labels' ? 'labels' : 'assignees'
+			this.$store.dispatch('setSwimlaneOrder', {
+				boardId: this.board.id,
+				type,
+				order,
+			})
 		},
 
 		addNewStack() {
@@ -292,6 +443,23 @@ export default {
 		overflow-x: auto;
 		flex-grow: 1;
 		scrollbar-gutter: stable;
+
+		&--swimlanes {
+			overflow-y: auto;
+			overflow-x: auto;
+			padding: 0;
+		}
+
+		&__stack-headers {
+			position: sticky;
+			top: 0;
+			z-index: 150;
+			background-color: var(--color-main-background);
+
+			.smooth-dnd-container.horizontal {
+				height: auto;
+			}
+		}
 	}
 
 	/**

--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -5,7 +5,8 @@
 
 <template>
 	<div class="stack" :class="{'stack--done-column': isDoneColumn}" :data-cy-stack="stack.title">
-		<div v-click-outside="stopCardCreation"
+		<div v-if="!hideHeader"
+			v-click-outside="stopCardCreation"
 			class="stack__header"
 			:class="{'stack__header--add': showAddCard, 'stack__header--done-column': isDoneColumn}"
 			:aria-label="stack.title">
@@ -101,9 +102,10 @@
 			</div>
 		</NcModal>
 
-		<Container :get-child-payload="payloadForCard(stack.id)"
+		<Container v-if="!headerOnly"
+			:get-child-payload="payloadForCard(stack.id)"
 			class="dnd-container"
-			group-name="stack"
+			:group-name="lane ? 'stack-' + lane.key : 'stack'"
 			data-click-closes-sidebar="true"
 			non-drag-area-selector=".dragDisabled"
 			:drag-handle-selector="dragHandleSelector"
@@ -186,6 +188,21 @@ export default {
 			type: Object,
 			default: undefined,
 		},
+		lane: {
+			type: Object,
+			default: null,
+		},
+		// Swimlane view: render only the header row (title, actions, add card)
+		headerOnly: {
+			type: Boolean,
+			default: false,
+		},
+		// Swimlane view: render only the card column, header lives in the
+		// shared sticky header row at the top of the board
+		hideHeader: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	data() {
 		return {
@@ -213,6 +230,14 @@ export default {
 			showArchived: state => state.showArchived,
 		}),
 		cardsByStack() {
+			if (this.lane && this.lane.id !== undefined) {
+				return this.$store.getters.cardsByStackAndLane(this.stack.id, this.lane.type, this.lane.id).filter((card) => {
+					if (this.showArchived) {
+						return card.archived
+					}
+					return !card.archived
+				})
+			}
 			return this.$store.getters.cardsByStack(this.stack.id).filter((card) => {
 				if (this.showArchived) {
 					return card.archived

--- a/src/components/board/Swimlane.vue
+++ b/src/components/board/Swimlane.vue
@@ -1,0 +1,169 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<section class="swimlane" :aria-label="lane.title">
+		<SwimlaneHeader :lane="lane"
+			:card-count="cardCount"
+			:collapsed="collapsed"
+			@toggle="toggleCollapse" />
+
+		<div v-show="!collapsed" class="swimlane__stacks">
+			<Container lock-axis="y"
+				orientation="horizontal"
+				:drag-handle-selector="dragHandleSelector"
+				data-click-closes-sidebar="true"
+				@drag-start="draggingStack = true"
+				@drag-end="draggingStack = false"
+				@drop="onDropStack">
+				<Draggable v-for="stack in stacks"
+					:key="stack.id"
+					data-click-closes-sidebar="true"
+					data-dragscroll-enabled
+					class="stack-draggable-wrapper">
+					<Stack :stack="stack"
+						:lane="lane"
+						:dragging="draggingStack"
+						hide-header
+						data-click-closes-sidebar="true" />
+				</Draggable>
+			</Container>
+		</div>
+	</section>
+</template>
+
+<script>
+import { Container, Draggable } from 'vue-smooth-dnd'
+import Stack from './Stack.vue'
+import SwimlaneHeader from './SwimlaneHeader.vue'
+import { mapGetters } from 'vuex'
+
+export default {
+	name: 'Swimlane',
+	components: {
+		Container,
+		Draggable,
+		Stack,
+		SwimlaneHeader,
+	},
+	props: {
+		lane: {
+			type: Object,
+			required: true,
+		},
+		stacks: {
+			type: Array,
+			required: true,
+		},
+		boardId: {
+			type: Number,
+			required: true,
+		},
+	},
+	data() {
+		let initialCollapsed = false
+		const stored = localStorage.getItem(`deck.board.${this.boardId}.swimlane.collapsed`)
+		if (stored) {
+			try {
+				initialCollapsed = !!JSON.parse(stored)[this.lane.key]
+			} catch (e) {
+				// ignore
+			}
+		}
+		return {
+			draggingStack: false,
+			collapsed: initialCollapsed,
+		}
+	},
+	computed: {
+		...mapGetters(['canEdit']),
+		cardCount() {
+			let count = 0
+			for (const stack of this.stacks) {
+				count += this.$store.getters.cardsByStackAndLane(stack.id, this.lane.type, this.lane.id).length
+			}
+			return count
+		},
+		dragHandleSelector() {
+			return this.canEdit ? '.stack__title' : '.no-drag'
+		},
+	},
+	methods: {
+		toggleCollapse() {
+			this.collapsed = !this.collapsed
+			const storageKey = `deck.board.${this.boardId}.swimlane.collapsed`
+			let stored = {}
+			try {
+				stored = JSON.parse(localStorage.getItem(storageKey)) || {}
+			} catch (e) {
+				stored = {}
+			}
+			stored[this.lane.key] = this.collapsed
+			localStorage.setItem(storageKey, JSON.stringify(stored))
+		},
+		onDropStack({ removedIndex, addedIndex }) {
+			this.$store.dispatch('orderStack', {
+				stack: this.stacks[removedIndex],
+				removedIndex,
+				addedIndex,
+			})
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../../css/variables.scss';
+
+.swimlane {
+	margin-bottom: calc(var(--default-grid-baseline) * 3);
+
+	&__stacks {
+		// Horizontal scrolling happens on .board--swimlanes so the sticky
+		// stack-header row at the top stays column-aligned with every lane.
+		padding-inline: $board-gap;
+
+		:deep(.smooth-dnd-container.horizontal) {
+			display: flex;
+			align-items: stretch;
+			gap: $board-gap;
+
+			.stack-draggable-wrapper.smooth-dnd-draggable-wrapper {
+				display: flex;
+				height: auto;
+				flex: 0 1 $card-max-width;
+				min-width: $card-min-width;
+
+				.stack {
+					display: flex;
+					flex-direction: column;
+					position: relative;
+
+					.smooth-dnd-container.vertical {
+						flex-grow: 1;
+						display: flex;
+						flex-direction: column;
+						margin-inline-start: $stack-gap;
+						padding-inline-end: $stack-gap;
+						overflow-x: hidden;
+						overflow-y: auto;
+						padding-top: 15px;
+						margin-top: -10px;
+						scrollbar-gutter: stable;
+					}
+
+					.smooth-dnd-container.vertical > .smooth-dnd-draggable-wrapper {
+						overflow: initial;
+					}
+
+					.smooth-dnd-container.vertical .smooth-dnd-draggable-wrapper {
+						height: auto;
+					}
+				}
+			}
+		}
+	}
+}
+</style>

--- a/src/components/board/SwimlaneHeader.vue
+++ b/src/components/board/SwimlaneHeader.vue
@@ -1,0 +1,166 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="swimlane-header"
+		:class="{'swimlane-header--collapsed': collapsed}"
+		:style="headerBorderStyle">
+		<button class="swimlane-header__toggle"
+			:aria-expanded="String(!collapsed)"
+			:aria-label="toggleLabel"
+			@click="$emit('toggle')">
+			<ChevronRightIcon v-if="collapsed" :size="20" decorative />
+			<ChevronDownIcon v-else :size="20" decorative />
+		</button>
+
+		<span v-if="lane.type === 'label' && lane.key !== '__none__'"
+			class="swimlane-header__label"
+			:style="labelStyle(lane)">
+			{{ lane.title }}
+		</span>
+		<NcAvatar v-else-if="lane.type === 'assignee' && lane.key !== '__none__'"
+			:user="lane.uid"
+			:size="24"
+			:disable-menu="true"
+			:hide-status="true" />
+		<span v-if="lane.type === 'assignee' || lane.key === '__none__'"
+			class="swimlane-header__title">
+			{{ lane.title }}
+		</span>
+
+		<NcCounterBubble class="swimlane-header__count">
+			{{ cardCount }}
+		</NcCounterBubble>
+
+		<span v-if="canEdit && !collapsed"
+			class="swimlane-header__drag-handle"
+			role="button"
+			:aria-label="t('deck', 'Drag to reorder {lane}', { lane: lane.title })"
+			:title="t('deck', 'Drag to reorder')">
+			<DragHorizontalVariantIcon :size="20" decorative />
+		</span>
+	</div>
+</template>
+
+<script>
+import { NcAvatar, NcCounterBubble } from '@nextcloud/vue'
+import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
+import ChevronDownIcon from 'vue-material-design-icons/ChevronDown.vue'
+import DragHorizontalVariantIcon from 'vue-material-design-icons/DragHorizontalVariant.vue'
+import labelStyle from '../../mixins/labelStyle.js'
+import { mapGetters } from 'vuex'
+
+export default {
+	name: 'SwimlaneHeader',
+	components: {
+		NcAvatar,
+		NcCounterBubble,
+		ChevronRightIcon,
+		ChevronDownIcon,
+		DragHorizontalVariantIcon,
+	},
+	mixins: [labelStyle],
+	props: {
+		lane: {
+			type: Object,
+			required: true,
+		},
+		cardCount: {
+			type: Number,
+			default: 0,
+		},
+		collapsed: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	computed: {
+		...mapGetters(['canEdit']),
+		toggleLabel() {
+			return this.collapsed
+				? t('deck', 'Expand {lane}', { lane: this.lane.title })
+				: t('deck', 'Collapse {lane}', { lane: this.lane.title })
+		},
+		headerBorderStyle() {
+			if (this.lane.type === 'label' && this.lane.color) {
+				return { borderBottomColor: '#' + this.lane.color }
+			}
+			return {}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.swimlane-header {
+	display: flex;
+	align-items: center;
+	gap: calc(var(--default-grid-baseline) * 2);
+	padding: var(--default-grid-baseline) calc(var(--default-grid-baseline) * 2);
+	position: sticky;
+	top: 0;
+	z-index: 100;
+	background-color: var(--color-main-background);
+	border-bottom: 2px solid var(--color-border);
+	min-height: var(--default-clickable-area);
+
+	&--collapsed {
+		border-bottom-color: var(--color-border-dark);
+	}
+
+	&__toggle {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+		border-radius: var(--border-radius-element);
+		width: var(--default-clickable-area);
+		height: var(--default-clickable-area);
+		color: var(--color-main-text);
+
+		&:hover {
+			background-color: var(--color-background-hover);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--color-primary-element);
+			border-radius: var(--border-radius-element);
+		}
+	}
+
+	&__label {
+		display: inline-block;
+		padding: 2px 8px;
+		border-radius: var(--border-radius-large);
+		font-size: 0.85em;
+		font-weight: bold;
+		white-space: nowrap;
+	}
+
+	&__title {
+		font-weight: bold;
+		white-space: nowrap;
+	}
+
+	&__count {
+		flex-shrink: 0;
+	}
+
+	&__drag-handle {
+		margin-inline-start: auto;
+		cursor: grab;
+		color: var(--color-text-maxcontrast);
+		display: flex;
+		align-items: center;
+
+		&:hover {
+			color: var(--color-main-text);
+		}
+	}
+}
+</style>

--- a/src/components/cards/CardBadges.vue
+++ b/src/components/cards/CardBadges.vue
@@ -33,6 +33,13 @@
 					<AttachmentIcon :size="16" />
 					<span>{{ card.attachmentCount }}</span>
 				</div>
+
+				<div v-if="laneCount > 0"
+					class="icon-badge icon-badge--lanes"
+					:title="t('deck', 'In {count} lanes', { count: laneCount })">
+					<ArrowTopRightThinIcon :size="16" />
+					<span>{{ laneCount }}</span>
+				</div>
 			</div>
 		</div>
 
@@ -51,6 +58,7 @@ import AttachmentIcon from 'vue-material-design-icons/Paperclip.vue'
 import CheckmarkIcon from 'vue-material-design-icons/CheckboxMarked.vue'
 import CommentIcon from 'vue-material-design-icons/CommentOutline.vue'
 import CommentUnreadIcon from 'vue-material-design-icons/CommentAccountOutline.vue'
+import ArrowTopRightThinIcon from 'vue-material-design-icons/ArrowTopRightThin.vue'
 import DueDate from './badges/DueDate.vue'
 
 export default {
@@ -64,6 +72,7 @@ export default {
 		CommentIcon,
 		CommentUnreadIcon,
 		CardId,
+		ArrowTopRightThinIcon,
 	},
 	props: {
 		card: {
@@ -72,6 +81,23 @@ export default {
 		},
 	},
 	computed: {
+		laneCount() {
+			const board = this.$store.state.currentBoard
+			if (!board?.id) {
+				return 0
+			}
+			const mode = board?.settings?.swimlaneMode || 'none'
+			if (mode === 'none') {
+				return 0
+			}
+			if (mode === 'labels') {
+				return (this.card.labels && this.card.labels.length > 1) ? this.card.labels.length : 0
+			}
+			if (mode === 'assignees') {
+				return (this.card.assignedUsers && this.card.assignedUsers.length > 1) ? this.card.assignedUsers.length : 0
+			}
+			return 0
+		},
 		checkListCount() {
 			return (this.card.description.match(/^\s*([*+-]|(\d\.))\s+\[\s*(\s|x)\s*\](.*)$/gim) || []).length
 		},
@@ -119,6 +145,10 @@ export default {
 			span,
 			&:deep(span) {
 				padding: 2px;
+			}
+
+			&--lanes {
+				opacity: 0.7;
 			}
 		}
 	}

--- a/src/store/card.js
+++ b/src/store/card.js
@@ -184,6 +184,25 @@ export default function cardModuleFactory() {
 					})
 					.sort((a, b) => a.order - b.order || a.createdAt - b.createdAt)
 			},
+			cardsByStackAndLane: (state, getters) => (stackId, laneType, laneKey) => {
+				const cards = getters.cardsByStack(stackId)
+				if (!laneType || laneType === 'none') {
+					return cards
+				}
+				if (laneType === 'label') {
+					if (laneKey === '__none__') {
+						return cards.filter(c => !c.labels || c.labels.length === 0)
+					}
+					return cards.filter(c => c.labels && c.labels.some(l => l.id === laneKey))
+				}
+				if (laneType === 'assignee') {
+					if (laneKey === '__none__') {
+						return cards.filter(c => !c.assignedUsers || c.assignedUsers.length === 0)
+					}
+					return cards.filter(c => c.assignedUsers && c.assignedUsers.some(u => u?.participant?.uid === laneKey))
+				}
+				return cards
+			},
 			cardById: state => (id) => {
 				return state.cards.find((card) => card.id === id)
 			},

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -59,6 +59,8 @@ export default function storeFactory() {
 			activity: [],
 			activityLoadMore: true,
 			filter: { tags: [], users: [], due: '', unassigned: false, completed: 'both' },
+			swimlaneLabelOrder: {},
+			swimlaneUserOrder: {},
 			shortcutLock: false,
 			viewModeByBoard: {},
 		},
@@ -307,6 +309,15 @@ export default function storeFactory() {
 					Vue.delete(state.currentBoard.acl, removeIndex)
 				}
 			},
+			SET_SWIMLANE_MODE(state, { mode }) {
+				if (state.currentBoard?.settings) {
+					Vue.set(state.currentBoard.settings, 'swimlaneMode', mode)
+				}
+			},
+			SET_SWIMLANE_ORDER(state, { boardId, type, order }) {
+				const key = type === 'labels' ? 'swimlaneLabelOrder' : 'swimlaneUserOrder'
+				Vue.set(state[key], boardId, order)
+			},
 			TOGGLE_SHORTCUT_LOCK(state, lock) {
 				state.shortcutLock = lock
 			},
@@ -346,6 +357,20 @@ export default function storeFactory() {
 				const board = await apiClient.loadById(boardId)
 				commit('setCurrentBoard', board)
 				commit('setAssignableUsers', board.users)
+				if (board.settings) {
+					try {
+						const labelOrder = JSON.parse(board.settings.swimlaneLabelOrder || '[]')
+						if (labelOrder.length > 0) {
+							commit('SET_SWIMLANE_ORDER', { boardId, type: 'labels', order: labelOrder })
+						}
+					} catch (e) { /* ignore parse errors */ }
+					try {
+						const userOrder = JSON.parse(board.settings.swimlaneUserOrder || '[]')
+						if (userOrder.length > 0) {
+							commit('SET_SWIMLANE_ORDER', { boardId, type: 'assignees', order: userOrder })
+						}
+					} catch (e) { /* ignore parse errors */ }
+				}
 			},
 
 			async refreshBoard({ commit, dispatch }, boardId) {
@@ -541,6 +566,33 @@ export default function storeFactory() {
 				await axios.put(generateUrl(`apps/deck/boards/${boardId}/transferOwner`), {
 					newOwner,
 				})
+			},
+			async setSwimlaneMode({ commit, dispatch, state }, { boardId, mode }) {
+				// Optimistic update with rollback so the UI does not stay out of
+				// sync with the server when the config write is rejected (403,
+				// validation 400, network error).
+				const previous = state.currentBoard?.settings?.swimlaneMode || 'none'
+				commit('SET_SWIMLANE_MODE', { mode })
+				try {
+					await dispatch('setConfig', { [`board:${boardId}:swimlaneMode`]: mode })
+				} catch (e) {
+					commit('SET_SWIMLANE_MODE', { mode: previous })
+					throw e
+				}
+			},
+			async setSwimlaneOrder({ commit, dispatch, state }, { boardId, type, order }) {
+				const configKey = type === 'labels' ? 'swimlaneLabelOrder' : 'swimlaneUserOrder'
+				const stateKey = type === 'labels' ? 'swimlaneLabelOrder' : 'swimlaneUserOrder'
+				const previous = state[stateKey][boardId] ? [...state[stateKey][boardId]] : null
+				commit('SET_SWIMLANE_ORDER', { boardId, type, order })
+				try {
+					await dispatch('setConfig', { [`board:${boardId}:${configKey}`]: JSON.stringify(order) })
+				} catch (e) {
+					if (previous) {
+						commit('SET_SWIMLANE_ORDER', { boardId, type, order: previous })
+					}
+					throw e
+				}
 			},
 			toggleShortcutLock({ commit }, lock) {
 				commit('TOGGLE_SHORTCUT_LOCK', lock)

--- a/tests/unit/Service/ConfigServiceTest.php
+++ b/tests/unit/Service/ConfigServiceTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Service;
+
+use OCA\Deck\AppInfo\Application;
+use OCA\Deck\BadRequestException;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ConfigServiceTest extends \Test\TestCase {
+	private IConfig|MockObject $config;
+	private IGroupManager|MockObject $groupManager;
+	private ConfigService $service;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->config = $this->createMock(IConfig::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+
+		$this->service = new ConfigService(
+			$this->config,
+			$this->groupManager,
+		);
+
+		// The service lazily reads userId from IUserSession via OCP\Server::get().
+		// We bypass that by setting the private property directly so set() can run.
+		$ref = new \ReflectionProperty(ConfigService::class, 'userId');
+		$ref->setValue($this->service, 'admin');
+	}
+
+	public function testSetSwimlaneModeIsStoredShared(): void {
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->with(Application::APP_ID, 'board:5:swimlaneMode', 'labels');
+		$this->config->expects($this->never())
+			->method('setUserValue');
+
+		$result = $this->service->set('board:5:swimlaneMode', 'labels');
+		$this->assertSame('labels', $result);
+	}
+
+	public function testSetSwimlaneLabelOrderIsShared(): void {
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->with(Application::APP_ID, 'board:7:swimlaneLabelOrder', '[3,1,2]');
+		$this->config->expects($this->never())
+			->method('setUserValue');
+
+		$result = $this->service->set('board:7:swimlaneLabelOrder', '[3,1,2]');
+		$this->assertSame('[3,1,2]', $result);
+	}
+
+	public function testSetSwimlaneUserOrderIsShared(): void {
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->with(Application::APP_ID, 'board:7:swimlaneUserOrder', '["admin","alice"]');
+		$this->config->expects($this->never())
+			->method('setUserValue');
+
+		$result = $this->service->set('board:7:swimlaneUserOrder', '["admin","alice"]');
+		$this->assertSame('["admin","alice"]', $result);
+	}
+
+	public function testSetBoardConfigRejectsEmptyKey(): void {
+		$this->config->expects($this->never())->method('setAppValue');
+		$this->config->expects($this->never())->method('setUserValue');
+
+		$this->expectException(BadRequestException::class);
+		$this->service->set('board:5:', 'x');
+	}
+
+	public function testSetBoardConfigRejectsEmptyBoardId(): void {
+		$this->config->expects($this->never())->method('setAppValue');
+		$this->config->expects($this->never())->method('setUserValue');
+
+		$this->expectException(BadRequestException::class);
+		$this->service->set('board::swimlaneMode', 'labels');
+	}
+
+	public function testSetSwimlaneConfigRejectsNonNumericBoardId(): void {
+		// ConfigController::setValue() only permission-checks keys matching
+		// board:(\d+): — a non-numeric id would bypass it, so the shared
+		// setAppValue path must refuse it.
+		$this->config->expects($this->never())->method('setAppValue');
+		$this->config->expects($this->never())->method('setUserValue');
+
+		$this->expectException(BadRequestException::class);
+		$this->service->set('board:abc:swimlaneMode', 'labels');
+	}
+
+	public function testSetSwimlaneModeRejectsUnknownMode(): void {
+		$this->config->expects($this->never())->method('setAppValue');
+		$this->config->expects($this->never())->method('setUserValue');
+
+		$this->expectException(BadRequestException::class);
+		$this->service->set('board:5:swimlaneMode', 'banana');
+	}
+
+	public function testSetSwimlaneOrderRejectsNonJsonValue(): void {
+		$this->config->expects($this->never())->method('setAppValue');
+		$this->config->expects($this->never())->method('setUserValue');
+
+		$this->expectException(BadRequestException::class);
+		$this->service->set('board:5:swimlaneLabelOrder', 'not json');
+	}
+
+	public function testSetSwimlaneOrderRejectsJsonObject(): void {
+		$this->config->expects($this->never())->method('setAppValue');
+		$this->config->expects($this->never())->method('setUserValue');
+
+		$this->expectException(BadRequestException::class);
+		$this->service->set('board:5:swimlaneLabelOrder', '{"a":1}');
+	}
+
+	public function testSetSwimlaneOrderRejectsInvalidEntries(): void {
+		$this->config->expects($this->never())->method('setAppValue');
+		$this->config->expects($this->never())->method('setUserValue');
+
+		$this->expectException(BadRequestException::class);
+		$this->service->set('board:5:swimlaneUserOrder', '[true]');
+	}
+
+	public function testSetSwimlaneOrderAcceptsCatchAllLaneId(): void {
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->with(Application::APP_ID, 'board:5:swimlaneLabelOrder', '[3,1,"__none__"]');
+		$this->config->expects($this->never())->method('setUserValue');
+
+		$result = $this->service->set('board:5:swimlaneLabelOrder', '[3,1,"__none__"]');
+		$this->assertSame('[3,1,"__none__"]', $result);
+	}
+
+	public function testNonSwimlaneBoardSettingStaysPerUser(): void {
+		// board:5:calendar is a per-user setting (setUserValue path)
+		$this->config->expects($this->never())->method('setAppValue');
+		$this->config->expects($this->once())
+			->method('setUserValue')
+			->with('admin', Application::APP_ID, 'board:5:calendar', 'yes');
+
+		$this->service->set('board:5:calendar', 'yes');
+	}
+
+	public function testSetBoardConfigWithoutSettingPartIsIgnored(): void {
+		// upstream behavior: 'board:5' (fewer than 3 segments) is silently ignored
+		$this->config->expects($this->never())->method('setAppValue');
+		$this->config->expects($this->never())->method('setUserValue');
+
+		$this->assertNull($this->service->set('board:5', 'x'));
+	}
+}


### PR DESCRIPTION
* Target version: NC34 +
* Resolves: #32
  * perhaps also relates to: #1878 


#### Disclaimer
This PR was written mainly with LLM assistance (Claude Opus 4.7 max effort) for technical implementation.

### Summary

Adds horizontal **swimlane grouping** to the board view.

Users can now group cards by **labels** or **assignees** via the existing "View Modes" menu. Each group renders as a collapsible horizontal row with its own set of stacks, showing only the cards that belong to that group.

**Key behaviors:**
- Cards with multiple labels (or multiple assignees) appear in **all matching lanes** - a subtle badge indicates the card is in multiple lanes
- A "No label" / "Unassigned" catchall lane appears at the bottom for ungrouped cards
- Empty lanes (labels/assignees with no cards) are automatically hidden
- Lanes can be **collapsed/expanded** (persisted per-user in localStorage)
- Lanes can be **reordered via drag-and-drop** (editors only, persisted via OCS config API as shared board setting)
- Card drag-and-drop works **within each lane** across stacks, but cross-lane dragging is blocked (prevents accidental label/assignee changes)
- Swimlane mode and lane order are **shared board settings** - all users see the same layout, only editors can change them (persisted via `setAppValue`, gated by `PERMISSION_EDIT`)
- Full **keyboard and screen reader accessibility** - `aria-expanded`, `aria-label`, focus-visible styles

**No database changes** - swimlanes are a computed view layer derived from existing card labels and assignee data.

### Architecture

The implementation adds **no new API endpoints or database tables**. It extends the existing frontend state management and adds two new Vue components:

| Layer | Changes |
|-------|---------|
| **Vue components** | New `Swimlane.vue` and `SwimlaneHeader.vue`; modified `Board.vue`, `Stack.vue`, `Controls.vue`, `CardBadges.vue` |
| **Vuex store** | New `cardsByStackAndLane` getter in `card.js`; swimlane order state + actions in `main.js` |
| **Backend** | Extended `BoardService::enrichWithBoardSettings()` to include swimlane config (3 new `getAppValue` calls); `ConfigService::set()` gates swimlane keys with `PERMISSION_EDIT` |
| **Persistence** | Swimlane mode and lane order stored as shared board settings via `setAppValue` (visible to all users, editable by board editors only). Collapse state remains per-user in localStorage |

The existing `vue-smooth-dnd` Container/Draggable pattern is reused for both within-lane card drag and lane reordering. Lane isolation uses `group-name` scoping (`'stack-' + lane.key`) to prevent cross-lane card drops.

### How it works

1. **Controls.vue** adds "Group by" radio options to the View Modes menu
2. When a mode is selected, it is stored via the OCS config API as a shared board setting and an event-bus message triggers Board.vue to re-render
3. **Board.vue** switches from the flat stack view to a vertical list of `Swimlane` components
4. Each `Swimlane` renders a `SwimlaneHeader` (with label color/avatar, card count, collapse toggle) and the same horizontal stack layout
5. **Stack.vue** accepts an optional `lane` prop - when present, it uses `cardsByStackAndLane` to filter cards for that lane
6. **CardBadges.vue** shows a duplicate badge when a card appears in 2+ lanes

### Changes

**New files (4):**
- `src/components/board/Swimlane.vue` - Swimlane row wrapper (header + stacks)
- `src/components/board/SwimlaneHeader.vue` - Lane header with label/avatar, count, collapse, drag handle
- `tests/unit/Service/ConfigServiceTest.php` - PHPUnit tests for swimlane config storage and permission gating
- `cypress/e2e/swimlanesFeatures.js` - Cypress E2E tests for swimlane grouping interactions

**Modified files (8):**
- `src/components/board/Board.vue` - Conditional flat vs swimlane rendering, lane computation, lane reorder DnD (editor-gated)
- `src/components/board/Stack.vue` - Accept `lane` prop, lane-scoped card filtering and DnD group names
- `src/components/Controls.vue` - "Group by" radio selector in View Modes menu (disabled for non-editors)
- `src/components/cards/CardBadges.vue` - Duplicate lane badge
- `src/store/card.js` - `cardsByStackAndLane` getter
- `src/store/main.js` - Swimlane mode/order state, mutations, actions, config loading
- `lib/Service/BoardService.php` - Swimlane settings in board enrichment (shared via `getAppValue`)
- `lib/Service/ConfigService.php` - Swimlane config keys gated by `PERMISSION_EDIT`, stored via `setAppValue`

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
- [x] Verify with NC dark mode / high-contrast themes
- [x] Test with right-to-left (RTL) languages