### PR TITLE
fix(navigation): drop active board icon fill override

### DIFF
--- a/src/components/navigation/AppNavigationBoard.vue
+++ b/src/components/navigation/AppNavigationBoard.vue
@@ -534,10 +534,4 @@ export default {
 	.forced-active {
 		box-shadow: inset 4px 0 var(--color-primary-element);
 	}
-
-	:deep(.active) {
-		.material-design-icon svg {
-			fill: var(--color-primary-element-text);
-		}
-	}
 </style>


### PR DESCRIPTION
## Summary
- Remove the active-board actions icon fill override so nextcloud-vue tertiary buttons keep `--color-main-text`.

Fixes #7539

## Test plan
- [ ] Dark mode: select a board in the sidebar and confirm the "..." actions icon is readable
- [ ] Confirm inactive boards still look correct
