### PR TITLE
chore: reduce cypress flakiness

### DIFF
--- a/cypress/e2e/cardFeatures.js
+++ b/cypress/e2e/cardFeatures.js
@@ -270,10 +270,10 @@ describe('Card', function () {
 
 			cy.get('.card:contains("Card with a due date")').should('be.visible').click()
 
-			cy.get('#app-sidebar-vue [data-cy-due-date-actions]').should('be.visible').click()
-
 			const now = new Date().setHours(11, 0, 0, 0)
 			cy.clock(now)
+			cy.get('#app-sidebar-vue [data-cy-due-date-actions]').should('be.visible').click()
+			cy.tick(1_000)
 			// Set a due date through shortcut
 			cy.get('[data-cy-due-date-shortcut="tomorrow"] button').should('be.visible').click()
 


### PR DESCRIPTION
* Target version: main

### Summary
this one specific cypress test has been very flaky on ci recently.
I suspect it to be caused by this pr: https://github.com/nextcloud/deck/pull/8161/changes
It seems to be not reproducible on a normal system but happens often on ci runners.
When running it with `systemd-run --scope -p CPUQuota=50%` I was able to reproduce with a measured failure rate of about 60%. I do not really know why low cpu availability would cause that issue with cypress, but changing the clock _after_ opening the menu somehow caused it to close again (or never open).

 [this line](https://github.com/nextcloud/deck/blob/chore/reduce-cypress-flakiness/cypress/e2e/cardFeatures.js#L290) indicates a similar problem might have occurred before, but also doesn't explain it imo.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
