### PR TITLE
fix(assignments): show real display name to share recipients

### DIFF
--- a/lib/Db/User.php
+++ b/lib/Db/User.php
@@ -12,18 +12,17 @@ use OCP\IUserManager;
 
 class User extends RelationalObject {
 	private IUserManager $userManager;
-	public function __construct($uid, IUserManager $userManager) {
+
+	public function __construct(string $uid, IUserManager $userManager) {
 		$this->userManager = $userManager;
-		parent::__construct($uid, function ($object) {
-			return $this->userManager->get($object->getPrimaryKey());
-		});
+		parent::__construct($uid, fn () => $this->userManager->get($uid));
 	}
 
 	public function getObjectSerialization(): array {
 		return [
-			'uid' => $this->getObject()->getUID(),
+			'uid' => $this->getUID(),
 			'displayname' => $this->getDisplayName(),
-			'type' => Acl::PERMISSION_TYPE_USER
+			'type' => Acl::PERMISSION_TYPE_USER,
 		];
 	}
 
@@ -32,10 +31,11 @@ class User extends RelationalObject {
 	}
 
 	public function getDisplayName(): ?string {
-		return $this->userManager->getDisplayName($this->getPrimaryKey());
+		$user = $this->getObject();
+		return $user ? $user->getDisplayName() : $this->getPrimaryKey();
 	}
 
-	public function getUserObject(): IUser {
+	public function getUserObject(): ?IUser {
 		return $this->getObject();
 	}
 }

--- a/lib/Sharing/DeckShareProvider.php
+++ b/lib/Sharing/DeckShareProvider.php
@@ -1210,7 +1210,10 @@ class DeckShareProvider implements \OCP\Share\IShareProvider, IPartialShareProvi
 			}
 
 			foreach ($this->permissionService->findUsers($boardId) as $user) {
-				yield $user->getUserObject();
+				$userObject = $user->getUserObject();
+				if ($userObject !== null) {
+					yield $userObject;
+				}
 			}
 		}
 

--- a/tests/unit/Db/UserTest.php
+++ b/tests/unit/Db/UserTest.php
@@ -34,13 +34,13 @@ class UserTest extends \Test\TestCase {
 		$user->expects($this->any())
 			->method('getUID')
 			->willReturn('myuser');
+		$user->expects($this->any())
+			->method('getDisplayName')
+			->willReturn('myuser displayname');
 		$userManager = $this->createMock(IUserManager::class);
 		$userManager->expects($this->any())
 			->method('get')
 			->willReturn($user);
-		$userManager->expects($this->any())
-			->method('getDisplayName')
-			->willReturn('myuser displayname');
 		$userRelationalObject = new User('myuser', $userManager);
 		$expected = [
 			'uid' => 'myuser',
@@ -56,13 +56,13 @@ class UserTest extends \Test\TestCase {
 		$user->expects($this->any())
 			->method('getUID')
 			->willReturn('myuser');
+		$user->expects($this->any())
+			->method('getDisplayName')
+			->willReturn('myuser displayname');
 		$userManager = $this->createMock(IUserManager::class);
 		$userManager->expects($this->any())
 			->method('get')
 			->willReturn($user);
-		$userManager->expects($this->any())
-			->method('getDisplayName')
-			->willReturn('myuser displayname');
 		$userRelationalObject = new User('myuser', $userManager);
 		$expected = [
 			'uid' => 'myuser',
@@ -71,5 +71,30 @@ class UserTest extends \Test\TestCase {
 			'type' => 0,
 		];
 		$this->assertEquals($expected, $userRelationalObject->jsonSerialize());
+	}
+
+	public function testIgnoresAccountPropertyScope() {
+		// Regression: IUserManager::getDisplayName() returns the UID when the
+		// requesting user is not allowed to see the target user's display name
+		// (account-property visibility scope). Serialization must use the IUser
+		// directly so collaborators on the same board always see real names.
+		/** @var IUser $user */
+		$user = $this->createMock(IUser::class);
+		$user->expects($this->any())
+			->method('getUID')
+			->willReturn('WBE32');
+		$user->expects($this->any())
+			->method('getDisplayName')
+			->willReturn('Pedro Jota');
+		$userManager = $this->createMock(IUserManager::class);
+		$userManager->expects($this->any())
+			->method('get')
+			->willReturn($user);
+		$userManager->expects($this->any())
+			->method('getDisplayName')
+			->willReturn('WBE32');
+		$userRelationalObject = new User('WBE32', $userManager);
+		$serialized = $userRelationalObject->getObjectSerialization();
+		$this->assertSame('Pedro Jota', $serialized['displayname']);
 	}
 }


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

Share recipients saw avatars rendered as a single letter from each user's UID (e.g. all "WTR…" UIDs collapsed to "W") instead of the proper display-name initials that the card owner saw.

`User::getDisplayName()` resolved names through `IUserManager::getDisplayName($uid)`. Switched it to reading from the `IUser` object directly (with a UID fallback for deleted accounts), so collaborators on the same board always get real names.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
