### PR TITLE
fix: read stackId from request body in CardApiController reorder

### DIFF
--- a/lib/Controller/CardApiController.php
+++ b/lib/Controller/CardApiController.php
@@ -200,7 +200,13 @@ class CardApiController extends ApiController {
 	#[CORS]
 	#[NoCSRFRequired]
 	public function reorder(int $stackId, int $order): DataResponse {
-		$card = $this->cardService->reorder((int)$this->request->getParam('cardId'), $stackId, $order);
+		// Read target stackId from request body to allow moving cards between stacks.
+		// The URL's {stackId} is the source stack (used in the route), but the request
+		// body can specify a different target stack for the move operation.
+		$input = json_decode(file_get_contents('php://input'), true);
+		$targetStackId = isset($input['stackId']) ? (int)$input['stackId'] : $stackId;
+
+		$card = $this->cardService->reorder((int)$this->request->getParam('cardId'), $targetStackId, $order);
 		return new DataResponse($card, HTTP::STATUS_OK);
 	}
 }


### PR DESCRIPTION
## Fix: CardApiController reorder() ignores request body stackId

**Issue:** #7933

The `reorder()` method in `CardApiController.php` receives `$stackId` as a route parameter, but the actual target stack is passed in the request body. When the API is called with `{"stackId": 37, "order": 0}`, the card stays in its original stack.

**Root Cause:**
```php
public function reorder($stackId, $order) {
    $card = $this->cardService->reorder(
        (int)$this->request->getParam('cardId'),
        (int)$stackId,  // <-- Uses route param, not body param
        ...
    );
}
```

**Fix:** Read `stackId` from the request body via `php://input` when the card needs to move to a different stack.

**Testing:**
1. Create a card in stack 36
2. Call `PUT /stacks/36/cards/{id}/reorder` with `{"stackId": 37, "order": 0}`
3. Card should now be in stack 37 (not stack 36)

Closes #7933