### PR TITLE
fix(tests): mock IUserFolder where getUserFolder is stubbed

### DIFF
--- a/tests/unit/Service/FilesAppServiceTest.php
+++ b/tests/unit/Service/FilesAppServiceTest.php
@@ -98,7 +98,7 @@ class FilesAppServiceTest extends TestCase {
 			->method('validateFilename')
 			->with('valid-file.txt');
 
-		$userFolder = $this->createMock(\OCP\Files\Folder::class);
+		$userFolder = $this->createMock(\OCP\Files\IUserFolder::class);
 		$this->rootFolder->expects($this->any())
 			->method('getUserFolder')
 			->willReturn($userFolder);


### PR DESCRIPTION
* Resolves: # no issue — found while rebasing #8052 onto current `main`
* Target version: main

### Summary

`IRootFolder::getUserFolder()` returns `OCP\Files\IUserFolder` since server 36 (`@since 36.0.0`), so a `Folder` mock no longer satisfies its declared return type and PHPUnit refuses to hand it back:

```
1) OCA\Deck\Service\FilesAppServiceTest::testCreateWithValidFilename
PHPUnit\Framework\MockObject\IncompatibleReturnValueException: Method getUserFolder
may not return value of type Mock_Folder_02a41b1e, its declared return type is
"OCP\Files\IUserFolder"
```

This is the only place in the test suite that stubs `getUserFolder`, and it fails the PHPUnit jobs (SQLite, MySQL, PostgreSQL) of **every** pull request that touches `appinfo/`, `lib/`, `templates/`, `tests/`, `composer.json` or the workflows — those are the paths the filter starts those jobs for. Pull requests that only touch `src/` never run them, which is why the breakage stayed unnoticed.

`IUserFolder extends Folder` and only adds `getUserQuota()`, so the mock still answers everything the code under test calls; nothing but the mocked type changes.

### TODO

- [x] Nothing outstanding — one-line test fix

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Tests (unit, integration, api and/or acceptance) are included
- [x] Documentation (manuals or wiki) has been updated or is not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
