### PR TITLE
feat(board): show owner label next to owner name

### DIFF
--- a/src/components/board/SharingTabSidebar.vue
+++ b/src/components/board/SharingTabSidebar.vue
@@ -15,7 +15,7 @@
 				<NcAvatar :user="board.owner.uid" />
 				<span class="username">
 					{{ board.owner.displayname }}
-					<span v-if="!isCurrentUser(board.owner.uid)" class="board-owner-label">
+					<span class="board-owner-label">
 						{{ t('deck', 'Board owner') }}
 					</span>
 				</span>


### PR DESCRIPTION
Show an "owner" label when viewing a board as the owner.

Fixes #7688

## Test plan
- [ ] Review diff against issue
- [ ] Run project lint/tests if applicable
