### PR TITLE
perf: windowed card rendering on large stacks + fix Tiptap mount race in Description

### DIFF
--- a/src/components/board/Stack.vue
+++ b/src/components/board/Stack.vue
@@ -101,7 +101,8 @@
 			</div>
 		</NcModal>
 
-		<Container :get-child-payload="payloadForCard(stack.id)"
+		<Container ref="dndContainer"
+			:get-child-payload="payloadForCard(stack.id)"
 			class="dnd-container"
 			group-name="stack"
 			data-click-closes-sidebar="true"
@@ -112,7 +113,7 @@
 			@drag-start="draggingCard = true"
 			@drag-end="draggingCard = false"
 			@drop="($event) => onDropCard(stack.id, $event)">
-			<Draggable v-for="card in cardsByStack" :key="card.id">
+			<Draggable v-for="card in visibleCards" :key="card.id">
 				<transition :appear="animate && !card.animated && (card.animated=true)"
 					:appear-class="'zoom-appear-class'"
 					:appear-active-class="'zoom-appear-active-class'">
@@ -161,6 +162,27 @@ import CardItem from '../cards/CardItem.vue'
 
 import '@nextcloud/dialogs/style.css'
 
+// Rendering every card of every stack at once does not scale: boards with
+// many cards per list (50+) end up with thousands of DOM nodes, which makes
+// every layout-invalidating interaction (e.g. opening the card sidebar) slow.
+//
+// A full virtual-scroller/recycling approach was intentionally avoided here:
+// vue-smooth-dnd (see node_modules/vue-smooth-dnd) measures the *real* DOM
+// children of the drag container at runtime (via the underlying smooth-dnd
+// library) and maps drop positions back to array indices 1:1 with rendered
+// children. Recycling/windowing an arbitrary middle slice of the list would
+// desync those indices and break drag-and-drop.
+//
+// Instead we render a contiguous *prefix* of the card list (cards 0..N) and
+// grow that prefix as the user scrolls down within the stack, or when a new
+// card is added. Because it is always a prefix starting at index 0, the
+// existing index-based drag-and-drop math (payloadForCard/onDropCard) stays
+// correct without any offset adjustments. Lists at or below the threshold
+// are rendered in full, unchanged from previous behaviour.
+const CARD_RENDER_THRESHOLD = 30
+const CARD_RENDER_BATCH_SIZE = 30
+const CARD_RENDER_SCROLL_MARGIN = 400
+
 export default {
 	name: 'Stack',
 	components: {
@@ -201,6 +223,7 @@ export default {
 				total: 0,
 				current: null,
 			},
+			renderedCardCount: CARD_RENDER_THRESHOLD,
 		}
 	},
 	computed: {
@@ -222,6 +245,15 @@ export default {
 		},
 		isDoneColumn() {
 			return !!this.stack.isDoneColumn
+		},
+		// See the comment above CARD_RENDER_THRESHOLD for why this is a
+		// growing prefix of `cardsByStack` rather than a virtualized/
+		// recycled window.
+		visibleCards() {
+			if (this.cardsByStack.length <= CARD_RENDER_THRESHOLD) {
+				return this.cardsByStack
+			}
+			return this.cardsByStack.slice(0, this.renderedCardCount)
 		},
 		dragHandleSelector() {
 			return this.canEdit && !this.showArchived ? null : '.no-drag'
@@ -249,6 +281,11 @@ export default {
 
 	mounted() {
 		this.setupAutoscrollOnDrag()
+		this.setupCardWindowScrollListener()
+	},
+
+	beforeDestroy() {
+		this.teardownCardWindowScrollListener()
 	},
 
 	methods: {
@@ -333,6 +370,9 @@ export default {
 				})
 				this.newCardTitle = ''
 				this.showAddCard = true
+				// A newly created card must be visible immediately, even if it
+				// landed past the currently rendered prefix of a windowed list.
+				this.renderedCardCount = this.cardsByStack.length
 				this.$nextTick(() => {
 					this.$refs.newCardInput.focus()
 					this.animate = false
@@ -379,6 +419,33 @@ export default {
 				clearInterval(timer)
 				timer = window.setInterval(() => autoscroll(e), 25)
 			})
+		},
+		setupCardWindowScrollListener() {
+			const el = this.$refs.dndContainer?.$el
+			if (!el) {
+				return
+			}
+			this.cardWindowScrollEl = el
+			this.onCardWindowScroll = () => {
+				if (this.renderedCardCount >= this.cardsByStack.length) {
+					return
+				}
+				const { scrollTop, scrollHeight, clientHeight } = el
+				if (scrollHeight - (scrollTop + clientHeight) < CARD_RENDER_SCROLL_MARGIN) {
+					this.renderedCardCount = Math.min(
+						this.cardsByStack.length,
+						this.renderedCardCount + CARD_RENDER_BATCH_SIZE,
+					)
+				}
+			}
+			el.addEventListener('scroll', this.onCardWindowScroll, { passive: true })
+		},
+		teardownCardWindowScrollListener() {
+			if (this.cardWindowScrollEl && this.onCardWindowScroll) {
+				this.cardWindowScrollEl.removeEventListener('scroll', this.onCardWindowScroll)
+			}
+			this.cardWindowScrollEl = null
+			this.onCardWindowScroll = null
 		},
 	},
 }

--- a/src/components/card/Description.vue
+++ b/src/components/card/Description.vue
@@ -117,6 +117,12 @@ export default {
 		return {
 			textAppAvailable: !!window.OCA?.Text?.createEditor,
 			editor: null,
+			// Set in beforeDestroy() and checked by every async callback that
+			// touches `this.editor`/the component instance, so that work left
+			// over from a card switch (this component is remounted per
+			// card.id, see CardSidebarTabDetails.vue) never reaches into a
+			// torn-down editor/ProseMirror view.
+			isDestroyed: false,
 			keyExitState: 0,
 			descriptionOld: '',
 			description: '',
@@ -181,7 +187,7 @@ export default {
 
 				this.descriptionOld = newCard.description
 				this.description = newCard.description
-				if (this.editor) {
+				if (this.editor && !this.isDestroyed) {
 					this.editor.setContent(this.description)
 				}
 				showWarning(t('deck', 'The description has been changed by another user.'), { timeout: 3000 })
@@ -192,22 +198,43 @@ export default {
 		this.setupEditor()
 	},
 	async beforeDestroy() {
+		this.isDestroyed = true
 		await this.destroyEditor()
 	},
 	methods: {
 		async setupEditor() {
 			await this.destroyEditor()
+			if (this.isDestroyed) {
+				return
+			}
 			this.descriptionLastEdit = 0
 			this.descriptionOld = this.card.description
 			this.description = this.card.description
-			this.editor = await window.OCA.Text.createEditor({
+
+			// Defer the (potentially expensive) editor mount until after the
+			// current render cycle - e.g. the card sidebar/modal opening
+			// transition - has settled, so it does not compete with it and
+			// so a fast card switch has a chance to flip `isDestroyed`
+			// before we ever touch window.OCA.Text.
+			await this.$nextTick()
+			if (this.isDestroyed || !this.$refs.editor) {
+				return
+			}
+
+			const editor = await window.OCA.Text.createEditor({
 				el: this.$refs.editor,
 				content: this.card.description,
 				readOnly: !this.canEdit,
 				onLoaded: () => {
+					if (this.isDestroyed) {
+						return
+					}
 					this.descriptionLastEdit = 0
 				},
 				onUpdate: ({ markdown }) => {
+					if (this.isDestroyed) {
+						return
+					}
 					if (this.description === markdown) {
 						return
 					}
@@ -215,14 +242,32 @@ export default {
 					this.updateDescription()
 				},
 				onFileInsert: () => {
+					if (this.isDestroyed) {
+						return
+					}
 					this.showAttachmentModal()
 				},
 			})
 
+			if (this.isDestroyed) {
+				// The component (and its DOM node passed as `el` above) was
+				// torn down while OCA.Text.createEditor() was still
+				// resolving - e.g. the user clicked another card before the
+				// editor finished mounting. Leaving this editor assigned to
+				// `this.editor` (or just dropped) is exactly what produces
+				// the "[tiptap error]: The editor view is not available"
+				// console error later, since it is bound to a detached
+				// element and nothing else will ever call destroy() on it.
+				editor?.destroy?.()
+				return
+			}
+
+			this.editor = editor
 		},
 		async destroyEditor() {
 			await this.saveDescription()
 			this?.editor?.destroy()
+			this.editor = null
 		},
 		addKeyListeners() {
 			this.$refs.markdownEditor.easymde.codemirror.on('keydown', (a, b) => {
@@ -264,7 +309,7 @@ export default {
 			// We need to strip those as text does not support rtl yet, so we cannot insert them separately
 			const stripRTLO = (text) => text.replaceAll('\u202e', '')
 			const fileName = stripRTLO(attachment.extendedData.info.filename) + '.' + stripRTLO(attachment.extendedData.info.extension)
-			if (this.editor) {
+			if (this.editor && !this.isDestroyed) {
 				this.editor.insertAtCursor(
 					asImage
 						? `<a href="${this.attachmentPreview(attachment)}"><img src="${this.attachmentPreview(attachment)}" alt="${attachment.data}" /></a>`


### PR DESCRIPTION
* Resolves: N/A (no pre-existing tracking issue; see #8112 for the related/overlapping fix this PR complements)
* Target version: main

### Summary

On boards with many cards per list, clicking a card to open the detail
sidebar is very slow. We profiled this on Deck 1.17.4 and measured an
INP (Interaction to Next Paint) of **2,649ms** on click, with **~10.7s**
of cumulative forced-reflow time attributable to that single click.

The root cause is layout thrashing spread across a few independent
problems in the card-open path. This PR fixes two of them:

**1. `src/components/board/Stack.vue` — unbounded card rendering per stack**

Every card in a stack is rendered in full at once, regardless of
column length. On a column with hundreds of cards this produces
thousands of DOM nodes (one board we tested against hit **4,942**
elements in a single column), so any layout-invalidating interaction —
such as opening the card sidebar — forces the browser to lay out that
entire subtree.

We considered a standard virtual-scroll/recycling approach, but Deck
uses `vue-smooth-dnd` for drag-and-drop, which resolves drop positions
against the *real* DOM children of the drag container, by index.
Recycling an arbitrary middle slice of the list would desync those
indices from the underlying card array and break drag-and-drop.

Instead, this PR renders a **contiguous prefix** of the card list
(the first 30 cards), growing it by 30 as the user scrolls near the
bottom of the stack (and immediately expanding to the full list when a
new card is added). Because the rendered set is always a prefix
starting at index 0, the existing index-based drag-and-drop math
(`payloadForCard` / `onDropCard`) is untouched and stays correct.
Stacks at or below the 30-card threshold render exactly as before.

*Known, intentional limitation:* a card cannot be dragged directly
into the not-yet-rendered tail of a very large stack until that part
of the list has been scrolled into view at least once. We consider
this an acceptable trade-off given it preserves 100% of the existing
drag-and-drop correctness, but flagging it explicitly for review.

**2. `src/components/card/Description.vue` — Tiptap/`OCA.Text` mount race**

`Description` is keyed by `card.id`, so Vue destroys and remounts it
every time the selected card changes. `setupEditor()` calls the async
`window.OCA.Text.createEditor(...)`; if the user switches cards
quickly, that promise can resolve *after* `beforeDestroy()` has already
run, binding a live Tiptap/ProseMirror editor to an already-detached
DOM element. That editor is then never destroyed, and interacting with
it (or with the stale `this.editor` reference from the old instance)
throws `"the editor view is not available"`.

This PR adds an `isDestroyed` flag (set in `beforeDestroy()`) that is
checked before starting editor creation, before assigning the resolved
editor to the instance (destroying it immediately instead, if the
component was torn down in the meantime), inside every
`createEditor()` callback (`onLoaded` / `onUpdate` / `onFileInsert`),
and at the other call sites that touch `this.editor`. It also defers
the `createEditor()` call by one `$nextTick()` so editor setup doesn't
compete with the sidebar/modal's own open transition, and resets
`this.editor` to `null` after teardown.

*Known, intentional limitation:* this narrows but does **not fully
eliminate** the race. Vue 2 does not await an async `beforeDestroy()`
hook before proceeding, so there remains, in principle, a narrower
window in the same microtask sequence. This is a meaningful reduction
of the failure window, not a complete fix.

**What's intentionally *not* in this PR**

A third contributor to the same click-lag problem is in
`src/components/cards/CardItem.vue`, where a `<transition-group>`
around the sidebar/card list causes additional forced reflow, plus a
full-list re-render on modal open. #8112 already fixes exactly this,
so it is **deliberately excluded here** to avoid duplicating that
open PR. We are not requesting any changes to #8112 or commenting on
it; it's referenced here purely for context on the full picture.

### Measurement, honestly stated

We measured before/after INP and forced-reflow time on a production
instance with **all three fixes applied together** (this PR's two
fixes + the CardItem.vue fix from #8112):

| | Before | After (all 3 fixes) |
|---|---|---|
| INP on card click | 2,649ms | 275ms |
| Cumulative forced-reflow time | ~10.7s | 632ms |

**We do not have isolated measurements for this PR's two fixes alone**
(Stack.vue windowing + Description.vue race guard), so we are not
claiming that combined result for this PR by itself. Both changes are
independently justified on their own merits (bounding DOM size, and
removing a real error condition), but for the full measured
improvement we'd recommend maintainers consider merging this PR
together with #8112.

### TODO

- [x] Verified only `Stack.vue` and `Description.vue` are touched (no
      overlap with #8112's `CardItem.vue` changes)

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
