### PR TITLE
fix: validate board permission in setDoneStack method

### DIFF
--- a/lib/Service/StackService.php
+++ b/lib/Service/StackService.php
@@ -306,6 +306,11 @@ class StackService {
 	 */
 	public function setDoneStack(int $stackId, int $boardId, bool $isDone): void {
 		$this->permissionService->checkPermission($this->stackMapper, $stackId, Acl::PERMISSION_MANAGE);
+		$stack = $this->stackMapper->find($stackId);
+
+		if ($stack->getBoardId() !== $boardId) {
+			throw new BadRequestException('Stack does not belong to the specified board.');
+		}
 
 		if ($this->boardService->isArchived($this->stackMapper, $stackId)) {
 			throw new NoPermissionException('Operation not allowed. This board is archived.');

--- a/tests/unit/Service/StackServiceTest.php
+++ b/tests/unit/Service/StackServiceTest.php
@@ -276,6 +276,10 @@ class StackServiceTest extends TestCase {
 
 	public function testSetDoneStackSetsDoneColumn(): void {
 		$this->permissionService->expects($this->once())->method('checkPermission');
+		$this->stackMapper->expects($this->once())
+			->method('find')
+			->with(5)
+			->willReturn($this->createStack(5, 0));
 		$this->boardService->expects($this->once())->method('isArchived')->willReturn(false);
 		$this->stackMapper->expects($this->once())
 			->method('clearDoneColumnForBoard')
@@ -303,6 +307,10 @@ class StackServiceTest extends TestCase {
 	public function testSetDoneStackDoesNotMarkCardsWhenUnsetting(): void {
 		$this->permissionService->expects($this->once())->method('checkPermission');
 		$this->boardService->expects($this->once())->method('isArchived')->willReturn(false);
+		$this->stackMapper->expects($this->once())
+			->method('find')
+			->with(5)
+			->willReturn($this->createStack(5, 0));
 		$this->stackMapper->expects($this->never())->method('clearDoneColumnForBoard');
 		$this->cardMapper->expects($this->never())->method('findAll');
 		$this->cardMapper->expects($this->never())->method('update');
@@ -314,9 +322,24 @@ class StackServiceTest extends TestCase {
 
 	public function testSetDoneStackThrowsOnArchivedBoard(): void {
 		$this->permissionService->expects($this->once())->method('checkPermission');
+		$this->stackMapper->expects($this->once())
+			->method('find')
+			->with(5)
+			->willReturn($this->createStack(5, 0));
 		$this->boardService->expects($this->once())->method('isArchived')->willReturn(true);
 		$this->stackMapper->expects($this->never())->method('setIsDoneColumn');
 		$this->expectException(\OCA\Deck\NoPermissionException::class);
 		$this->stackService->setDoneStack(5, 1, true);
+	}
+
+	public function testSetDoneStackThrowsOnMismatchBoardId(): void {
+		$this->permissionService->expects($this->once())->method('checkPermission');
+		$this->stackMapper->expects($this->once())
+			->method('find')
+			->with(5)
+			->willReturn($this->createStack(5, 0));
+		$this->stackMapper->expects($this->never())->method('setIsDoneColumn');
+		$this->expectException(\OCA\Deck\BadRequestException::class);
+		$this->stackService->setDoneStack(5, 2, true);
 	}
 }


### PR DESCRIPTION
# Summary

Added an explicit permission check for the board in addition to the stack, and validated that the stack belongs to the specified board in `setDoneStack`.