### PR TITLE
Deck cards attachment fix: Prevent TypeError crash on undefined attachment info

### DIFF
--- a/src/components/card/AttachmentList.vue
+++ b/src/components/card/AttachmentList.vue
@@ -195,7 +195,7 @@ export default {
 			}
 		},
 		attachmentBasename() {
-			return (attachment) => attachment?.extendedData?.info.filename
+			return (attachment) => attachment?.extendedData?.info?.filename
 				?? (attachment?.name ?? attachment.data).replace(/\.[^/.]+$/, '')
 		},
 		attachmentExtension() {


### PR DESCRIPTION
the attachment list was not getting populated on some cards

Adds optional chaining to info.filename in AttachmentList.vue. This prevents a complete UI crash (TypeError: Cannot read properties of undefined (reading 'filename')) when rendering a card that has an attachment with missing or undefined info data. 


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
