### PR TITLE
fix: align attachment frontend requests with registered OCS routes

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -160,6 +160,8 @@ return [
 		['name' => 'attachment_ocs#getAll', 'url' => '/api/v{apiVersion}/cards/{cardId}/attachments', 'verb' => 'GET'],
 		['name' => 'attachment_ocs#create', 'url' => '/api/v{apiVersion}/cards/{cardId}/attachment', 'verb' => 'POST'],
 		['name' => 'attachment_ocs#update', 'url' => '/api/v{apiVersion}/cards/{cardId}/attachments/{attachmentId}', 'verb' => 'PUT'],
+		// POST is needed next to PUT as file uploads (multipart/form-data) are only parsed by PHP for POST requests
+		['name' => 'attachment_ocs#update', 'url' => '/api/v{apiVersion}/cards/{cardId}/attachments/{attachmentId}', 'verb' => 'POST'],
 		['name' => 'attachment_ocs#delete', 'url' => '/api/v{apiVersion}/cards/{cardId}/attachments/{attachmentId}', 'verb' => 'DELETE'],
 		['name' => 'attachment_ocs#restore', 'url' => '/api/v{apiVersion}/cards/{cardId}/attachments/{attachmentId}/restore', 'verb' => 'PUT'],
 

--- a/lib/Controller/AttachmentOcsController.php
+++ b/lib/Controller/AttachmentOcsController.php
@@ -51,7 +51,7 @@ class AttachmentOcsController extends OCSController {
 	}
 
 	#[NoAdminRequired]
-	public function update(int $cardId, int $attachmentId, string $data, string $type = 'file', ?int $boardId = null): DataResponse {
+	public function update(int $cardId, int $attachmentId, string $data = '', string $type = 'file', ?int $boardId = null): DataResponse {
 		$this->ensureLocalBoard($boardId);
 		$attachment = $this->attachmentService->update($cardId, $attachmentId, $data, $type);
 		return new DataResponse($attachment);

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     },
     "transform": {
       "^.+\\.js$": "<rootDir>/node_modules/babel-jest",
-      ".*\\.(vue)$": "<rootDir>/node_modules/vue-jest"
+      ".*\\.(vue)$": "<rootDir>/node_modules/@vue/vue2-jest"
     },
     "snapshotSerializers": [
       "<rootDir>/node_modules/jest-serializer-vue"

--- a/src/services/AttachmentApi.js
+++ b/src/services/AttachmentApi.js
@@ -42,22 +42,25 @@ export class AttachmentApi {
 	}
 
 	async updateAttachment({ cardId, attachment, formData, boardId }) {
+		// POST instead of PUT as multipart/form-data bodies are only parsed by PHP for POST requests
 		const response = await axios({
 		   method: 'POST',
-		   url: this.ocsUrl(`/cards/${cardId}/attachment/${attachment.type}:${attachment.id}`),
+		   url: this.ocsUrl(`/cards/${cardId}/attachments/${attachment.id}`),
 		   params: {
+				type: attachment.type,
 				boardId: boardId ?? null,
 		   },
 		   data: formData,
 	   })
-	   return response.data
+	   return response.data.ocs.data
 	}
 
 	async deleteAttachment(attachment, boardId) {
 		await axios({
 			method: 'DELETE',
-			url: this.ocsUrl(`/cards/${attachment.cardId}/attachment/${attachment.type}:${attachment.id}`),
+			url: this.ocsUrl(`/cards/${attachment.cardId}/attachments/${attachment.id}`),
 			params: {
+				type: attachment.type,
 				boardId: boardId ?? null,
 			},
 		})
@@ -65,9 +68,10 @@ export class AttachmentApi {
 
 	async restoreAttachment(attachment, boardId) {
 		const response = await axios({
-			method: 'GET',
-			url: this.ocsUrl(`/cards/${attachment.cardId}/attachment/${attachment.type}:${attachment.id}/restore`),
+			method: 'PUT',
+			url: this.ocsUrl(`/cards/${attachment.cardId}/attachments/${attachment.id}/restore`),
 			params: {
+				type: attachment.type,
 				boardId: boardId ?? null,
 			},
 		})

--- a/src/services/AttachmentApi.spec.js
+++ b/src/services/AttachmentApi.spec.js
@@ -1,0 +1,86 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import axios from '@nextcloud/axios'
+import { AttachmentApi } from './AttachmentApi.js'
+
+jest.mock('@nextcloud/axios', () => ({
+	__esModule: true,
+	default: jest.fn(),
+}))
+
+jest.mock('@nextcloud/router', () => ({
+	__esModule: true,
+	generateUrl: jest.fn((url) => `/index.php${url}`),
+	generateOcsUrl: jest.fn((url) => `/ocs/v2.php${url.startsWith('/') ? url : '/' + url}`),
+}))
+
+describe('AttachmentApi', () => {
+	const api = new AttachmentApi()
+	const attachment = { id: 3, cardId: 7, type: 'deck_file' }
+	const boardId = 5
+
+	beforeEach(() => {
+		axios.mockReset()
+		axios.mockResolvedValue({ data: { ocs: { data: {} } } })
+	})
+
+	it('fetches attachments from the registered OCS route', async () => {
+		await api.fetchAttachments(7, boardId)
+
+		expect(axios).toHaveBeenCalledWith(expect.objectContaining({
+			method: 'GET',
+			url: '/ocs/v2.php/apps/deck/api/v1.0/cards/7/attachments',
+			params: { boardId },
+		}))
+	})
+
+	it('creates an attachment through the registered OCS route', async () => {
+		const formData = { fake: 'formData' }
+		await api.createAttachment({ cardId: 7, formData, onUploadProgress: undefined, boardId })
+
+		expect(axios).toHaveBeenCalledWith(expect.objectContaining({
+			method: 'POST',
+			url: '/ocs/v2.php/apps/deck/api/v1.0/cards/7/attachment',
+			params: { boardId },
+			data: formData,
+		}))
+	})
+
+	it('deletes an attachment through the registered OCS route', async () => {
+		await api.deleteAttachment(attachment, boardId)
+
+		expect(axios).toHaveBeenCalledWith(expect.objectContaining({
+			method: 'DELETE',
+			url: '/ocs/v2.php/apps/deck/api/v1.0/cards/7/attachments/3',
+			params: { type: 'deck_file', boardId },
+		}))
+	})
+
+	it('updates an attachment through the registered OCS route', async () => {
+		const updated = { id: 3, cardId: 7, type: 'deck_file', data: 'file.png' }
+		axios.mockResolvedValue({ data: { ocs: { data: updated } } })
+		const formData = { fake: 'formData' }
+		const result = await api.updateAttachment({ cardId: 7, attachment, formData, boardId })
+		expect(result).toEqual(updated)
+
+		expect(axios).toHaveBeenCalledWith(expect.objectContaining({
+			method: 'POST',
+			url: '/ocs/v2.php/apps/deck/api/v1.0/cards/7/attachments/3',
+			params: { type: 'deck_file', boardId },
+			data: formData,
+		}))
+	})
+
+	it('restores an attachment through the registered OCS route', async () => {
+		await api.restoreAttachment(attachment, boardId)
+
+		expect(axios).toHaveBeenCalledWith(expect.objectContaining({
+			method: 'PUT',
+			url: '/ocs/v2.php/apps/deck/api/v1.0/cards/7/attachments/3/restore',
+			params: { type: 'deck_file', boardId },
+		}))
+	})
+})


### PR DESCRIPTION
* Resolves: attachment delete/update/restore silently failing in the UI
* Target version: main

### Summary

696ca2f3e52b59a08c390c9351951337b66d13af migrated the attachment frontend to OCS endpoints, but the frontend kept the old page-route URL shape (singular `/attachment/`, composite `{type}:{id}` ids, `POST`/`GET` verbs) while the registered OCS routes use plural `/attachments/{attachmentId}` with `PUT`/`DELETE`. As a result, deleting, updating and restoring an attachment from the card sidebar hit non-existent routes and silently failed with 404 (the Vuex dispatch has no error handling).

This PR aligns the frontend with the registered OCS routes and fixes the remaining gaps on the backend side:

- `AttachmentApi.js`: call `/cards/{cardId}/attachments/{attachmentId}` with a numeric id, pass the attachment `type` as a query parameter (the OCS controller defaults to `file`, so `deck_file` attachments need it explicitly), use `PUT` for restore, and unwrap the OCS envelope in `updateAttachment()`.
- `routes.php`: register a `POST` route for `attachment_ocs#update` next to `PUT`, since PHP only parses `multipart/form-data` bodies (file uploads) for `POST` requests — mirroring the old page routes which registered both verbs for the same reason.
- `AttachmentOcsController::update()`: default `$data` to an empty string, as the upload form data contains `file`/`type` but no `data` field.
- Add jest regression tests covering the URL, verb and parameters of all five attachment endpoints. This is the first jest test in the repo; the jest config in `package.json` pointed at `vue-jest`, which is not a dependency (the installed transformer is `@vue/vue2-jest`), so it is fixed in a separate commit.

### How to test

1. Open a card → attachments tab → upload a file
2. Delete it via the three-dot menu → the attachment should be greyed out (soft-deleted) and the `DELETE .../ocs/v2.php/apps/deck/api/v1.0/cards/{cardId}/attachments/{attachmentId}?type=deck_file` request should return 200 (previously 404)
3. Restore it → it comes back (`PUT .../restore`)
4. `npx jest src/services/AttachmentApi.spec.js` → 5 passing

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)