### PR TITLE
feat(board): show card count next to the list title

### DIFF
--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -15,6 +15,7 @@
 					<CheckCircleOutline v-if="isDoneColumn"
 						class="stack__done-icon"
 						decorative />
+					<span class="stack__card-count">{{ cardsByStack.length }}</span>
 				</h3>
 				<h3 v-else-if="!editing"
 					tabindex="0"
@@ -27,6 +28,7 @@
 					<CheckCircleOutline v-if="isDoneColumn"
 						class="stack__done-icon"
 						decorative />
+					<span class="stack__card-count">{{ cardsByStack.length }}</span>
 				</h3>
 				<form v-else-if="editing"
 					v-click-outside="cancelEdit"
@@ -473,6 +475,18 @@ export default {
 				width: 1em;
 				height: 1em;
 			}
+		}
+
+		.stack__card-count {
+			flex-shrink: 0;
+			margin-inline-start: 6px;
+			padding: 0 8px;
+			border-radius: var(--border-radius-pill, 16px);
+			background-color: var(--color-background-darker);
+			color: var(--color-text-maxcontrast);
+			font-size: var(--default-font-size);
+			font-weight: normal;
+			line-height: 1.5;
 		}
 
 		form {


### PR DESCRIPTION
Display the number of cards in each list as a small badge after the list title in the stack header. The count reuses the existing cardsByStack computed, so it follows the archived/active filter and stays reactive as cards are added, moved or removed. The badge does not shrink, keeping it visible when a long title is truncated.


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
