### PR TITLE
fix(sharing): show more board sharing targets and clarify the picker label

### DIFF
--- a/src/components/board/SharingTabSidebar.vue
+++ b/src/components/board/SharingTabSidebar.vue
@@ -7,6 +7,7 @@
 		<NcSelectUsers v-model="addAcl"
 			:options="formatedSharees"
 			:loading="isLoading"
+			:input-label="t('deck', 'Search for users, groups and teams')"
 			@search="(search) => asyncFind(search)" />
 
 		<ul id="shareWithList"
@@ -143,7 +144,7 @@ export default {
 					type: SOURCE_TO_SHARE_TYPE[item.source],
 				}
 				return res
-			}).slice(0, 10)
+			}).slice(0, 200)
 			return result
 		},
 		unallocatedSharees() {

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -451,7 +451,7 @@ export default function storeFactory() {
 					search: query,
 					itemType: 'deck',
 					shareTypes: [0, 1, 6, 7],
-					limit: 20,
+					limit: 200,
 				}
 
 				const response = await axios.get(generateOcsUrl('/core/autocomplete/get'), { params })


### PR DESCRIPTION
The board sharing picker supports users, groups, and teams, but it only requested 20 autocomplete results and displayed the first 10 unallocated entries. This may give the impression that only users are supported.

Raise both limits to 200 and use a more specific picker label to clarify the supported sharing targets.

The 200-result limit follows established behaviour in Calendar, Tasks, and Bookmarks.

* Resolves: n/a, discussed in multiple places no single issue just for that.
* Target version: main

### Summary

In my local Nextcloud instance, I was only ever suggested 10 users for sharing a board with, the label _Select account_ with the absence of any suggested groups led me to believe that group-sharing was not supported.

It turned out, after searching existing groups are found just fine.

Two improvements to resolve that UI/UX gripe, bump the limit to 200 displayed users/groups/teams to share a board with in line with Calendar, Tasks, and Bookmarks and clarify in the label that teams and groups are also supported.

### TODO

n/a

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required