### PR TITLE
fix(board): truncate stack title for read-only and archived boards

### DIFF
--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -10,8 +10,11 @@
 			:class="{'stack__header--add': showAddCard, 'stack__header--done-column': isDoneColumn}"
 			:aria-label="stack.title">
 			<transition name="fade" mode="out-in">
-				<h3 v-if="!canManage || isArchived" tabindex="0">
-					{{ stack.title }}
+				<h3 v-if="!canManage || isArchived"
+					tabindex="0"
+					:title="stack.title"
+					class="stack__title">
+					<span dir="auto">{{ stack.title }}</span>
 					<CheckCircleOutline v-if="isDoneColumn"
 						class="stack__done-icon"
 						decorative />


### PR DESCRIPTION
## Summary

- Fixes #7980
- The read-only `<h3>` branch in `Stack.vue` was missing `class="stack__title"` and the `<span dir="auto">` wrapper, causing long list titles to wrap into cards instead of being clipped with `…`
- Added the same class and span structure as the editable branch — no logic change, CSS-only fix

## Test plan

- [ ] Share a board with a user who has no manage rights
- [ ] Log in as that user and open the board with a long list title
- [ ] Verify the title is now truncated with `…` instead of wrapping
- [ ] Verify archived boards show the same truncation
- [ ] Verify users with manage rights still see the title correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)