### PR TITLE
fix: expose the documented endpoint for cloning a board

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -86,6 +86,7 @@ return [
 		['name' => 'board_api#addAcl', 'url' => '/api/v{apiVersion}/boards/{boardId}/acl', 'verb' => 'POST'],
 		['name' => 'board_api#deleteAcl', 'url' => '/api/v{apiVersion}/boards/{boardId}/acl/{aclId}', 'verb' => 'DELETE'],
 		['name' => 'board_api#updateAcl', 'url' => '/api/v{apiVersion}/boards/{boardId}/acl/{aclId}', 'verb' => 'PUT'],
+		['name' => 'board_api#clone', 'url' => '/api/v{apiVersion}/boards/{boardId}/clone', 'verb' => 'POST'],
 
 		['name' => 'board_import_api#getAllowedSystems', 'url' => '/api/v{apiVersion}/boards/import/getSystems','verb' => 'GET'],
 		['name' => 'board_import_api#getConfigSchema', 'url' => '/api/v{apiVersion}/boards/import/config/schema/{name}','verb' => 'GET'],

--- a/lib/Controller/BoardApiController.php
+++ b/lib/Controller/BoardApiController.php
@@ -147,9 +147,9 @@ class BoardApiController extends ApiController {
 		return new DataResponse($acl, HTTP::STATUS_OK);
 	}
 
-	/**
-	 * @NoAdminRequired
-	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[CORS]
 	public function clone(int $boardId, bool $withCards = false, bool $withAssignments = false, bool $withLabels = false, bool $withDueDate = false, bool $moveCardsToLeftStack = false, bool $restoreArchivedCards = false): DataResponse {
 		return new DataResponse(
 			$this->boardService->clone($boardId, $this->userId, $withCards, $withAssignments, $withLabels, $withDueDate, $moveCardsToLeftStack, $restoreArchivedCards)


### PR DESCRIPTION
* Target version: main

### Summary

`BoardApiController::clone()` has never been routed, so the endpoint the API documentation lists as `POST /boards/{boardId}/clone` answered with a 405 and the controller method was dead code.

Register the route and mark the method up like its neighbours, so that integrations authenticating without a CSRF token can reach it too. The underlying service call is the same one the web route already uses.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required
