### PR TITLE
Update Cardsidebar.vue fix: Prevent TypeError crash on undefined curr…

### DIFF
--- a/src/components/card/CardSidebar.vue
+++ b/src/components/card/CardSidebar.vue
@@ -205,7 +205,7 @@ export default {
 	},
 	watch: {
 		currentCard(newCard, oldCard) {
-			if (newCard.id === oldCard?.id) return
+			if (newCard?.id === oldCard?.id) return
 			this.focusHeader()
 		},
 		'currentCard.title': {


### PR DESCRIPTION
…entCard

Adds optional chaining to `newCard.id` and `oldCard.id` in the watcher of `CardSidebar.vue`. 

This prevents a UI crash (`TypeError: Cannot read properties of undefined (reading 'id')`) when the sidebar attempts to render a card that has been deleted or failed to load, causing `newCard` to be undefined.


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
