### PR TITLE
fix(comments): register event listener for typed comment events

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -60,7 +60,10 @@ use OCP\Collaboration\Reference\RenderReferenceEvent;
 use OCP\Collaboration\Resources\IProviderManager;
 use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent;
 use OCP\Comments\CommentsEntityEvent;
-use OCP\Comments\CommentsEvent;
+use OCP\Comments\Events\BeforeCommentUpdatedEvent;
+use OCP\Comments\Events\CommentAddedEvent;
+use OCP\Comments\Events\CommentDeletedEvent;
+use OCP\Comments\Events\CommentUpdatedEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudFederationProvider;
 use OCP\Federation\ICloudFederationProviderManager;
@@ -155,7 +158,10 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(AclCreatedEvent::class, FullTextSearchEventListener::class);
 		$context->registerEventListener(AclUpdatedEvent::class, FullTextSearchEventListener::class);
 		$context->registerEventListener(AclDeletedEvent::class, FullTextSearchEventListener::class);
-		$context->registerEventListener(CommentsEvent::class, CommentEventListener::class);
+		$context->registerEventListener(CommentAddedEvent::class, CommentEventListener::class);
+		$context->registerEventListener(BeforeCommentUpdatedEvent::class, CommentEventListener::class);
+		$context->registerEventListener(CommentUpdatedEvent::class, CommentEventListener::class);
+		$context->registerEventListener(CommentDeletedEvent::class, CommentEventListener::class);
 
 		// Handling cache invalidation for collections
 		$context->registerEventListener(AclCreatedEvent::class, ResourceListener::class);

--- a/tests/integration/features/decks.feature
+++ b/tests/integration/features/decks.feature
@@ -127,7 +127,7 @@ Feature: decks
 		And remember the last attachment as "my-attachment"
 		And post a comment with content "My first comment" on the card
 		When get the activities for the last card
-		Then the fetched activities should have 2 entries
+		Then the fetched activities should have 3 entries
 		And delete the card
 
 		When get the activities for the last card

--- a/tests/unit/Listeners/CommentEventListenerTest.php
+++ b/tests/unit/Listeners/CommentEventListenerTest.php
@@ -29,7 +29,8 @@ use OCA\Deck\Db\Card;
 use OCA\Deck\Db\CardMapper;
 use OCA\Deck\Db\ChangeHelper;
 use OCA\Deck\Notification\NotificationHelper;
-use OCP\Comments\CommentsEvent;
+use OCP\Comments\Events\CommentAddedEvent;
+use OCP\Comments\Events\CommentUpdatedEvent;
 use OCP\Comments\IComment;
 use PHPUnit\Framework\TestCase;
 
@@ -68,7 +69,7 @@ class CommentEventListenerTest extends TestCase {
 		$this->cardMapper->expects($this->once())
 			->method('find')
 			->willReturn($card);
-		$commentsEvent = new CommentsEvent(CommentsEvent::EVENT_ADD, $comment);
+		$commentsEvent = new CommentAddedEvent($comment);
 		$this->activityManager->expects($this->once())
 			->method('triggerEvent')
 			->with(ActivityManager::DECK_OBJECT_CARD, $card, ActivityManager::SUBJECT_CARD_COMMENT_CREATE, ['comment' => $comment]);
@@ -82,7 +83,7 @@ class CommentEventListenerTest extends TestCase {
 		$comment = $this->createMock(IComment::class);
 		$comment->expects($this->any())->method('getId')->willReturn(1);
 		$comment->expects($this->any())->method('getObjectType')->willReturn('deckCard');
-		$commentsEvent = new CommentsEvent(CommentsEvent::EVENT_UPDATE, $comment);
+		$commentsEvent = new CommentUpdatedEvent($comment);
 		$this->activityManager->expects($this->never())
 			->method('triggerEvent');
 		$this->notificationHelper->expects($this->once())
@@ -95,7 +96,7 @@ class CommentEventListenerTest extends TestCase {
 		$comment = $this->createMock(IComment::class);
 		$comment->expects($this->any())->method('getId')->willReturn(1);
 		$comment->expects($this->any())->method('getObjectType')->willReturn('other');
-		$commentsEvent = new CommentsEvent(CommentsEvent::EVENT_ADD, $comment);
+		$commentsEvent = new CommentAddedEvent($comment);
 		$this->activityManager->expects($this->never())
 			->method('triggerEvent');
 		$this->commentEventHandler->handle($commentsEvent);


### PR DESCRIPTION
### Summary

Since the typed comment events (CommentAddedEvent, CommentUpdatedEvent, etc.) were introduced in NC34, dispatchTyped() dispatches using the exact subclass name. Registering only for CommentsEvent::class means the listener never fires, so comment mentions in Deck cards never create notifications or activity entries.

Update tests to use typed events directly, matching how Manager now dispatches them.

Changes were introduced in https://github.com/nextcloud/server/pull/56076

AI-Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>

* Target version: main


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
