### PR TITLE
fix: make upcoming view reachable again

### DIFF
--- a/src/components/navigation/AppNavigation.vue
+++ b/src/components/navigation/AppNavigation.vue
@@ -8,7 +8,7 @@
 		<template #list>
 			<NcAppNavigationItem :name="t('deck', 'Upcoming cards')"
 				:exact="true"
-				to="/">
+				to="/upcoming">
 				<template #icon>
 					<CalendarIcon v-if="$route.path === '/'" :size="20" />
 					<CalendarOutlineIcon v-else :size="20" />

--- a/src/router.js
+++ b/src/router.js
@@ -33,6 +33,11 @@ const router = new Router({
 			component: Overview,
 		},
 		{
+			path: '/upcoming',
+			name: 'upcoming',
+			component: Overview,
+		},
+		{
 			path: '/overview/:filter',
 			name: 'overview',
 			components: {


### PR DESCRIPTION
#7675 made it impossible to navigate to the upcoming view if a default board was set, now it's possible again