### PR TITLE
feat(events): make card, ACL and board events webhook-compatible

### DIFF
--- a/lib/Event/AAclEvent.php
+++ b/lib/Event/AAclEvent.php
@@ -12,8 +12,9 @@ namespace OCA\Deck\Event;
 
 use OCA\Deck\Db\Acl;
 use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IWebhookCompatibleEvent;
 
-abstract class AAclEvent extends Event {
+abstract class AAclEvent extends Event implements IWebhookCompatibleEvent {
 	private $acl;
 
 	public function __construct(Acl $acl) {
@@ -28,5 +29,11 @@ abstract class AAclEvent extends Event {
 
 	public function getBoardId(): int {
 		return $this->acl->getBoardId();
+	}
+
+	public function getWebhookSerializable(): array {
+		return [
+			'acl' => $this->acl->jsonSerialize(),
+		];
 	}
 }

--- a/lib/Event/ACardEvent.php
+++ b/lib/Event/ACardEvent.php
@@ -12,8 +12,9 @@ namespace OCA\Deck\Event;
 
 use OCA\Deck\Db\Card;
 use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IWebhookCompatibleEvent;
 
-abstract class ACardEvent extends Event {
+abstract class ACardEvent extends Event implements IWebhookCompatibleEvent {
 	private $card;
 
 	public function __construct(Card $card) {
@@ -24,5 +25,11 @@ abstract class ACardEvent extends Event {
 
 	public function getCard(): Card {
 		return $this->card;
+	}
+
+	public function getWebhookSerializable(): array {
+		return [
+			'card' => $this->card->jsonSerialize(),
+		];
 	}
 }

--- a/lib/Event/BoardUpdatedEvent.php
+++ b/lib/Event/BoardUpdatedEvent.php
@@ -11,8 +11,9 @@ declare(strict_types=1);
 namespace OCA\Deck\Event;
 
 use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IWebhookCompatibleEvent;
 
-class BoardUpdatedEvent extends Event {
+class BoardUpdatedEvent extends Event implements IWebhookCompatibleEvent {
 	private $boardId;
 
 	public function __construct(int $boardId) {
@@ -23,5 +24,11 @@ class BoardUpdatedEvent extends Event {
 
 	public function getBoardId(): int {
 		return $this->boardId;
+	}
+
+	public function getWebhookSerializable(): array {
+		return [
+			'boardId' => $this->boardId,
+		];
 	}
 }

--- a/tests/unit/Event/WebhookCompatibleEventsTest.php
+++ b/tests/unit/Event/WebhookCompatibleEventsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Deck\Event;
+
+use OCA\Deck\Db\Acl;
+use OCA\Deck\Db\Card;
+use OCP\EventDispatcher\IWebhookCompatibleEvent;
+use Test\TestCase;
+
+class WebhookCompatibleEventsTest extends TestCase {
+	public function testCardEventIsWebhookCompatible(): void {
+		$card = new Card();
+		$card->setId(42);
+		$card->setTitle('Test card');
+		$card->setStackId(1);
+
+		$event = new CardCreatedEvent($card);
+
+		$this->assertInstanceOf(IWebhookCompatibleEvent::class, $event);
+		$payload = $event->getWebhookSerializable();
+		$this->assertArrayHasKey('card', $payload);
+		$this->assertSame(42, $payload['card']['id']);
+		$this->assertSame('Test card', $payload['card']['title']);
+	}
+
+	public function testAclEventIsWebhookCompatible(): void {
+		$acl = new Acl();
+		$acl->setId(7);
+		$acl->setBoardId(3);
+		$acl->setType(Acl::PERMISSION_TYPE_USER);
+		$acl->setParticipant('alice');
+		$acl->setPermissionEdit(true);
+
+		$event = new AclCreatedEvent($acl);
+
+		$this->assertInstanceOf(IWebhookCompatibleEvent::class, $event);
+		$payload = $event->getWebhookSerializable();
+		$this->assertArrayHasKey('acl', $payload);
+		$this->assertSame(7, $payload['acl']['id']);
+		$this->assertSame(3, $payload['acl']['boardId']);
+		$this->assertArrayNotHasKey('token', $payload['acl'], 'token must be stripped from serialized ACL');
+	}
+
+	public function testBoardUpdatedEventIsWebhookCompatible(): void {
+		$event = new BoardUpdatedEvent(99);
+
+		$this->assertInstanceOf(IWebhookCompatibleEvent::class, $event);
+		$this->assertSame(['boardId' => 99], $event->getWebhookSerializable());
+	}
+}


### PR DESCRIPTION
## Summary

Implements `OCP\EventDispatcher\IWebhookCompatibleEvent` on Deck's event base classes so the [`webhook_listeners`](https://github.com/nextcloud/server/tree/master/apps/webhook_listeners) app (added in NC 30) can serialize and deliver them. Today Deck dispatches plain `OCP\EventDispatcher\Event` instances, so the listener has nothing to serialize and Deck cannot drive any webhook automation.

This is the path the maintainer suggested in #3341 (use `flow_webhooks` rather than building a webhook system inside Deck). With this change in place, an admin can register listeners for `OCA\Deck\Event\CardCreatedEvent`, `CardUpdatedEvent`, `CardDeletedEvent`, `BoardUpdatedEvent`, and the ACL events directly through the existing webhook UI.

## Changes

| File | Change |
|---|---|
| `lib/Event/ACardEvent.php` | `implements IWebhookCompatibleEvent` — `getWebhookSerializable()` returns `['card' => $card->jsonSerialize()]` (covers `CardCreatedEvent`, `CardUpdatedEvent`, `CardDeletedEvent`) |
| `lib/Event/AAclEvent.php` | `implements IWebhookCompatibleEvent` — `getWebhookSerializable()` returns `['acl' => $acl->jsonSerialize()]`. The existing `Acl::jsonSerialize()` already strips `token`, so it is not exposed via webhooks |
| `lib/Event/BoardUpdatedEvent.php` | `implements IWebhookCompatibleEvent` — returns `['boardId' => $boardId]` (the event only carries the id today; receivers can fetch detail via API if needed) |
| `tests/unit/Event/WebhookCompatibleEventsTest.php` | New unit tests asserting interface conformance and payload shape for `CardCreatedEvent`, `AclCreatedEvent`, and `BoardUpdatedEvent` |

The shape (`{"<entity>": …}`) follows the convention used by core OCP events such as `OCP\Files\Events\Node\AbstractNodeEvent` and `OCP\SystemTag\TagAssignedEvent`.

## Compatibility

`appinfo/info.xml` requires `nextcloud min-version="34"`. `IWebhookCompatibleEvent` was introduced in NC 30, so no version gate is needed.

## Refs

- Closes (or contributes to) #1722 — Flow integration
- Closes (or contributes to) #7299 — Feature request: Automated Deck card actions and webhook-compatible event
- Follows the maintainer guidance in #3341

## Test plan

- [ ] CI passes (`composer test:unit`)
- [ ] Register a webhook against a homelab NC for `OCA\Deck\Event\CardCreatedEvent` and confirm the receiver gets `{"event": {"card": {…}}, …}`
- [ ] Repeat for `CardUpdatedEvent`, `CardDeletedEvent`, `BoardUpdatedEvent`, `AclCreatedEvent`
- [ ] Confirm `token` field is absent from the ACL payload

---

_This PR was generated with the help of AI, and reviewed by a Human_