### PR TITLE
Fix: overview page is too slow to load

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1128,6 +1128,7 @@ Deck stores user and app configuration values globally and per board. The GET en
 | --- | --- |
 | calendar | Determines if the calendar/tasks integration through the CalDAV backend is enabled for the user (boolean) |
 | cardDetailsInModal | Determines if the bigger view is used (boolean) |
+| hideNoDueOnOverview | Determines if the No Due Date column should be displayed |
 | cardIdBadge | Determines if the ID badges are displayed on cards (boolean) |
 | groupLimit | Determines if creating new boards is limited to certain groups of the instance. The resulting output is an array of group objects with the id and the displayname (Admin only)|
 
@@ -1173,6 +1174,7 @@ Deck stores user and app configuration values globally and per board. The GET en
 | notify-due | `off`, `assigned` or `all` |
 | calendar | Boolean |
 | cardDetailsInModal | Boolean |
+| hideNoDueOnOverview | Boolean |
 | cardIdBadge | Boolean |
 
 #### Example request

--- a/lib/Controller/OverviewApiController.php
+++ b/lib/Controller/OverviewApiController.php
@@ -27,6 +27,7 @@ class OverviewApiController extends OCSController {
 
 	#[NoAdminRequired]
 	public function upcomingCards(): DataResponse {
-		return new DataResponse($this->dashboardService->findUpcomingCards($this->userId));
+		$hideNoDue = ($this->request->getParam('hideNoDueOnOverview') == "true");
+		return new DataResponse($this->dashboardService->findUpcomingCards($this->userId, $hideNoDue));
 	}
 }

