### PR TITLE
fix: improve card open performance on boards with many cards

### DIFF
--- a/src/components/cards/CardItem.vue
+++ b/src/components/cards/CardItem.vue
@@ -6,7 +6,7 @@
 <template>
 	<AttachmentDragAndDrop v-if="card" :card-id="card.id" class="drop-upload--card">
 		<div :ref="`card${card.id}`"
-			:class="{'compact': compactMode, 'current-card': currentCard, 'no-labels': !hasLabels, 'card__editable': canEdit, 'card__archived': card.archived, 'card__highlight': highlight}"
+			:class="{'compact': compactMode, 'current-card': isCurrentCard, 'no-labels': !hasLabels, 'card__editable': canEdit, 'card__archived': card.archived, 'card__highlight': highlight}"
 			:style="{backgroundColor: color}"
 			tag="div"
 			:tabindex="0"
@@ -48,15 +48,13 @@
 			</div>
 
 			<div v-if="hasLabels" class="card-labels">
-				<transition-group v-if="card.labels && card.labels.length"
-					name="zoom"
-					tag="ul"
+				<ul v-if="card.labels && card.labels.length"
 					class="labels"
 					@click.stop="openCard">
 					<li v-for="label in labelsSorted" :key="label?.id ?? label?.title" :style="labelStyle(label)">
 						<span @click.stop="applyLabelFilter(label)">{{ label.title }}</span>
 					</li>
-				</transition-group>
+				</ul>
 				<CardMenu v-if="showMenuAtLabels"
 					:card="card"
 					class="right"
@@ -125,6 +123,7 @@ export default {
 		return {
 			highlight: false,
 			editingTitle: TITLE_EDITING_STATE.OFF,
+			isCurrentCard: false,
 		}
 	},
 	computed: {
@@ -157,9 +156,6 @@ export default {
 		displayTitle() {
 			const reference = this.card?.referenceData
 			return reference ? reference.openGraphObject.name : this.card.title
-		},
-		currentCard() {
-			return this.card && this.$route && this.$route.params.cardId === this.card.id
 		},
 		labelsSorted() {
 			return [...this.card.labels].sort((a, b) => (a.title < b.title) ? -1 : 1)
@@ -199,10 +195,21 @@ export default {
 		},
 	},
 	watch: {
-		currentCard(newValue) {
-			if (newValue) {
-				this.$nextTick(() => this.$el.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' }))
-			}
+		'$route.params.cardId': {
+			immediate: true,
+			handler(cardId) {
+				if (!this.card) {
+					return
+				}
+				const newValue = cardId && parseInt(cardId, 10) === this.card.id
+				if (newValue === this.isCurrentCard) {
+					return
+				}
+				this.isCurrentCard = newValue
+				if (newValue) {
+					this.$nextTick(() => this.$el.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' }))
+				}
+			},
 		},
 	},
 	methods: {


### PR DESCRIPTION
* Resolves: #3710 
* Target version: main

### Summary

Fixes severe UI lag when opening a card on boards with a large number of cards (e.g. 200+). Clicking a card to open its details could block the main thread for several seconds due to forced layout recalculations.

## Problem
On boards with many cards, opening a card's sidebar was unbearably slow. Chrome DevTools showed multi-second main-thread blocks dominated by **Recalculate Style**, triggered from Vue's `<transition-group>` update logic (`hasMove` → `getTransitionInfo`).
Two issues compounded:
1. **`<transition-group>` on card labels** — Each `CardItem` wrapped its label list in a `<transition-group>`. On any component update, Vue checks whether children have moved by reading layout from the DOM. With hundreds of cards (each potentially having multiple labels), this caused thousands of forced reflows on every interaction that updated the card list.
2. **`$route` in a computed property** — `currentCard` depended on `$route.params.cardId`, so **every** card component re-rendered whenever the route changed (e.g. opening or closing the card sidebar), not just the previously selected and newly selected card.
## Solution
- Replace the label `<transition-group>` with a plain `<ul>`. Label add/remove zoom animations are dropped, which is an acceptable trade-off for large boards.
- Track selection state in local `isCurrentCard` data, updated via a route watcher that only mutates state when **this** card's selection actually changes. Only the two affected cards re-render for the highlight border.

### Checklist

- [ ] Open a board with 100+ cards and click a card — sidebar should open without a noticeable delay
- [ ] Verify the selected card still shows the primary-color border highlight
- [ ] Close the sidebar and confirm the highlight is removed from the previously selected card
- [ ] Confirm labels still render and label-filter clicks still work
- [ ] Smoke-test on a board with few cards to ensure no regressions in normal use
- [ ] Optional: record a Chrome Performance profile while opening a card — the long `Recalculate Style` block from `hasMove` should be gone