### PR TITLE
fix: propagate board clone failures

### DIFF
--- a/src/services/BoardApi.js
+++ b/src/services/BoardApi.js
@@ -144,19 +144,15 @@ export class BoardApi {
 	}
 
 	async cloneBoard(board, withCards = false, withAssignments = false, withLabels = false, withDueDate = false, moveCardsToLeftStack = false, restoreArchivedCards = false) {
-		try {
-			const response = await axios.post(this.url(`/boards/${board.id}/clone`), {
-				withCards,
-				withAssignments,
-				withLabels,
-				withDueDate,
-				moveCardsToLeftStack,
-				restoreArchivedCards,
-			})
-			return response.data
-		} catch (err) {
-			return err
-		}
+		const response = await axios.post(this.url(`/boards/${board.id}/clone`), {
+			withCards,
+			withAssignments,
+			withLabels,
+			withDueDate,
+			moveCardsToLeftStack,
+			restoreArchivedCards,
+		})
+		return response.data
 	}
 
 	exportBoard(board, format) {

--- a/src/services/BoardApi.spec.js
+++ b/src/services/BoardApi.spec.js
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import axios from '@nextcloud/axios'
+import { BoardApi } from './BoardApi.js'
+
+jest.mock('@nextcloud/axios', () => ({
+	post: jest.fn(),
+}))
+
+jest.mock('@nextcloud/router', () => ({
+	generateOcsUrl: jest.fn(url => url),
+	generateUrl: jest.fn(url => url),
+}))
+
+describe('BoardApi', () => {
+	describe('cloneBoard', () => {
+		it('returns the cloned board on success', async () => {
+			const board = { id: 42 }
+			const clonedBoard = { id: 84, title: 'Cloned board' }
+			axios.post.mockResolvedValue({ data: clonedBoard })
+
+			await expect(new BoardApi().cloneBoard(board)).resolves.toEqual(clonedBoard)
+		})
+
+		it('rejects when the request fails', async () => {
+			const error = new Error('Clone failed')
+			axios.post.mockRejectedValue(error)
+
+			await expect(new BoardApi().cloneBoard({ id: 42 })).rejects.toBe(error)
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- let failed board clone requests reject instead of resolving with an Axios error
- add focused tests for both successful and failed clone requests
- prevent failed requests from entering the Pinia store's success path

## Verification

- `npx jest src/services/BoardApi.spec.js --runInBand --config='{"rootDir":".","moduleFileExtensions":["js"],"transform":{"^.+\\.js$":"babel-jest"}}'`
- `npx eslint src/services/BoardApi.js src/services/BoardApi.spec.js`
- `npm run build`

All checks passed. The build reports existing Sass deprecation and bundle-size warnings.

Closes #8360