### PR TITLE
fix: avoid a TypeError when uploading an attachment via the API

### DIFF
--- a/lib/Controller/AttachmentApiController.php
+++ b/lib/Controller/AttachmentApiController.php
@@ -48,7 +48,7 @@ class AttachmentApiController extends ApiController {
 	#[CORS]
 	#[NoCSRFRequired]
 	public function create(int $cardId, string $type, ?string $data): DataResponse {
-		$attachment = $this->attachmentService->create($cardId, $type, $data);
+		$attachment = $this->attachmentService->create($cardId, $type, $data ?? '');
 		return new DataResponse($attachment, HTTP::STATUS_OK);
 	}
 


### PR DESCRIPTION
* Resolves: TypeError from https://github.com/nextcloud/deck/pull/8156
* Target version: main

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
