### PR TITLE
fix: loading notifications

### DIFF
--- a/lib/Activity/ActivityManager.php
+++ b/lib/Activity/ActivityManager.php
@@ -565,7 +565,7 @@ class ActivityManager {
 			$this->permissionService->checkPermission($this->cardMapper, $cardId, Acl::PERMISSION_READ, $userId);
 			$card = $this->cardMapper->find($cardId);
 			return $card->getDeletedAt() === 0;
-		} catch (NoPermissionException $e) {
+		} catch (NoPermissionException|DoesNotExistException $e) {
 			return false;
 		}
 	}
@@ -575,7 +575,7 @@ class ActivityManager {
 			$this->permissionService->checkPermission($this->boardMapper, $boardId, Acl::PERMISSION_READ, $userId);
 			$board = $this->boardMapper->find($boardId);
 			return $board->getDeletedAt() === 0;
-		} catch (NoPermissionException $e) {
+		} catch (NoPermissionException|DoesNotExistException $e) {
 			return false;
 		}
 	}


### PR DESCRIPTION
* Resolves: #8115
* Target version: main

### Summary
**Exception handling improvements:**

* Updated `canSeeCardActivity` to catch both `NoPermissionException` and `DoesNotExistException`, ensuring it returns `false` if the card doesn't exist or the user lacks permission.
* Updated `canSeeBoardActivity` to also catch both `NoPermissionException` and `DoesNotExistException`, so it returns `false` if the board doesn't exist or the user lacks permission.


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
