### PR TITLE
fix: broken upload of attachment via api

### DIFF
--- a/lib/Controller/AttachmentApiController.php
+++ b/lib/Controller/AttachmentApiController.php
@@ -47,7 +47,7 @@ class AttachmentApiController extends ApiController {
 	#[NoAdminRequired]
 	#[CORS]
 	#[NoCSRFRequired]
-	public function create(int $cardId, string $type, string $data): DataResponse {
+	public function create(int $cardId, string $type, ?string $data): DataResponse {
 		$attachment = $this->attachmentService->create($cardId, $type, $data);
 		return new DataResponse($attachment, HTTP::STATUS_OK);
 	}


### PR DESCRIPTION
* Resolves: #8123
* Target version: main

### Summary
Fixes an issue that prevents a user from uploading **any** attachment to a card by using the api endpoint [POST /boards/{boardId}/stacks/{stackId}/cards/{cardId}/attachments](https://deck.readthedocs.io/en/stable/API/#post-boardsboardidstacksstackidcardscardidattachments-upload-an-attachment) which in practice broke the endpoint completely. The issue was raised in 5cf486150ab297c166ccd4cdead2294890be713a as `$data` of AttachmentApiController::create() is not required but was marked as required.



### TODO
--

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required

Do you really want a unit test for checking if a parameter is optional?

**A general remark**: This repository should have API tests, that covers basic cases of the api documented under https://deck.readthedocs.io/en/stable/API. This broken api controller could have been avoided with a simple, static multipart/form-data request to create an attachment.
I am not able to write such tests in PHP otherwise I would have done it. But maybe someone ready this and has some time :)