### PR TITLE
chore: enable jsdoc linting rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,14 +1,14 @@
 module.exports = {
 	root: true,
 	extends: [
-		'@nextcloud',
+		' @nextcloud',
 	],
 	rules: {
-		'jsdoc/require-param-description': ['off'],
-		'jsdoc/require-param-type': ['off'],
-		'jsdoc/check-param-names': ['off'],
-		'jsdoc/no-undefined-types': ['off'],
-		'jsdoc/require-property-description': ['off'],
+		'jsdoc/require-param-description': ['warn'],
+		'jsdoc/require-param-type': ['warn'],
+		'jsdoc/check-param-names': ['warn'],
+		'jsdoc/no-undefined-types': ['warn'],
+		'jsdoc/require-property-description': ['warn'],
 		'import/no-named-as-default-member': ['off'],
 	},
 }


### PR DESCRIPTION
Enabling JSDoc linting rules in .eslintrc.js to enforce better documentation standards across the project. Previously, these rules were explicitly disabled, which allowed undocumented or poorly documented functions to accumulate, hindering maintainability. This change updates the linting configuration to warn when JSDoc parameters or types are missing, encouraging developers to provide comprehensive documentation and leading to more robust and readable code.