--- a/lib/Dashboard/DeckWidgetUpcoming.php
+++ b/lib/Dashboard/DeckWidgetUpcoming.php
@@ -96,7 +96,7 @@ class DeckWidgetUpcoming implements IAPIWidget, IButtonWidget, IIconWidget {
 	 * @inheritDoc
 	 */
 	public function getItems(string $userId, ?string $since = null, int $limit = 7): array {
-		$upcomingCards = $this->dashboardService->findUpcomingCards($userId);
+		$upcomingCards = $this->dashboardService->findUpcomingCards($userId, false);
 		$nowTimestamp = (new Datetime())->getTimestamp();
 		$sinceTimestamp = $since !== null ? (new Datetime($since))->getTimestamp() : null;
 		$upcomingCards = array_filter($upcomingCards, static function (array $card) use ($nowTimestamp, $sinceTimestamp) {

--- a/lib/Db/CardMapper.php
+++ b/lib/Db/CardMapper.php
@@ -328,9 +328,10 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 
 	/**
 	 * @param int[] $boardIds
+	 * @param bool $filterNoDue
 	 * @return Card[]
 	 */
-	public function findToMeOrNotAssignedCards(array $boardIds, string $username): array {
+	public function findToMeOrNotAssignedCards(array $boardIds, string $username, bool $filterNoDue): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('c.*')
 			->from('deck_cards', 'c')
@@ -349,6 +350,9 @@ class CardMapper extends QBMapper implements IPermissionMapper {
 			->andWhere($qb->expr()->eq('s.deleted_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('b.archived', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)))
 			->andWhere($qb->expr()->eq('b.deleted_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+		if($filterNoDue) {
+			$qb = $qb->andWhere($qb->expr()->isNotNull('duedate'));
+		}
 		return $this->findEntities($qb);
 	}
 

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -52,7 +52,8 @@ class ConfigService {
 		$data = [
 			'calendar' => $this->isCalendarEnabled(),
 			'cardDetailsInModal' => $this->isCardDetailsInModal(),
-			'cardIdBadge' => $this->isCardIdBadgeEnabled()
+			'cardIdBadge' => $this->isCardIdBadgeEnabled(),
+			'hideNoDueOnOverview' => $this->isHideNoDueOnOverviewEnabled()
 		];
 		if ($this->groupManager->isAdmin($userId)) {
 			$data['groupLimit'] = $this->get('groupLimit');
@@ -85,6 +86,11 @@ class ConfigService {
 					return false;
 				}
 				return (bool)$this->config->getUserValue($this->getUserId(), Application::APP_ID, 'cardDetailsInModal', true);
+			case 'hideNoDueOnOverview':
+				if ($this->getUserId() === null) {
+					return false;
+				}
+				return (bool)$this->config->getUserValue($this->getUserId(), Application::APP_ID, 'hideNoDueOnOverview', true);
 			case 'cardIdBadge':
 				if ($this->getUserId() === null) {
 					return false;
@@ -121,6 +127,20 @@ class ConfigService {
 		}
 
 		return (bool)$this->config->getUserValue($userId, Application::APP_ID, 'board:' . $boardId . ':cardDetailsInModal', $defaultState);
+	}
+
+	public function isHideNoDueOnOverviewEnabled(?int $boardId = null): bool {
+		$userId = $this->getUserId();
+		if ($userId === null) {
+			return false;
+		}
+
+		$defaultState = (bool)$this->config->getUserValue($userId, Application::APP_ID, 'hideNoDueOnOverview', false);
+		if ($boardId === null) {
+			return $defaultState;
+		}
+
+		return (bool)$this->config->getUserValue($userId, Application::APP_ID, 'board:' . $boardId . ':hideNoDueOnOverview', $defaultState);
 	}
 
 	public function isCardIdBadgeEnabled(): bool {
@@ -175,6 +195,10 @@ class ConfigService {
 				break;
 			case 'cardDetailsInModal':
 				$this->config->setUserValue($userId, Application::APP_ID, 'cardDetailsInModal', (string)$value);
+				$result = $value;
+				break;
+			case 'hideNoDueOnOverview':
+				$this->config->setUserValue($userId, Application::APP_ID, 'hideNoDueOnOverview', (string)$value);
 				$result = $value;
 				break;
 			case 'cardIdBadge':

--- a/lib/Service/OverviewService.php
+++ b/lib/Service/OverviewService.php
@@ -23,7 +23,7 @@ class OverviewService {
 	) {
 	}
 
-	public function findUpcomingCards(string $userId): array {
+	public function findUpcomingCards(string $userId, bool $filterNoDue): array {
 		$userBoards = $this->boardMapper->findAllForUser($userId);
 
 		$boardOwnerIds = array_filter(array_map(function (Board $board) {
@@ -35,9 +35,9 @@ class OverviewService {
 
 		$foundCards = array_merge(
 			// private board: get all my assigned or unassigned cards
-			$this->cardMapper->findToMeOrNotAssignedCards($boardOwnerIds, $userId),
+			$this->cardMapper->findToMeOrNotAssignedCards($boardOwnerIds, $userId, $filterNoDue),
 			// shared board: get all my assigned or unassigned cards
-			$this->cardMapper->findToMeOrNotAssignedCards($boardSharedIds, $userId)
+			$this->cardMapper->findToMeOrNotAssignedCards($boardSharedIds, $userId, $filterNoDue)
 		);
 
 		$this->cardService->enrichCards($foundCards);

--- a/src/App.vue
+++ b/src/App.vue
@@ -98,6 +98,14 @@ export default {
 				this.$store.dispatch('setConfig', { cardDetailsInModal: newValue })
 			},
 		},
+		hideNoDueOnOverview: {
+			get() {
+				return this.$store.getters.config('hideNoDueOnOverview')
+			},
+			set(newValue) {
+				this.$store.dispatch('setConfig', { hideNoDueOnOverview: newValue })
+			},
+		},
 	},
 	created() {
 		const initialState = loadState('deck', 'initialBoards', null)

--- a/src/components/DeckAppSettings.vue
+++ b/src/components/DeckAppSettings.vue
@@ -12,6 +12,8 @@
 			<NcFormBox>
 				<NcFormBoxSwitch v-model="cardDetailsInModal"
 					:label="t('deck', 'Use bigger card view')" />
+				<NcFormBoxSwitch v-model="hideNoDueOnOverview"
+					:label="t('deck', 'Hide no-due column on upcoming cards')" />
 			</NcFormBox>
 		</NcAppSettingsSection>
 
@@ -117,6 +119,14 @@ export default {
 			},
 			set(newValue) {
 				this.$store.dispatch('setConfig', { cardDetailsInModal: newValue })
+			},
+		},
+		hideNoDueOnOverview: {
+			get() {
+				return this.$store.getters.config('hideNoDueOnOverview')
+			},
+			set(newValue) {
+				this.$store.dispatch('setConfig', { hideNoDueOnOverview: newValue })
 			},
 		},
 		cardIdBadge: {

--- a/src/components/overview/Overview.vue
+++ b/src/components/overview/Overview.vue
@@ -47,6 +47,7 @@ import CardItem from '../cards/CardItem.vue'
 import GlobalSearchResults from '../search/GlobalSearchResults.vue'
 import { useOverviewStore } from '../../stores/overview.js'
 import { mapActions, mapState } from 'pinia'
+import { mapGetters } from 'vuex'
 
 const FILTER_UPCOMING = 'upcoming'
 
@@ -124,7 +125,7 @@ export default {
 				this.$store.dispatch('setConfig', { hideNoDueOnOverview: newValue })
 			},
 		},
-		...mapGetters(['assignedCardsDashboard']),
+		...mapState(useOverviewStore, ['assignedCards']),
 	},
 	watch: {
 		'$route.params.filter'() {

--- a/src/components/overview/Overview.vue
+++ b/src/components/overview/Overview.vue
@@ -75,11 +75,6 @@ const COLUMN_PROPS_LIST = [
 		title: 'Later',
 		filter: 'later',
 	},
-	{
-		title: 'No due',
-		filter: 'nodue',
-		sort: false,
-	},
 ]
 
 export default {
@@ -96,9 +91,17 @@ export default {
 		},
 	},
 	data() {
+		const dynamicList = [...COLUMN_PROPS_LIST];
+		if(!this.$store.getters.config('hideNoDueOnOverview')) {
+			dynamicList.push({
+				title: 'No due',
+				filter: 'nodue',
+				sort: false,
+			});
+		}
 		return {
 			loading: true,
-			columnPropsList: COLUMN_PROPS_LIST,
+			columnPropsList: dynamicList,
 		}
 	},
 	computed: {
@@ -113,7 +116,15 @@ export default {
 				return ''
 			}
 		},
-		...mapState(useOverviewStore, ['assignedCards']),
+		hideNoDueOnOverview: {
+			get() {
+				return this.$store.getters.config('hideNoDueOnOverview')
+			},
+			set(newValue) {
+				this.$store.dispatch('setConfig', { hideNoDueOnOverview: newValue })
+			},
+		},
+		...mapGetters(['assignedCardsDashboard']),
 	},
 	watch: {
 		'$route.params.filter'() {
@@ -129,7 +140,7 @@ export default {
 			this.loading = true
 			try {
 				if (this.filter === FILTER_UPCOMING) {
-					await this.loadUpcoming()
+					await this.loadUpcoming(this.$store.getters.config('hideNoDueOnOverview'))
 				}
 			} catch (e) {
 				console.error(e)

--- a/src/services/OverviewApi.js
+++ b/src/services/OverviewApi.js
@@ -12,9 +12,12 @@ export class OverviewApi {
 		return generateOcsUrl(`apps/deck/api/v1.0/${url}`)
 	}
 
-	get(filter) {
+	get(filter, hideNoDueOnOverview) {
 		return axios.get(this.url(`overview/${filter}`), {
 			headers: { 'OCS-APIRequest': 'true' },
+			params: {
+				hideNoDueOnOverview: hideNoDueOnOverview,
+			}
 		})
 			.then(
 				(response) => Promise.resolve(response.data.ocs.data),

--- a/src/stores/dashboard.js
+++ b/src/stores/dashboard.js
@@ -13,8 +13,8 @@ export const useDashboardStore = defineStore('dashboard', {
 		assignedCards: [],
 	}),
 	actions: {
-		async loadUpcoming() {
-			const upcommingCards = await apiClient.get('upcoming')
+		async loadUpcoming(hideNoDueOnOverview) {
+			const upcommingCards = await apiClient.get('upcoming', hideNoDueOnOverview)
 			this.assignedCards = upcommingCards
 		},
 	},

--- a/src/stores/overview.js
+++ b/src/stores/overview.js
@@ -14,13 +14,13 @@ export const useOverviewStore = defineStore('overview', {
 		loading: false,
 	}),
 	actions: {
-		async loadUpcoming() {
+		async loadUpcoming(hideNoDueOnOverview) {
 			if (this.loading) {
 				return this.loading
 			}
 			const promise = (async () => {
 				this.$vuex.commit('setCurrentBoard', null)
-				const assignedCards = await overviewApi.get('upcoming')
+				const assignedCards = await overviewApi.get('upcoming', hideNoDueOnOverview)
 				const assignedCardsFlat = Object.values(assignedCards).flat()
 				for (const i in assignedCardsFlat) {
 					this.$vuex.commit('addCard', assignedCardsFlat[i])


### PR DESCRIPTION
* Resolves: 
* Target version: main

### Summary
On my current configuration, I have approximately 400 cards in the no-due section on the overview that actually live across multiple boards. This means that if I click the overview page I have to wait about 10 seconds for it to load before I can go somewhere else and this column is of no-use to me at all. I do use the due date on specific cards that are time sensitive so the page is useful for the other columns.

### TODO

- [x] Test this actually works

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
