### PR TITLE
Fix/date selector names

### DIFF
--- a/src/components/card/CardSidebarTabDetails.vue
+++ b/src/components/card/CardSidebarTabDetails.vue
@@ -20,12 +20,10 @@
 
 		<StartDateSelector :card="card"
 			:can-edit="canEdit"
-			@change="updateCardStartDate"
 			@input="debouncedUpdateCardStartDate" />
 
 		<DueDateSelector :card="card"
 			:can-edit="canEdit"
-			@change="updateCardDue"
 			@input="debouncedUpdateCardDue" />
 
 		<DependentCardsSelector :card="card"
@@ -163,7 +161,7 @@ export default {
 
 		debouncedUpdateCardDue: debounce(function(val) {
 			this.updateCardDue(val)
-		}, 500),
+		}, 500, { leading: true }),
 
 		updateCardStartDate(val) {
 			this.$store.dispatch('updateCardStartDate', {
@@ -174,7 +172,7 @@ export default {
 
 		debouncedUpdateCardStartDate: debounce(function(val) {
 			this.updateCardStartDate(val)
-		}, 500),
+		}, 500, { leading: true }),
 
 		addLabelToCard(newLabel) {
 			this.copiedCard.labels.push(newLabel)

--- a/src/components/card/DueDateSelector.vue
+++ b/src/components/card/DueDateSelector.vue
@@ -14,7 +14,7 @@
 				:hide-label="true"
 				type="datetime-local" />
 			<NcActions v-if="canEdit"
-				:menu-title="!duedate ? t('deck', 'Add due date') : null"
+				:menu-name="!duedate ? t('deck', 'Add due date') : null"
 				type="tertiary"
 				data-cy-due-date-actions>
 				<template v-if="!duedate" #icon>

--- a/src/components/card/DueDateSelector.vue
+++ b/src/components/card/DueDateSelector.vue
@@ -220,12 +220,10 @@ export default defineComponent({
 		},
 		removeDue() {
 			this.duedate = null
-			this.$emit('change', null)
 
 		},
 		selectShortcut(shortcut) {
 			this.duedate = shortcut.timestamp
-			this.$emit('change', shortcut.timestamp)
 		},
 		getTimestamp(momentObject) {
 			return momentObject?.minute(0).second(0).millisecond(0).toDate() || null

--- a/src/components/card/StartDateSelector.vue
+++ b/src/components/card/StartDateSelector.vue
@@ -13,7 +13,7 @@
 				:hide-label="true"
 				type="datetime-local" />
 			<NcActions v-if="canEdit"
-				:menu-title="!startdate ? t('deck', 'Add start date') : null"
+				:force-name="!startdate"
 				type="tertiary">
 				<template v-if="!startdate" #icon>
 					<Plus :size="20" />
@@ -24,7 +24,7 @@
 					<template #icon>
 						<Plus :size="20" />
 					</template>
-					{{ t('deck', 'Choose a date') }}
+					{{ t('deck', 'Add start date') }}
 				</NcActionButton>
 				<NcActionButton v-else
 					icon="icon-delete"

--- a/src/components/card/StartDateSelector.vue
+++ b/src/components/card/StartDateSelector.vue
@@ -99,7 +99,6 @@ export default defineComponent({
 		},
 		removeStartDate() {
 			this.startdate = null
-			this.$emit('change', null)
 		},
 	},
 })


### PR DESCRIPTION
There was an old regression because nextcloud/vue used to have the menuTitle prop, but switched to menuName and it seems like no one noticed.

Also the debounced update functions used to run on the trailing edge (after 500ms) now the first call runs the function instantly and after that debouncing starts.

What it will look like now (I do think it looked like that a big while ago):
<img width="1372" height="438" alt="image" src="https://github.com/user-attachments/assets/c985590d-cccb-4e32-8ca0-7138cea6c4c3" />
