### PR TITLE
feat(OCM): Implement ISignedCloudFederationProvider for deck

### DIFF
--- a/lib/Db/BoardMapper.php
+++ b/lib/Db/BoardMapper.php
@@ -145,6 +145,22 @@ class BoardMapper extends QBMapper implements IPermissionMapper {
 		return $this->findEntities($qb);
 	}
 
+	/**
+	 * Used by ISignedCloudFederationProvider to resolve a board from a share token.
+	 *
+	 * @param string $shareToken
+	 * @return Board
+	 * @throws DoesNotExistException
+	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
+	 */
+	public function findByShareToken(string $shareToken): Board {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from('deck_boards')
+			->where($qb->expr()->eq('share_token', $qb->createNamedParameter($shareToken, IQueryBuilder::PARAM_STR)));
+		return $this->findEntity($qb);
+	}
+
 	public function findAllForUser(string $userId, ?int $since = null, bool $includeArchived = true, ?int $before = null,
 		?string $term = null): array {
 		$useCache = ($since === -1 && $includeArchived === true && $before === null && $term === null);

--- a/lib/Federation/DeckFederationProvider.php
+++ b/lib/Federation/DeckFederationProvider.php
@@ -14,13 +14,15 @@ use OCA\Deck\Db\Board;
 use OCA\Deck\Db\BoardMapper;
 use OCA\Deck\Db\ChangeHelper;
 use OCA\Deck\Service\ConfigService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\Common\Exception\NotFoundException;
-use OCP\Federation\ICloudFederationProvider;
 use OCP\Federation\ICloudFederationShare;
 use OCP\Federation\ICloudIdManager;
+use OCP\Federation\ISignedCloudFederationProvider;
 use OCP\Notification\IManager as INotificationManager;
 
-class DeckFederationProvider implements ICloudFederationProvider {
+class DeckFederationProvider implements ISignedCloudFederationProvider {
 	public const PROVIDER_ID = 'deck';
 
 	public function __construct(
@@ -105,5 +107,14 @@ class DeckFederationProvider implements ICloudFederationProvider {
 
 	public function getSupportedShareTypes(): array {
 		return ['user'];
+	}
+
+	#[\Override]
+	public function getFederationIdFromSharedSecret(#[\SensitiveParameter] string $sharedSecret, array $payload): string {
+		try {
+			return $this->boardMapper->findByShareToken($sharedSecret)->getOwner();
+		} catch (DoesNotExistException|MultipleObjectsReturnedException) {
+			return '';
+		}
 	}
 }


### PR DESCRIPTION

* Resolves: Need arises from this PR: https://github.com/nextcloud/server/pull/62543
* Target version: main

### Summary
When an app recieves OCM notifications, core needs to be able to resolve the remote server that sent the notification so that it can verify the signature of the notification.

This patch implements the ISignedCloudFederationProvider interface for the deck app, so that this can happen.


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
I did not include any extra test, since the current test suite caught this error.
- [x] Documentation (manuals or wiki) has been updated or is not required
See https://github.com/nextcloud/documentation/pull/15444