### PR TITLE
fix: do not clear card color when update omits the field

### DIFF
--- a/lib/Controller/CardApiController.php
+++ b/lib/Controller/CardApiController.php
@@ -88,8 +88,9 @@ class CardApiController extends ApiController {
 	#[NoAdminRequired]
 	#[CORS]
 	#[NoCSRFRequired]
-	public function update(string $title, $type, string $owner, string $description = '', int $order = 0, $duedate = null, $startdate = null, $archived = null, ?string $color = null): DataResponse {
+	public function update(string $title, $type, string $owner, string $description = '', int $order = 0, $duedate = null, $startdate = null, $archived = null): DataResponse {
 		$done = array_key_exists('done', $this->request->getParams()) ? new OptionalNullableValue($this->request->getParam('done', null)) : null;
+		$color = array_key_exists('color', $this->request->getParams()) ? new OptionalNullableValue($this->request->getParam('color', null)) : null;
 		$card = $this->cardService->update($this->request->getParam('cardId'), $title, $this->request->getParam('stackId'), $type, $owner, $description, $order, $duedate, 0, $archived, $done, $startdate, $color);
 		return new DataResponse($card, HTTP::STATUS_OK);
 	}

--- a/lib/Controller/CardController.php
+++ b/lib/Controller/CardController.php
@@ -64,9 +64,12 @@ class CardController extends Controller {
 	 * @param $duedate
 	 */
 	#[NoAdminRequired]
-	public function update(int $id, string $title, int $stackId, string $type, int $order, string $description, $duedate, $deletedAt, $archived = null, $startdate = null, ?string $color = null): Card {
+	public function update(int $id, string $title, int $stackId, string $type, int $order, string $description, $duedate, $deletedAt, $archived = null, $startdate = null): Card {
 		$done = array_key_exists('done', $this->request->getParams())
 			? new OptionalNullableValue($this->request->getParam('done', null))
+			: null;
+		$color = array_key_exists('color', $this->request->getParams())
+			? new OptionalNullableValue($this->request->getParam('color', null))
 			: null;
 		return $this->cardService->update($id, $title, $stackId, $type, $this->userId, $description, $order, $duedate, $deletedAt, $archived, $done, $startdate, $color);
 	}

--- a/lib/Controller/CardOcsController.php
+++ b/lib/Controller/CardOcsController.php
@@ -113,9 +113,12 @@ class CardOcsController extends OCSController {
 
 	#[NoAdminRequired]
 	#[PublicPage]
-	public function update(int $id, string $title, int $stackId, string $type, int $order, string $description, $duedate, $deletedAt, int $boardId, array|string|null $owner = null, $archived = null, $startdate = null, ?string $color = null): DataResponse {
+	public function update(int $id, string $title, int $stackId, string $type, int $order, string $description, $duedate, $deletedAt, int $boardId, array|string|null $owner = null, $archived = null, $startdate = null): DataResponse {
 		$done = array_key_exists('done', $this->request->getParams())
 			? new OptionalNullableValue($this->request->getParam('done', null))
+			: null;
+		$color = array_key_exists('color', $this->request->getParams())
+			? new OptionalNullableValue($this->request->getParam('color', null))
 			: null;
 		if (!$owner) {
 			$owner = $this->userId;

--- a/lib/Service/CardService.php
+++ b/lib/Service/CardService.php
@@ -246,7 +246,7 @@ class CardService {
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 * @throws BadRequestException
 	 */
-	public function update(int $id, string $title, int $stackId, string $type, string $owner, string $description = '', int $order = 0, ?string $duedate = null, ?int $deletedAt = null, ?bool $archived = null, ?OptionalNullableValue $done = null, ?string $startdate = null, ?string $color = null): Card {
+	public function update(int $id, string $title, int $stackId, string $type, string $owner, string $description = '', int $order = 0, ?string $duedate = null, ?int $deletedAt = null, ?bool $archived = null, ?OptionalNullableValue $done = null, ?string $startdate = null, ?OptionalNullableValue $color = null): Card {
 		$this->cardServiceValidator->check(compact('id', 'title', 'stackId', 'type', 'owner', 'order'));
 
 		$this->permissionService->checkPermission($this->cardMapper, $id, Acl::PERMISSION_EDIT, allowDeletedCard: true);
@@ -289,7 +289,10 @@ class CardService {
 		$card->setOrder($order);
 		$card->setDuedate($duedate ? new \DateTime($duedate) : null);
 		$card->setStartdate($startdate ? new \DateTime($startdate) : null);
-		$card->setColor($color);
+		if ($color !== null) {
+			$colorValue = $color->getValue();
+			$card->setColor(is_string($colorValue) && $colorValue !== '' ? $colorValue : null);
+		}
 		$resetDuedateNotification = false;
 		if (
 			$card->getDuedate() === null

--- a/tests/unit/Service/CardServiceTest.php
+++ b/tests/unit/Service/CardServiceTest.php
@@ -37,6 +37,7 @@ use OCA\Deck\Db\LabelMapper;
 use OCA\Deck\Db\Stack;
 use OCA\Deck\Db\StackMapper;
 use OCA\Deck\Model\CardDetails;
+use OCA\Deck\Model\OptionalNullableValue;
 use OCA\Deck\Notification\NotificationHelper;
 use OCA\Deck\StatusException;
 use OCA\Deck\Validators\CardServiceValidator;
@@ -368,7 +369,7 @@ class CardServiceTest extends TestCase {
 			->method('find')
 			->with(234)
 			->willReturn($stack);
-		$actual = $this->cardService->update(123, 'newtitle', 234, 'text', 'admin', 'foo', 999, '2017-01-01 00:00:00', null, null, null, null, 'ffffff');
+		$actual = $this->cardService->update(123, 'newtitle', 234, 'text', 'admin', 'foo', 999, '2017-01-01 00:00:00', null, null, null, null, new OptionalNullableValue('ffffff'));
 		$this->assertEquals('newtitle', $actual->getTitle());
 		$this->assertEquals(234, $actual->getStackId());
 		$this->assertEquals('text', $actual->getType());
@@ -376,6 +377,104 @@ class CardServiceTest extends TestCase {
 		$this->assertEquals('foo', $actual->getDescription());
 		$this->assertEquals(new \DateTime('2017-01-01T00:00:00+00:00'), $actual->getDuedate());
 		$this->assertEquals('ffffff', $actual->getColor());
+	}
+
+	public function testUpdateKeepsColorWhenOmitted() {
+		$card = Card::fromParams([
+			'title' => 'Card title',
+			'archived' => 'false',
+			'stackId' => 234,
+			'color' => '00ff00',
+		]);
+		$card->setColor('ff0000');
+		$stack = Stack::fromParams([
+			'id' => 234,
+			'boardId' => 1337,
+		]);
+		$this->cardMapper->expects($this->once())->method('find')->willReturn($card);
+		$this->cardMapper->expects($this->once())->method('update')->willReturnCallback(function ($c) {
+			$c->setId(1);
+			return $c;
+		});
+		$this->stackMapper->expects($this->once())
+			->method('find')
+			->with(234)
+			->willReturn($stack);
+		$actual = $this->cardService->update(123, 'newtitle', 234, 'text', 'admin', 'foo', 999, '2017-01-01 00:00:00', null, null, null, null, null);
+		$this->assertSame('ff0000', $actual->getColor());
+	}
+
+	public function testUpdateClearsColorWhenNullProvided() {
+		$card = Card::fromParams([
+			'title' => 'Card title',
+			'archived' => 'false',
+			'stackId' => 234,
+			'color' => '00ff00',
+		]);
+		$card->setColor('ff0000');
+		$stack = Stack::fromParams([
+			'id' => 234,
+			'boardId' => 1337,
+		]);
+		$this->cardMapper->expects($this->once())->method('find')->willReturn($card);
+		$this->cardMapper->expects($this->once())->method('update')->willReturnCallback(function ($c) {
+			$c->setId(1);
+			return $c;
+		});
+		$this->stackMapper->expects($this->once())
+			->method('find')
+			->with(234)
+			->willReturn($stack);
+		$actual = $this->cardService->update(123, 'newtitle', 234, 'text', 'admin', 'foo', 999, '2017-01-01 00:00:00', null, null, null, null, new OptionalNullableValue(null));
+		$this->assertNull($actual->getColor());
+	}
+
+	public function testUpdateClearsColorWhenEmptyStringProvided() {
+		$card = Card::fromParams([
+			'title' => 'Card title',
+			'archived' => 'false',
+			'stackId' => 234,
+			'color' => '00ff00',
+		]);
+		$card->setColor('ff0000');
+		$stack = Stack::fromParams([
+			'id' => 234,
+			'boardId' => 1337,
+		]);
+		$this->cardMapper->expects($this->once())->method('find')->willReturn($card);
+		$this->cardMapper->expects($this->once())->method('update')->willReturnCallback(function ($c) {
+			$c->setId(1);
+			return $c;
+		});
+		$this->stackMapper->expects($this->once())
+			->method('find')
+			->with(234)
+			->willReturn($stack);
+		$actual = $this->cardService->update(123, 'newtitle', 234, 'text', 'admin', 'foo', 999, '2017-01-01 00:00:00', null, null, null, null, new OptionalNullableValue(''));
+		$this->assertNull($actual->getColor());
+	}
+
+	public function testUpdateSetsColor() {
+		$card = Card::fromParams([
+			'title' => 'Card title',
+			'archived' => 'false',
+			'stackId' => 234,
+		]);
+		$stack = Stack::fromParams([
+			'id' => 234,
+			'boardId' => 1337,
+		]);
+		$this->cardMapper->expects($this->once())->method('find')->willReturn($card);
+		$this->cardMapper->expects($this->once())->method('update')->willReturnCallback(function ($c) {
+			$c->setId(1);
+			return $c;
+		});
+		$this->stackMapper->expects($this->once())
+			->method('find')
+			->with(234)
+			->willReturn($stack);
+		$actual = $this->cardService->update(123, 'newtitle', 234, 'text', 'admin', 'foo', 999, '2017-01-01 00:00:00', null, null, null, null, new OptionalNullableValue('00ff00'));
+		$this->assertSame('00ff00', $actual->getColor());
 	}
 
 	public function testUpdateWithStartdate() {


### PR DESCRIPTION
* Resolves: #8131
* Target version: main

### Summary

`CardService::update()` unconditionally called `$card->setColor($color)`, so any API client that omits the `color` field on a card update (mobile clients, scripts, integrations) silently wiped the stored card color.

This applies the exact mechanism already used for the `done` field: the controllers build an `OptionalNullableValue` only when the request body actually contains a `color` key (`array_key_exists`), and the service only touches the color when the wrapper is present:

- field omitted → color kept (the fix)
- explicit `null` or `""` → color cleared
- hex string → color set

The service guards with `is_string()`, so malformed non-scalar payloads (e.g. an array) are treated as "clear" instead of being string-cast. Note: an unquoted numeric JSON value (`"color": 123456`), which previously coerced to the string `"123456"`, now also clears — strings are the documented type for this field.

The web frontend always sends the full card object including `color`, so UI behaviour is unchanged. Covered by four new PHPUnit cases (kept / cleared via null / cleared via empty string / set).

### How to test

1. Set a card color in the web UI
2. `PUT /index.php/apps/deck/cards/{cardId}` with a body that contains title/stackId/type/order but no `color` key
3. Before: color wiped. After: color kept. Sending `"color": null` still clears it.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
