### PR TITLE
feat: per-user board ordering in the navigation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1126,10 +1126,10 @@ Deck stores user and app configuration values globally and per board. The GET en
 
 | Config key | Description |
 | --- | --- |
+| boardOrder | Per-user ordered list of board ids used to persist the manual drag and drop order of boards in the web navigation (array of integers) |
 | calendar | Determines if the calendar/tasks integration through the CalDAV backend is enabled for the user (boolean) |
 | cardDetailsInModal | Determines if the bigger view is used (boolean) |
 | cardIdBadge | Determines if the ID badges are displayed on cards (boolean) |
-| boardOrder | Per-user ordered list of board ids used to persist the manual drag and drop order of boards in the web navigation (array of integers) |
 | groupLimit | Determines if creating new boards is limited to certain groups of the instance. The resulting output is an array of group objects with the id and the displayname (Admin only)|
 
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -1129,6 +1129,7 @@ Deck stores user and app configuration values globally and per board. The GET en
 | calendar | Determines if the calendar/tasks integration through the CalDAV backend is enabled for the user (boolean) |
 | cardDetailsInModal | Determines if the bigger view is used (boolean) |
 | cardIdBadge | Determines if the ID badges are displayed on cards (boolean) |
+| boardOrder | Per-user ordered list of board ids used to persist the manual drag and drop order of boards in the web navigation (array of integers) |
 | groupLimit | Determines if creating new boards is limited to certain groups of the instance. The resulting output is an array of group objects with the id and the displayname (Admin only)|
 
 ```

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -63,7 +63,7 @@ class ConfigService {
 	}
 
 	/**
-	 * @return bool|array{id: string, displayname: string}[]
+	 * @return bool|array{id: string, displayname: string}[]|int[]
 	 * @throws NoPermissionException
 	 */
 	public function get(string $key) {

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -52,7 +52,8 @@ class ConfigService {
 		$data = [
 			'calendar' => $this->isCalendarEnabled(),
 			'cardDetailsInModal' => $this->isCardDetailsInModal(),
-			'cardIdBadge' => $this->isCardIdBadgeEnabled()
+			'cardIdBadge' => $this->isCardIdBadgeEnabled(),
+			'boardOrder' => $this->getBoardOrder()
 		];
 		if ($this->groupManager->isAdmin($userId)) {
 			$data['groupLimit'] = $this->get('groupLimit');
@@ -90,6 +91,8 @@ class ConfigService {
 					return false;
 				}
 				return (bool)$this->config->getUserValue($this->getUserId(), Application::APP_ID, 'cardIdBadge', false);
+			case 'boardOrder':
+				return $this->getBoardOrder();
 		}
 		return false;
 	}
@@ -181,6 +184,14 @@ class ConfigService {
 				$this->config->setUserValue($userId, Application::APP_ID, 'cardIdBadge', (string)$value);
 				$result = $value;
 				break;
+			case 'boardOrder':
+				if (!is_array($value)) {
+					throw new BadRequestException('boardOrder must be a list of board ids');
+				}
+				$ids = array_values(array_map('intval', array_filter($value, 'is_numeric')));
+				$this->config->setUserValue($userId, Application::APP_ID, 'boardOrder', json_encode($ids));
+				$result = $ids;
+				break;
 			case 'board':
 				// extra check that user only send one of the allowed board settings and not something random
 				$parts = explode(':', $key, 3);
@@ -234,6 +245,20 @@ class ConfigService {
 			];
 		}, $groups);
 		return array_filter($groups);
+	}
+
+	/** @return int[] */
+	private function getBoardOrder(): array {
+		$userId = $this->getUserId();
+		if ($userId === null) {
+			return [];
+		}
+		$value = $this->config->getUserValue($userId, Application::APP_ID, 'boardOrder', '[]');
+		$decoded = json_decode($value, true);
+		if (!is_array($decoded)) {
+			return [];
+		}
+		return array_values(array_map('intval', array_filter($decoded, 'is_numeric')));
 	}
 
 	public function getAttachmentFolder(?string $userId = null): string {

--- a/src/components/navigation/AppNavigation.vue
+++ b/src/components/navigation/AppNavigation.vue
@@ -20,6 +20,7 @@
 				:boards="noneArchivedBoards"
 				:open-on-add-boards="true"
 				:default-open="true"
+				:sortable="true"
 				icon="icon-deck">
 				<template #icon>
 					<DeckIcon :size="16" />

--- a/src/components/navigation/AppNavigationBoardCategory.vue
+++ b/src/components/navigation/AppNavigationBoardCategory.vue
@@ -12,6 +12,7 @@
 		<Container v-if="sortable"
 			lock-axis="y"
 			tag="div"
+			non-drag-area-selector="input, .app-navigation-entry__actions"
 			@drop="onDropBoard">
 			<Draggable v-for="board in boardsSorted" :key="board.id">
 				<AppNavigationBoard :board="board" />

--- a/src/components/navigation/AppNavigationBoardCategory.vue
+++ b/src/components/navigation/AppNavigationBoardCategory.vue
@@ -9,7 +9,17 @@
 		:exact="true"
 		:allow-collapse="collapsible"
 		:open="opened">
-		<AppNavigationBoard v-for="board in boardsSorted" :key="board.id" :board="board" />
+		<Container v-if="sortable"
+			lock-axis="y"
+			tag="div"
+			@drop="onDropBoard">
+			<Draggable v-for="board in boardsSorted" :key="board.id">
+				<AppNavigationBoard :board="board" />
+			</Draggable>
+		</Container>
+		<template v-else>
+			<AppNavigationBoard v-for="board in boardsSorted" :key="board.id" :board="board" />
+		</template>
 		<template #icon>
 			<slot name="icon" />
 		</template>
@@ -19,12 +29,17 @@
 <script>
 import AppNavigationBoard from './AppNavigationBoard.vue'
 import { NcAppNavigationItem } from '@nextcloud/vue'
+import { Container, Draggable } from 'vue-smooth-dnd'
+import { showError } from '@nextcloud/dialogs'
+import { sortBoards } from '../../helpers/boardSort.js'
 
 export default {
 	name: 'AppNavigationBoardCategory',
 	components: {
 		NcAppNavigationItem,
 		AppNavigationBoard,
+		Container,
+		Draggable,
 	},
 	props: {
 		to: {
@@ -55,6 +70,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		sortable: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	data() {
 		return {
@@ -63,7 +82,7 @@ export default {
 	},
 	computed: {
 		boardsSorted() {
-			return [...this.boards].sort((a, b) => a.title.localeCompare(b.title))
+			return sortBoards(this.boards, this.sortable ? this.$store.getters.config('boardOrder') : null)
 		},
 		collapsible() {
 			return this.boards.length > 0
@@ -79,5 +98,29 @@ export default {
 	mounted() {
 		this.opened = this.defaultOpen
 	},
+	methods: {
+		async onDropBoard({ removedIndex, addedIndex }) {
+			if (removedIndex === null || addedIndex === null || removedIndex === addedIndex) {
+				return
+			}
+			const ordered = [...this.boardsSorted]
+			const [moved] = ordered.splice(removedIndex, 1)
+			ordered.splice(addedIndex, 0, moved)
+			try {
+				await this.$store.dispatch('setConfig', { boardOrder: ordered.map((board) => board.id) })
+			} catch (error) {
+				console.error('Failed to reorder boards', error)
+				showError(t('deck', 'Failed to reorder boards'))
+			}
+		},
+	},
 }
 </script>
+
+<style lang="scss" scoped>
+.smooth-dnd-container {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline, 4px);
+}
+</style>

--- a/src/components/navigation/AppNavigationBoardCategory.vue
+++ b/src/components/navigation/AppNavigationBoardCategory.vue
@@ -12,10 +12,15 @@
 		<Container v-if="sortable"
 			lock-axis="y"
 			tag="div"
-			non-drag-area-selector="input, .app-navigation-entry__actions"
+			drag-handle-selector=".board-drag-handle"
 			@drop="onDropBoard">
 			<Draggable v-for="board in boardsSorted" :key="board.id">
-				<AppNavigationBoard :board="board" />
+				<div class="board-drag-row">
+					<span class="board-drag-handle" :title="t('deck', 'Drag to reorder')">
+						<DragVertical :size="20" />
+					</span>
+					<AppNavigationBoard :board="board" />
+				</div>
 			</Draggable>
 		</Container>
 		<template v-else>
@@ -32,6 +37,7 @@ import AppNavigationBoard from './AppNavigationBoard.vue'
 import { NcAppNavigationItem } from '@nextcloud/vue'
 import { Container, Draggable } from 'vue-smooth-dnd'
 import { showError } from '@nextcloud/dialogs'
+import DragVertical from 'vue-material-design-icons/DragVertical.vue'
 import { sortBoards } from '../../helpers/boardSort.js'
 
 export default {
@@ -41,6 +47,7 @@ export default {
 		AppNavigationBoard,
 		Container,
 		Draggable,
+		DragVertical,
 	},
 	props: {
 		to: {
@@ -123,5 +130,31 @@ export default {
 	display: flex;
 	flex-direction: column;
 	gap: var(--default-grid-baseline, 4px);
+}
+
+.board-drag-row {
+	display: flex;
+	align-items: center;
+
+	> :last-child {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+}
+
+.board-drag-handle {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 24px;
+	color: var(--color-text-maxcontrast);
+	cursor: grab;
+	opacity: 0;
+	transition: opacity var(--animation-quick, 100ms) ease;
+}
+
+.board-drag-row:hover .board-drag-handle,
+.board-drag-handle:focus-visible {
+	opacity: 1;
 }
 </style>

--- a/src/helpers/boardSort.js
+++ b/src/helpers/boardSort.js
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Sort boards by the user defined order (list of board ids), boards not in
+ * the list come last, alphabetically.
+ *
+ * @param {Array} boards array of board objects ({ id, title })
+ * @param {Array|null} order ordered list of board ids or null
+ * @return {Array} new sorted array
+ */
+export function sortBoards(boards, order) {
+	const position = new Map((order ?? []).map((id, index) => [id, index]))
+	return [...boards].sort((a, b) => {
+		const positionA = position.has(a.id) ? position.get(a.id) : Number.POSITIVE_INFINITY
+		const positionB = position.has(b.id) ? position.get(b.id) : Number.POSITIVE_INFINITY
+		if (positionA !== positionB) {
+			return positionA - positionB
+		}
+		return a.title.localeCompare(b.title)
+	})
+}

--- a/src/helpers/boardSort.spec.js
+++ b/src/helpers/boardSort.spec.js
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { sortBoards } from './boardSort.js'
+
+describe('sortBoards', () => {
+	it('sorts alphabetically without a custom order', () => {
+		const boards = [{ id: 1, title: 'Zebra' }, { id: 2, title: 'Alpha' }]
+		expect(sortBoards(boards, null).map(b => b.id)).toEqual([2, 1])
+	})
+
+	it('applies the custom order first', () => {
+		const boards = [{ id: 1, title: 'Alpha' }, { id: 2, title: 'Beta' }, { id: 3, title: 'Gamma' }]
+		expect(sortBoards(boards, [3, 1]).map(b => b.id)).toEqual([3, 1, 2])
+	})
+
+	it('appends unknown boards alphabetically after ordered ones', () => {
+		const boards = [{ id: 5, title: 'Zzz' }, { id: 6, title: 'Aaa' }, { id: 7, title: 'Mmm' }]
+		expect(sortBoards(boards, [7]).map(b => b.id)).toEqual([7, 6, 5])
+	})
+
+	it('ignores ids of removed boards', () => {
+		const boards = [{ id: 1, title: 'B' }, { id: 2, title: 'A' }]
+		expect(sortBoards(boards, [999, 2]).map(b => b.id)).toEqual([2, 1])
+	})
+})

--- a/tests/unit/Service/ConfigServiceTest.php
+++ b/tests/unit/Service/ConfigServiceTest.php
@@ -3,25 +3,8 @@
 declare(strict_types=1);
 
 /**
- * @copyright Copyright (c) 2016 Julius Härtl <jus@bitgrid.net>
- *
- * @author Julius Härtl <jus@bitgrid.net>
- *
- * @license GNU AGPL version 3 or any later version
- *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Affero General Public License for more details.
- *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\Deck\Service;

--- a/tests/unit/Service/ConfigServiceTest.php
+++ b/tests/unit/Service/ConfigServiceTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2016 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Deck\Service;
+
+use OCA\Deck\BadRequestException;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class ConfigServiceTest extends TestCase {
+
+	private IConfig&MockObject $config;
+	private IGroupManager&MockObject $groupManager;
+	/** @var ConfigService|MockObject */
+	private $configService;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->config = $this->createMock(IConfig::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+
+		// ConfigService::getUserId() resolves the current user through
+		// \OCP\Server::get(IUserSession::class) instead of a constructor
+		// dependency, so it can't be mocked via the constructor. Stub just
+		// that method and keep everything else on the real implementation.
+		$this->configService = $this->getMockBuilder(ConfigService::class)
+			->setConstructorArgs([$this->config, $this->groupManager])
+			->onlyMethods(['getUserId'])
+			->getMock();
+		$this->configService->method('getUserId')->willReturn('admin');
+	}
+
+	public function testBoardOrderRoundTrip() {
+		$this->config->expects($this->once())
+			->method('setUserValue')
+			->with('admin', 'deck', 'boardOrder', '[4,2,9]');
+		$result = $this->configService->set('boardOrder', [4, '2', 9.0]);
+		$this->assertSame([4, 2, 9], $result);
+	}
+
+	public function testBoardOrderRejectsNonArray() {
+		$this->expectException(BadRequestException::class);
+		$this->configService->set('boardOrder', 'not-a-list');
+	}
+
+	public function testGetBoardOrderDecodesAndFiltersStoredValue() {
+		$this->config->expects($this->once())
+			->method('getUserValue')
+			->with('admin', 'deck', 'boardOrder', '[]')
+			->willReturn('[3,1,5,"x"]');
+		$this->assertSame([3, 1, 5], $this->configService->get('boardOrder'));
+	}
+
+	public function testGetAllIncludesBoardOrder() {
+		$this->config->method('getUserValue')->willReturnCallback(function ($userId, $appId, $key, $default) {
+			if ($key === 'boardOrder') {
+				return '[7,3]';
+			}
+			return $default;
+		});
+		$this->config->method('getAppValue')->willReturnArgument(2);
+		$this->groupManager->method('isAdmin')->willReturn(false);
+
+		$data = $this->configService->getAll();
+		$this->assertSame([7, 3], $data['boardOrder']);
+	}
+}


### PR DESCRIPTION
* Resolves: recurring request to control the order of boards in the navigation (related discussion: #7871)
* Target version: main

### Summary

The left navigation sorts boards alphabetically (hard-coded), which does not match how people prioritise their boards. This adds per-user manual ordering:

- New per-user config key `boardOrder` (JSON array of board ids) through the existing `ConfigService` user-config plumbing and the existing OCS `POST /config/{key}` route — **no schema migration, no shared state**: each user has their own order and boards themselves are untouched
- `getAll()` exposes `boardOrder` to the frontend initial state; value is validated (list of ints) and cleaned on write; documented in docs/API.md
- Frontend: drag & drop of boards in the "All boards" navigation category only (archived/shared categories keep the alphabetical sort), `sortBoards()` helper — user order first, boards not in the list appended alphabetically (new/newly shared boards), stale ids ignored
- Rename input and actions menu are non-drag areas; failures show an error toast and the order reverts
- Jest tests for the helper; PHPUnit tests for the config round-trip and validation

### How to test

1. Drag boards into a custom order in the "All boards" section; F5 persists it
2. A second user on the same boards keeps their own independent order
3. New boards appear at the end of the list alphabetically

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
