### PR TITLE
feat: allow read-only users to assign labels to cards (#590)

### DIFF
--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -617,7 +617,7 @@ class CardService {
 	public function assignLabel(int $cardId, int $labelId): Card {
 		$this->cardServiceValidator->check(compact('cardId', 'labelId'));
 
-		$this->permissionService->checkPermission($this->cardMapper, $cardId, Acl::PERMISSION_EDIT);
+		$this->permissionService->checkPermission($this->cardMapper, $cardId, Acl::PERMISSION_READ);
 		$this->permissionService->checkPermission($this->labelMapper, $labelId, Acl::PERMISSION_READ);
 
 		if ($this->boardService->isArchived($this->cardMapper, $cardId)) {

--- a/tests/unit/Service/CardServiceTest.php
+++ b/tests/unit/Service/CardServiceTest.php
@@ -25,8 +25,10 @@
 namespace OCA\Deck\Service;
 
 use OCA\Deck\Activity\ActivityManager;
+use OCA\Deck\Db\Acl;
 use OCA\Deck\Db\Assignment;
 use OCA\Deck\Db\AssignmentMapper;
+use OCA\Deck\NoPermissionException;
 use OCA\Deck\Db\Board;
 use OCA\Deck\Db\BoardMapper;
 use OCA\Deck\Db\Card;
@@ -546,6 +548,69 @@ class CardServiceTest extends TestCase {
 		$this->cardMapper->expects($this->once())->method('find')->willReturn($card);
 		$this->cardMapper->expects($this->never())->method('removeLabel');
 		$this->expectException(StatusException::class);
+		$this->cardService->removeLabel(123, 999);
+	}
+
+	public function testAssignLabelWithReadPermission() {
+		// Users with READ permission (but not EDIT) should be able to assign labels
+		// This allows read-only users to label cards they are assigned to
+		$card = new Card();
+		$card->setArchived(false);
+		$card->setId(123);
+		$label = new Label();
+		$label->setBoardId(1);
+
+		$this->permissionService->expects($this->exactly(2))
+			->method('checkPermission')
+			->willReturn(true);
+		$this->cardMapper->expects($this->once())->method('find')->willReturn($card);
+		$this->cardMapper->expects($this->once())->method('assignLabel');
+		$this->cardMapper->expects($this->once())
+			->method('findBoardId')
+			->willReturn(1);
+		$this->labelMapper->expects($this->once())
+			->method('find')
+			->willReturn($label);
+		$this->cardService->assignLabel(123, 999);
+	}
+
+	public function testAssignLabelWithoutReadPermission() {
+		// Users without READ permission should get NoPermissionException
+		$this->permissionService->expects($this->once())
+			->method('checkPermission')
+			->willThrowException(new NoPermissionException('Permission denied'));
+		$this->cardMapper->expects($this->never())->method('assignLabel');
+		$this->expectException(NoPermissionException::class);
+		$this->cardService->assignLabel(123, 999);
+	}
+
+	public function testRemoveLabelRequiresEditPermission() {
+		// Removing a label requires EDIT permission (higher than READ)
+		// This is intentional: read-only users can add labels but not remove them
+		$card = new Card();
+		$card->setArchived(false);
+		$card->setId(123);
+		$label = new Label();
+		$label->setBoardId(1);
+
+		$this->permissionService->expects($this->exactly(2))
+			->method('checkPermission')
+			->willReturn(true);
+		$this->cardMapper->expects($this->once())->method('find')->willReturn($card);
+		$this->cardMapper->expects($this->once())->method('removeLabel');
+		$this->labelMapper->expects($this->once())
+			->method('find')
+			->willReturn($label);
+		$this->cardService->removeLabel(123, 999);
+	}
+
+	public function testRemoveLabelWithoutEditPermission() {
+		// Without EDIT permission, removing a label should fail
+		$this->permissionService->expects($this->once())
+			->method('checkPermission')
+			->willThrowException(new NoPermissionException('Permission denied'));
+		$this->cardMapper->expects($this->never())->method('removeLabel');
+		$this->expectException(NoPermissionException::class);
 		$this->cardService->removeLabel(123, 999);
 	}
 


### PR DESCRIPTION
## Summary

Fixes #590 — Allow users with read-only board access to assign labels to cards.

### Problem

Users with only `PERMISSION_READ` on a board could not assign labels to cards, even though the board owner intended them to self-manage card labels. The `assignLabel()` method required `PERMISSION_EDIT`, which is too restrictive for collaborative workflows.

### Solution

Lower the permission check in `CardService::assignLabel()` from `PERMISSION_EDIT` to `PERMISSION_READ`:

```diff
- $this->permissionService->checkPermission($this->cardMapper, $cardId, Acl::PERMISSION_EDIT);
+ $this->permissionService->checkPermission($this->cardMapper, $cardId, Acl::PERMISSION_READ);
```

`removeLabel()` still requires `PERMISSION_EDIT`, so read-only users can add labels but cannot remove them.

### Additional Changes

- Added 4 unit tests covering permission scenarios:
  - `testAssignLabelWithReadPermission` — READ-permission user CAN add labels
  - `testAssignLabelWithoutReadPermission` — no-permission user CANNOT add labels  
  - `testRemoveLabelRequiresEditPermission` — EDIT-permission user CAN remove labels
  - `testRemoveLabelWithoutEditPermission` — no-permission user CANNOT remove labels

### BC Note

This is a **backwards-compatible bug fix**. Read-only users who previously could not add labels now can, but they still cannot remove labels or modify card content.

---

Closes #590