### PR TITLE
fix: avoid breaking card details modal when viewing attachment

### DIFF
--- a/src/components/card/AttachmentList.vue
+++ b/src/components/card/AttachmentList.vue
@@ -197,6 +197,9 @@ export default {
 			return (attachment) => attachment?.extendedData?.info?.extension
 				?? (attachment?.name ?? attachment.data).split('.').pop()
 		},
+		cardDetailsInModal() {
+			return this.$store.getters.config('cardDetailsInModal')
+		},
 	},
 	watch: {
 		cardId: {
@@ -245,7 +248,17 @@ export default {
 		},
 		showViewer(attachment) {
 			if (attachment.extendedData.fileid && window.OCA.Viewer.availableHandlers.map(handler => handler.mimes).flat().includes(attachment.extendedData.mimetype)) {
-				window.OCA.Viewer.open({ path: attachment.extendedData.path })
+				// Hide the sidebar if opening card in modal to avoid wrong sidebar position calculating in Viewer app
+				const sidebar = document.querySelector('aside.app-sidebar')
+				if (sidebar && this.cardDetailsInModal) {
+					sidebar.style.display = 'none'
+				}
+				const onClose = () => {
+					if (sidebar && sidebar.style.display === 'none') {
+						sidebar.style.display = ''
+					}
+				}
+				window.OCA.Viewer.open({ path: attachment.extendedData.path, onClose })
 				return
 			}
 


### PR DESCRIPTION
* Resolves: #7916
* Target version: main

### Summary
Hide the sidebar when viewing attachment if opening card in modal to avoid wrong sidebar position calculating in Viewer app


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
