### PR TITLE
feat: collaborative description editing

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -24,6 +24,7 @@ use OCA\Deck\Event\BoardUpdatedEvent;
 use OCA\Deck\Event\CardCreatedEvent;
 use OCA\Deck\Event\CardDeletedEvent;
 use OCA\Deck\Event\CardUpdatedEvent;
+use OCA\Deck\Event\RegisterTextContextEventListener;
 use OCA\Deck\Event\SessionClosedEvent;
 use OCA\Deck\Event\SessionCreatedEvent;
 use OCA\Deck\Federation\DeckFederationProvider;
@@ -52,6 +53,7 @@ use OCA\Deck\Sharing\Listener;
 use OCA\Deck\Teams\DeckTeamResourceProvider;
 use OCA\Deck\UserMigration\DeckMigrator;
 use OCA\Text\Event\LoadEditor;
+use OCA\Text\Event\RegisterContextEvent;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -189,6 +191,8 @@ class Application extends App implements IBootstrap {
 		$context->registerTeamResourceProvider(DeckTeamResourceProvider::class);
 
 		$context->registerUserMigrator(DeckMigrator::class);
+
+		$context->registerEventListener(RegisterContextEvent::class, RegisterTextContextEventListener::class);
 	}
 
 	public function registerCommentsEntity(IEventDispatcher $eventDispatcher): void {

--- a/lib/Event/RegisterTextContextEventListener.php
+++ b/lib/Event/RegisterTextContextEventListener.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Deck\Event;
+
+use OCA\Deck\Provider\TextContextProviderFactory;
+use OCA\Text\Event\RegisterContextEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+class RegisterTextContextEventListener implements IEventListener{
+	public function __construct(
+		private readonly TextContextProviderFactory $textContextProviderFactory,
+	){}
+	public function handle(Event $event): void{
+		if (!$event instanceof RegisterContextEvent) {
+			return;
+		}
+
+		$event->getContextManager()->registerContext(
+			'deck_card',
+			TextContextProviderFactory::class
+		);
+	}
+}

--- a/lib/Provider/TextContextProvider.php
+++ b/lib/Provider/TextContextProvider.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Provider;
+
+use Co\Http\Server;
+use OC\Security\SecureRandom;
+use OCA\Deck\Db\Acl;
+use OCA\Deck\Db\CardMapper;
+use OCA\Deck\Service\CardService;
+use OCA\Deck\Service\PermissionService;
+use OCA\Text\Context\DocumentData;
+use OCA\Text\Context\IContext;
+use OCA\Text\Context\SessionInfo;
+use OCA\Text\Db\Document;
+use OCA\Text\Exception\DocumentSaveConflictException;
+use OCP\Files\File;
+
+class TextContextProvider implements IContext {
+	public function __construct(
+		private readonly SecureRandom $secureRandom,
+		private readonly CardService $cardService,
+		private readonly CardMapper $cardMapper,
+		private readonly PermissionService $permissionService,
+		private readonly string $userId,
+		private readonly int $cardId,
+	) {
+	}
+	public function getId(): int {
+		return $this->cardId;
+	}
+
+	public function getType(): string {
+		return 'deck_card';
+	}
+
+	public function toString(): string {
+		return $this->getType() . ' (' . $this->getId() . ')';
+	}
+
+	public function buildDocument(): Document{
+		$document = new Document();
+		$document->setContextType($this->getType());
+		$document->setContextId($this->getId());
+		$document->setLastSavedVersion(0);
+		$document->setLastSavedVersionTime(1);
+		$document->setLastSavedVersionEtag($this->secureRandom->generate(6));
+
+		$document->setChecksum($this->computeChecksum());
+		$document->setBaseVersionEtag(uniqid());
+		return $document;
+	}
+
+	public function prepareSession(DocumentData $documentData): SessionInfo {
+		if ($documentData->documentState === null) {
+			$content = null;
+		} else {
+			$content = $this->cardService->find($this->cardId)->getDescription();
+		}
+		$readonly = !$this->permissionService->checkPermission($this->cardMapper, $this->cardId, Acl::PERMISSION_EDIT, $this->userId);
+		return new SessionInfo(
+			content: $content,
+			readOnly: $readonly,
+			lock: null,
+			hasOwner: true,
+		);
+	}
+
+	public function isReadOnly(): bool {
+		return !$this->permissionService->checkPermission($this->cardMapper, $this->cardId, Acl::PERMISSION_EDIT, $this->userId);
+	}
+
+	public function updateDocument(Document $document): ?Document {
+		if ($this->computeChecksum() !== $document->getChecksum()) {
+			$card = $this->cardService->find($this->cardId);
+			throw new DocumentSaveConflictException($card->getDescription());
+		}
+		return null;
+	}
+
+	public function getFile(): ?File{
+		return null;
+	}
+
+	public function loadContent(): ?string {
+		$card = $this->cardService->find($this->cardId);
+		if ($card === null) {
+			return null;
+		}
+		return $card->getDescription();
+	}
+
+	public function saveWithLock(string $content, callable $doWhileLocked): void {
+		$card = $this->cardService->find($this->cardId);
+		if ($card === null) {
+			return;
+		}
+		$card->setDescription($content);
+		$this->cardService->update($card->getId(), $card->getTitle(), $card->getStackId(), $card->getType(), $card->getOwner(), $card->getDescription(), $card->getOrder());
+	}
+
+	public function cleanup(): void {
+	}
+
+	private function computeChecksum(): string {
+		$card = $this->cardService->find($this->cardId);
+		if ($card === null) {
+			return '';
+		}
+		return hash('crc32', $card->getDescription());
+	}
+
+}

--- a/lib/Provider/TextContextProviderFactory.php
+++ b/lib/Provider/TextContextProviderFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Deck\Provider;
+
+use OC\Security\SecureRandom;
+use OCA\Deck\Db\CardMapper;
+use OCA\Deck\Service\CardService;
+use OCA\Deck\Service\PermissionService;
+use OCA\Text\Context\IContext;
+use OCA\Text\Context\IContextFactory;
+use OCP\IUser;
+use OCP\Share\IShare;
+
+class TextContextProviderFactory implements IContextFactory{
+	public function __construct(
+		private readonly SecureRandom $secureRandom,
+		private readonly CardService $cardService,
+		private readonly CardMapper $cardMapper,
+		private readonly PermissionService $permissionService,
+		private readonly string $userId,
+	) {
+	}
+
+	public function build(IUser|IShare $auth, string $type, int $id): IContext {
+		return new TextContextProvider(
+			secureRandom: $this->secureRandom,
+			cardService: $this->cardService,
+			cardMapper: $this->cardMapper,
+			permissionService: $this->permissionService,
+			userId: $this->userId,
+			cardId: $id,
+		);
+	}
+}

--- a/src/components/card/Description.vue
+++ b/src/components/card/Description.vue
@@ -117,7 +117,7 @@ export default {
 	},
 	data() {
 		return {
-			textAppAvailable: !!window.OCA?.Text?.createEditor,
+			textAppAvailable: !!window.OCA?.Text?.createCollaborativeEditor,
 			editor: null,
 			keyExitState: 0,
 			descriptionOld: '',
@@ -205,9 +205,9 @@ export default {
 			this.descriptionLastEdit = 0
 			this.descriptionOld = this.card.description
 			this.description = this.card.description
-			this.editor = await window.OCA.Text.createEditor({
+			this.editor = await window.OCA.Text.createCollaborativeEditor({
+				context: { type: 'deck_card', id: this.card.id },
 				el: this.$refs.editor,
-				content: this.card.description,
 				readOnly: !this.canEdit,
 				onLoaded: () => {
 					this.descriptionLastEdit = 0


### PR DESCRIPTION
* Target version: main

### Summary
collaborative editing of the description.
requires: https://github.com/nextcloud/text/pull/9062

### TODO
- [ ] text's last saved indicator says 57 years ago
- [ ] old description saving mechanism still interfering
- [ ] another user updated description notification pops up when notify_push is on
- [ ] conflict view (needed/possible?)
- [ ] attachments (requires text, see text pr)
- [ ] cypress failures

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Documentation (manuals or wiki) has been updated or is not required
