### PR TITLE
fix(trash): allow to configure the trash retention in hours

### DIFF
--- a/lib/Cron/DeleteCron.php
+++ b/lib/Cron/DeleteCron.php
@@ -13,6 +13,7 @@ use OCA\Deck\Db\CardMapper;
 use OCA\Deck\Db\StackMapper;
 use OCA\Deck\InvalidAttachmentType;
 use OCA\Deck\Service\AttachmentService;
+use OCA\Deck\Service\ConfigService;
 use OCA\Deck\Sharing\DeckShareProvider;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJob;
@@ -35,6 +36,7 @@ class DeleteCron extends TimedJob {
 
 	public function __construct(
 		ITimeFactory $time,
+		private readonly ConfigService $configService,
 		BoardMapper $boardMapper,
 		CardMapper $cardMapper,
 		AttachmentService $attachmentService,
@@ -50,7 +52,7 @@ class DeleteCron extends TimedJob {
 		$this->stackMapper = $stackMapper;
 		$this->deckShareProvider = $deckShareProvider;
 
-		$this->setInterval(60 * 60 * 24);
+		$this->setInterval(60 * 60); // Run once every hour
 		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
 	}
 
@@ -59,18 +61,19 @@ class DeleteCron extends TimedJob {
 	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
 	 */
 	protected function run($argument) {
-		$boards = $this->boardMapper->findToDelete();
+		$timeLimit = time() - $this->configService->getTrashRetention();
+
+		$boards = $this->boardMapper->findToDelete($timeLimit);
 		foreach ($boards as $board) {
 			$this->boardMapper->delete($board);
 		}
 
-		$timeLimit = time() - (60 * 5); // 5 min buffer
 		$cards = $this->cardMapper->findToDelete($timeLimit, 500);
 		foreach ($cards as $card) {
 			$this->cardMapper->delete($card);
 		}
 
-		$attachments = $this->attachmentMapper->findToDelete();
+		$attachments = $this->attachmentMapper->findToDelete($timeLimit);
 		foreach ($attachments as $attachment) {
 			try {
 				$service = $this->attachmentService->getService($attachment->getType());
@@ -87,7 +90,7 @@ class DeleteCron extends TimedJob {
 			$this->deckShareProvider->delete($share);
 		}
 
-		$stacks = $this->stackMapper->findToDelete();
+		$stacks = $this->stackMapper->findToDelete($timeLimit);
 		foreach ($stacks as $stack) {
 			$this->stackMapper->delete($stack);
 		}

--- a/lib/Db/AttachmentMapper.php
+++ b/lib/Db/AttachmentMapper.php
@@ -108,9 +108,7 @@ class AttachmentMapper extends DeckMapper implements IPermissionMapper {
 	/**
 	 * @return Attachment[]
 	 */
-	public function findToDelete(?int $cardId = null, bool $withOffset = true): array {
-		// add buffer of 5 min
-		$timeLimit = time() - (60 * 5);
+	public function findToDelete(int $timeLimit, ?int $cardId = null, bool $withOffset = true): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from($this->getTableName())

--- a/lib/Db/BoardMapper.php
+++ b/lib/Db/BoardMapper.php
@@ -455,9 +455,7 @@ class BoardMapper extends QBMapper implements IPermissionMapper {
 		return $this->findEntities($qb);
 	}
 
-	public function findToDelete() {
-		// add buffer of 5 min
-		$timeLimit = time() - (60 * 5);
+	public function findToDelete(int $timeLimit) {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('id', 'title', 'owner', 'color', 'archived', 'deleted_at', 'last_modified', 'external_id', 'share_token')
 			->from('deck_boards')

--- a/lib/Db/StackMapper.php
+++ b/lib/Db/StackMapper.php
@@ -219,9 +219,7 @@ class StackMapper extends DeckMapper implements IPermissionMapper {
 	 * @return array<Stack>
 	 * @throws \OCP\DB\Exception
 	 */
-	public function findToDelete(): array {
-		// add buffer of 5 min
-		$timeLimit = time() - (60 * 5);
+	public function findToDelete(int $timeLimit): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from($this->getTableName())

--- a/lib/Service/AttachmentService.php
+++ b/lib/Service/AttachmentService.php
@@ -32,6 +32,7 @@ class AttachmentService {
 	private array $services = [];
 
 	public function __construct(
+		private readonly ConfigService $configService,
 		private readonly AttachmentMapper $attachmentMapper,
 		private readonly CardMapper $cardMapper,
 		private readonly IUserManager $userManager,
@@ -77,7 +78,8 @@ class AttachmentService {
 
 		$attachments = $this->attachmentMapper->findAll($cardId);
 		if ($withDeleted) {
-			$attachments = array_merge($attachments, $this->attachmentMapper->findToDelete($cardId, false));
+			$timeLimit = time() - $this->configService->getTrashRetention();
+			$attachments = array_merge($attachments, $this->attachmentMapper->findToDelete($timeLimit, $cardId, false));
 		}
 
 		foreach (array_keys($this->services) as $attachmentType) {

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -251,4 +251,10 @@ class ConfigService {
 
 		$this->config->setUserValue($userId ?? $this->getUserId(), 'deck', 'attachment_folder', $path);
 	}
+
+	public function getTrashRetention(): int {
+		$value = $this->config->getAppValue(Application::APP_ID, 'trashRetentionHours', '5');
+		$hours = (int)$value > 0 ? (int)$value : 5;
+		return 60 * 60 * $hours;
+	}
 }

--- a/tests/unit/Cron/DeleteCronTest.php
+++ b/tests/unit/Cron/DeleteCronTest.php
@@ -34,6 +34,7 @@ use OCA\Deck\Db\Stack;
 use OCA\Deck\Db\StackMapper;
 use OCA\Deck\InvalidAttachmentType;
 use OCA\Deck\Service\AttachmentService;
+use OCA\Deck\Service\ConfigService;
 use OCA\Deck\Service\IAttachmentService;
 use OCA\Deck\Sharing\DeckShareProvider;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -44,6 +45,8 @@ class DeleteCronTest extends TestCase {
 
 	/** @var ITimeFactory|MockObject */
 	private $timeFactory;
+	/** @var ConfigService|MockObject */
+	private $configService;
 	/** @var BoardMapper|MockObject */
 	protected $boardMapper;
 	/** @var CardMapper|\PHPUnit\Framework\MockObject\MockObject */
@@ -62,6 +65,7 @@ class DeleteCronTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->configService = $this->createMock(ConfigService::class);
 		$this->boardMapper = $this->createMock(BoardMapper::class);
 		$this->cardMapper = $this->createMock(CardMapper::class);
 		$this->attachmentService = $this->createMock(AttachmentService::class);
@@ -70,6 +74,7 @@ class DeleteCronTest extends TestCase {
 		$this->deckShareProvider = $this->createMock(DeckShareProvider::class);
 		$this->deleteCron = new DeleteCron(
 			$this->timeFactory,
+			$this->configService,
 			$this->boardMapper,
 			$this->cardMapper,
 			$this->attachmentService,

--- a/tests/unit/Db/AttachmentMapperTest.php
+++ b/tests/unit/Db/AttachmentMapperTest.php
@@ -110,8 +110,9 @@ class AttachmentMapperTest extends TestCase {
 			$attachment->resetUpdatedFields();
 		}
 
-		$this->assertEquals([$attachmentsToDelete[0]], $this->attachmentMapper->findToDelete(1));
-		$this->assertEquals([$attachmentsToDelete[2]], $this->attachmentMapper->findToDelete(2));
+		$timeLimit = time() - (60 * 60 * 5);
+		$this->assertEquals([$attachmentsToDelete[0]], $this->attachmentMapper->findToDelete($timeLimit, 1));
+		$this->assertEquals([$attachmentsToDelete[2]], $this->attachmentMapper->findToDelete($timeLimit, 2));
 	}
 
 	public function testIsOwner() {

--- a/tests/unit/Db/BoardMapperTest.php
+++ b/tests/unit/Db/BoardMapperTest.php
@@ -154,7 +154,8 @@ class BoardMapperTest extends TestCase {
 		$this->boards[0]->setDeletedAt(1);
 		$this->boards[0] = $this->boardMapper->update($this->boards[0]);
 
-		$actual = $this->boardMapper->findToDelete();
+		$timeLimit = time() - (60 * 60 * 5);
+		$actual = $this->boardMapper->findToDelete($timeLimit);
 		$this->boards[0]->resetUpdatedFields();
 
 		$filteredActual = array_values(array_filter($actual, function ($board) {

--- a/tests/unit/Service/AttachmentServiceTest.php
+++ b/tests/unit/Service/AttachmentServiceTest.php
@@ -67,6 +67,8 @@ class AttachmentServiceTest extends TestCase {
 
 	/** @var IUserManager|MockObject */
 	private $userManager;
+	/** @var ConfigService */
+	private $configService;
 	/** @var AttachmentMapper|MockObject */
 	private $attachmentMapper;
 	/** @var CardMapper|MockObject */
@@ -106,6 +108,8 @@ class AttachmentServiceTest extends TestCase {
 
 		$this->appContainer = $this->createMock(ContainerInterface::class);
 
+		$this->configService = $this->createMock(ConfigService::class);
+
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->attachmentMapper = $this->createMock(AttachmentMapper::class);
 		$this->cardMapper = $this->createMock(CardMapper::class);
@@ -130,6 +134,7 @@ class AttachmentServiceTest extends TestCase {
 		$this->attachmentServiceValidator = $this->createMock(AttachmentServiceValidator::class);
 
 		$this->attachmentService = new AttachmentService(
+			$this->configService,
 			$this->attachmentMapper,
 			$this->cardMapper,
 			$this->userManager,
@@ -166,7 +171,7 @@ class AttachmentServiceTest extends TestCase {
 		$application->expects($this->any())
 			->method('getContainer')
 			->willReturn($appContainer);
-		$attachmentService = new AttachmentService($this->attachmentMapper, $this->cardMapper, $this->userManager, $this->changeHelper, $this->permissionService, $application, $this->attachmentCacheHelper, $this->userId, $this->l10n, $this->activityManager, $this->attachmentServiceValidator);
+		$attachmentService = new AttachmentService($this->configService, $this->attachmentMapper, $this->cardMapper, $this->userManager, $this->changeHelper, $this->permissionService, $application, $this->attachmentCacheHelper, $this->userId, $this->l10n, $this->activityManager, $this->attachmentServiceValidator);
 		$attachmentService->registerAttachmentService('custom', MyAttachmentService::class);
 		$this->assertEquals($fileServiceMock, $attachmentService->getService('deck_file'));
 		$this->assertEquals(MyAttachmentService::class, get_class($attachmentService->getService('custom')));
@@ -191,7 +196,7 @@ class AttachmentServiceTest extends TestCase {
 			->method('getContainer')
 			->willReturn($appContainer);
 
-		$attachmentService = new AttachmentService($this->attachmentMapper, $this->cardMapper, $this->userManager, $this->changeHelper, $this->permissionService, $application, $this->attachmentCacheHelper, $this->userId, $this->l10n, $this->activityManager, $this->attachmentServiceValidator);
+		$attachmentService = new AttachmentService($this->configService, $this->attachmentMapper, $this->cardMapper, $this->userManager, $this->changeHelper, $this->permissionService, $application, $this->attachmentCacheHelper, $this->userId, $this->l10n, $this->activityManager, $this->attachmentServiceValidator);
 		$attachmentService->registerAttachmentService('custom', MyAttachmentService::class);
 		$attachmentService->getService('deck_file_invalid');
 	}
@@ -252,9 +257,12 @@ class AttachmentServiceTest extends TestCase {
 			->method('findAll')
 			->with(123)
 			->willReturn($attachments);
+		$this->configService->expects($this->once())
+			->method('getTrashRetention')
+			->willReturn(3600);
 		$this->attachmentMapper->expects($this->once())
 			->method('findToDelete')
-			->with(123, false)
+			->with($this->anything(), 123, false)
 			->willReturn($attachmentsDeleted);
 
 		$this->attachmentServiceImpl->expects($this->exactly(4))

--- a/tests/unit/Service/BatchQueryPerformanceTest.php
+++ b/tests/unit/Service/BatchQueryPerformanceTest.php
@@ -332,6 +332,7 @@ class BatchQueryPerformanceTest extends TestCase {
 		$application->method('getContainer')->willReturn($appContainer);
 
 		$this->attachmentService = new AttachmentService(
+			$this->createMock(ConfigService::class),
 			$this->attachmentMapper,
 			$this->createMock(CardMapper::class),
 			$this->createMock(IUserManager::class),

--- a/tests/unit/Service/Importer/BoardImportServiceTest.php
+++ b/tests/unit/Service/Importer/BoardImportServiceTest.php
@@ -30,6 +30,7 @@ use OCA\Deck\Db\AclMapper;
 use OCA\Deck\Db\Assignment;
 use OCA\Deck\Db\AssignmentMapper;
 use OCA\Deck\Db\AttachmentMapper;
+use OCA\Deck\Db\Board;
 use OCA\Deck\Db\BoardMapper;
 use OCA\Deck\Db\Card;
 use OCA\Deck\Db\CardMapper;
@@ -156,6 +157,12 @@ class BoardImportServiceTest extends \Test\TestCase {
 	public function testImportSuccess() {
 		$this->userManager->method('userExists')
 			->willReturn(true);
+
+		$board = new Board();
+		$board->setOwner('admin');
+		$this->trelloJsonService
+			->method('getBoard')
+			->willReturn($board);
 
 		$this->boardMapper
 			->expects($this->once())

--- a/tests/unit/Service/PermissionServiceTest.php
+++ b/tests/unit/Service/PermissionServiceTest.php
@@ -363,7 +363,7 @@ class PermissionServiceTest extends \Test\TestCase {
 		$this->userManager->expects($this->any())
 			->method('userExists')
 			->withConsecutive(['user1'], ['user2'])
-			->willReturnOnConsecutiveCalls($user1, $user2);
+			->willReturnOnConsecutiveCalls(true, true);
 
 		$group = $this->createMock(IGroup::class);
 		$group->expects($this->once())


### PR DESCRIPTION
Also change default from 5 minutes to 5 hours. The cronjob was configured to run only once a day anyway, so the deletion took place sometime between 5 minutes and 1 day after the item was trashed.

Assisted-by: OpenCode:claude-fable-5

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
