### PR TITLE
Fix undoing deleted cards

### DIFF
--- a/src/components/board/DeletedTabSidebar.vue
+++ b/src/components/board/DeletedTabSidebar.vue
@@ -79,6 +79,7 @@ export default {
 		cardUndoDeleteLocal(deletedCard) {
 			const copiedDeletedCard = Object.assign({}, deletedCard)
 			copiedDeletedCard.deletedAt = 0
+			copiedDeletedCard.boardId = this.board.id
 			this.cardUndoDelete(copiedDeletedCard)
 		},
 	},

--- a/src/components/cards/CardMenuEntries.vue
+++ b/src/components/cards/CardMenuEntries.vue
@@ -198,7 +198,7 @@ export default {
 		},
 		deleteCard() {
 			this.deleteCardInStore(this.card)
-			const undoCard = { ...this.card, deletedAt: 0 }
+			const undoCard = { ...this.card, deletedAt: 0, boardId: this.boardId }
 			showUndo(t('deck', 'Card deleted'), () => useTrashbinStore().cardUndoDelete(undoCard))
 			if (this.$router.currentRoute.name === 'card') {
 				this.$router.push({ name: 'board' })

--- a/src/stores/trashbin.js
+++ b/src/stores/trashbin.js
@@ -63,7 +63,7 @@ export const useTrashbinStore = defineStore('trashbin', {
 			})
 		},
 		cardUndoDelete(card) {
-			cardApi.updateCard(card).then((restoredCard) => {
+			cardApi.updateCard(card, card.boardId).then((restoredCard) => {
 				this.removeCardFromTrash(restoredCard)
 				useCardStore().addCardToStore(restoredCard)
 			})


### PR DESCRIPTION
Fixes #8293

Fix undoing deleted cards returning HTTP 400.

The card update API requires the board ID as a separate argument. Deleted-card data does not reliably include that runtime context, so card undo was calling `updateCard` without a board ID. This caused the request to be sent with an undefined board context.

The board ID is now propagated from the active board/card context for both undo entry points and passed to the API action.