### PR TITLE
feat: add support for view mode in URL

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -13,6 +13,8 @@ return [
 		['name' => 'page#indexBoard', 'url' => '/board/{boardId}', 'verb' => 'GET'],
 		['name' => 'page#indexBoardDetails', 'url' => '/board/{boardId}/details', 'verb' => 'GET'],
 		['name' => 'page#indexCard', 'url' => '/board/{boardId}/card/{cardId}', 'verb' => 'GET'],
+		// Declared after the more specific board routes so those keep priority.
+		['name' => 'page#indexBoardView', 'url' => '/board/{boardId}/{viewMode}', 'verb' => 'GET', 'requirements' => ['viewMode' => 'kanban|gantt']],
 
 		['name' => 'page#redirectToCard', 'url' => '/card/{cardId}', 'verb' => 'GET'],
 

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -103,6 +103,12 @@ class PageController extends Controller {
 
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
+	public function indexBoardView(int $boardId, string $viewMode): TemplateResponse {
+		return $this->index();
+	}
+
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function indexCard(int $cardId): TemplateResponse {
 		return $this->index();
 	}

--- a/src/components/board/Board.vue
+++ b/src/components/board/Board.vue
@@ -124,6 +124,15 @@ export default {
 			type: Number,
 			default: null,
 		},
+		/**
+		 * View to open the board in, coming from the /board/:id/:viewMode
+		 * route. Applied for this session only, so linking to a view does not
+		 * change the user's stored preference for the board.
+		 */
+		initialViewMode: {
+			type: String,
+			default: null,
+		},
 	},
 	data() {
 		return {
@@ -185,6 +194,11 @@ export default {
 			try {
 				await this.$store.dispatch('loadBoardById', this.id)
 				await this.$store.dispatch('loadStacks', this.id)
+
+				// Only after loadBoardById, as the mutation needs currentBoard
+				if (this.initialViewMode) {
+					this.$store.commit('setViewModeForSession', this.initialViewMode)
+				}
 
 				const routeCardId = this.$route?.params?.cardId ? parseInt(this.$route.params.cardId) : null
 				// If an archived card is requested, and we cannot find it in the current we load the archived stacks instead

--- a/src/router.js
+++ b/src/router.js
@@ -76,6 +76,25 @@ const router = new Router({
 			},
 		},
 		{
+			// Opens a board directly in a given view, so a board can be linked
+			// to as e.g. a Gantt chart. The view is applied for this session
+			// only and does not overwrite the user's stored preference.
+			path: '/board/:id/:viewMode(kanban|gantt)',
+			name: 'board.view',
+			components: {
+				default: Board,
+				sidebar: Sidebar,
+			},
+			props: {
+				default: (route) => {
+					return {
+						id: parseInt(route.params.id, 10),
+						initialViewMode: route.params.viewMode,
+					}
+				},
+			},
+		},
+		{
 			path: '/board/:id',
 			name: 'board',
 			components: {

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -309,6 +309,20 @@ export default function storeFactory() {
 				Vue.set(state.viewModeByBoard, state.currentBoard.id, mode)
 				localStorage.setItem(`deck.viewMode.${state.currentBoard.id}`, mode)
 			},
+			/**
+			 * Set the view mode without storing it as the user's preference.
+			 *
+			 * Used by the /board/:id/:viewMode routes, so that opening a link
+			 * to a specific view does not change how the recipient sees that
+			 * board afterwards.
+			 *
+			 * @param {object} state the store state
+			 * @param {string} mode the view mode to apply
+			 */
+			setViewModeForSession(state, mode) {
+				if (!state.currentBoard) return
+				Vue.set(state.viewModeByBoard, state.currentBoard.id, mode)
+			},
 		},
 		actions: {
 			setFullApp({ commit }, isFullApp) {


### PR DESCRIPTION

* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

This allows to link directly to a specific view by adding /gantt or /kanab to a board. It does not store the information, so the default user setting isn't touched.

This was generated using AI.



### TODO

- [ ] Discuss if this approach makes sense or if parameters should be used instead.

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
